### PR TITLE
[feat]: Enable log service in gravity's consensus engine

### DIFF
--- a/dependencies/aptos-config/src/config/logger_config.rs
+++ b/dependencies/aptos-config/src/config/logger_config.rs
@@ -45,8 +45,8 @@ impl Default for LoggerConfig {
             enable_backtrace: false,
             is_async: true,
             level: Level::Info,
-            enable_telemetry_remote_log: true,
-            enable_telemetry_flush: true,
+            enable_telemetry_remote_log: false,
+            enable_telemetry_flush: false,
             telemetry_level: Level::Error,
 
             // This is the default port used by tokio-console.

--- a/dependencies/aptos-config/src/config/node_config.rs
+++ b/dependencies/aptos-config/src/config/node_config.rs
@@ -90,6 +90,8 @@ pub struct NodeConfig {
     pub mock_db_path: PathBuf,
     #[serde(default)]
     pub test_mode: bool,
+    #[serde(default)]
+    pub log_file_path: PathBuf,
 }
 
 impl NodeConfig {

--- a/dependencies/aptos-logger/src/aptos_logger.rs
+++ b/dependencies/aptos-logger/src/aptos_logger.rs
@@ -205,7 +205,7 @@ impl LogEntry {
         let hostname = HOSTNAME.as_deref();
         let namespace = NAMESPACE.as_deref();
        
-        panic!("peer_id and chain_id are not implemented");
+        // panic!("peer_id and chain_id are not implemented");
         let peer_id = Some("");
         let chain_id = Some(0);
         let backtrace = if enable_backtrace && matches!(metadata.level(), Level::Error) {

--- a/node1/genesis/validator.yaml
+++ b/node1/genesis/validator.yaml
@@ -31,3 +31,5 @@ storage:
   dir: "/tmp/node1/data"
 
 mock_db_path: "/tmp/node1/genesis/nodes_config.json"
+
+log_file_path: "/tmp/node1/consensus_log"

--- a/node2/genesis/validator.yaml
+++ b/node2/genesis/validator.yaml
@@ -31,3 +31,5 @@ storage:
   dir: "/tmp/node2/data"
 
 mock_db_path: "/tmp/node2/genesis/nodes_config.json"
+
+log_file_path: "/tmp/node2/consensus_log"

--- a/node3/genesis/validator.yaml
+++ b/node3/genesis/validator.yaml
@@ -31,3 +31,5 @@ storage:
   dir: "/tmp/node3/data"
 
 mock_db_path: "/tmp/node3/genesis/nodes_config.json"
+
+log_file_path: "/tmp/node3/consensus_log"

--- a/node4/genesis/validator.yaml
+++ b/node4/genesis/validator.yaml
@@ -31,3 +31,5 @@ storage:
   dir: "/tmp/node4/data"
 
 mock_db_path: "/tmp/node4/genesis/nodes_config.json"
+
+log_file_path: "/tmp/node4/consensus_log"

--- a/src/consensus_engine.rs
+++ b/src/consensus_engine.rs
@@ -5,7 +5,7 @@ use crate::bootstrap::{
 use crate::consensus_mempool_handler::{ConsensusToMempoolHandler, MempoolNotificationHandler};
 use crate::network::{create_network_runtime, extract_network_configs};
 use crate::utils::bimap::BiMap;
-use crate::{GCEIError, GTxn, GravityConsensusEngineInterface};
+use crate::{logger, GCEIError, GTxn, GravityConsensusEngineInterface};
 use aptos_config::config::NodeConfig;
 use aptos_config::network_id::NetworkId;
 use aptos_consensus::gravity_state_computer::ConsensusAdapterArgs;
@@ -29,6 +29,7 @@ use futures::{
 };
 use std::collections::HashMap;
 use std::ops::DerefMut;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::{Mutex, RwLock};
@@ -83,6 +84,7 @@ impl GravityConsensusEngineInterface for GravityConsensusEngine {
     fn init(node_config: NodeConfig) -> Self {
         let gravity_db = init_gravity_db(&node_config);
         let peers_and_metadata = init_peers_and_metadata(&node_config, &gravity_db);
+        let (_remote_log_receiver, _logger_filter_update) = logger::create_logger(&node_config, Some(node_config.log_file_path.clone()));
         let db: DbReaderWriter = DbReaderWriter::new(gravity_db);
         let mut event_subscription_service =
             aptos_event_notifications::EventSubscriptionService::new(Arc::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod storage;
 pub mod simple_consensus_engine;
 mod consensus_mempool_handler;
 mod utils;
+mod logger;
 
 pub use aptos_config::config::NodeConfig;
 pub use bootstrap::{check_bootstrap_config, start};

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,101 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::channel::mpsc::Receiver;
+use aptos_config::config::NodeConfig;
+use aptos_logger::{
+    aptos_logger::FileWriter, info, telemetry_log_writer::TelemetryLog, LoggerFilterUpdater,
+};
+use futures::channel::mpsc;
+use std::path::PathBuf;
+
+const TELEMETRY_LOG_INGEST_BUFFER_SIZE: usize = 128;
+
+// Simple macro to help print out feature configurations
+macro_rules! log_feature_info {
+    ($($feature:literal),*) => {
+        $(
+        if cfg!(feature = $feature) {
+            info!("Running with {} feature enabled", $feature);
+        } else {
+            info!("Running with {} feature disabled", $feature);
+        }
+        )*
+    }
+}
+
+/// Creates the logger and returns the remote log receiver alongside
+/// the logger filter updater.
+pub fn create_logger(
+    node_config: &NodeConfig,
+    log_file: Option<PathBuf>,
+) -> (Option<Receiver<TelemetryLog>>, LoggerFilterUpdater) {
+    // Create the logger builder
+    let mut logger_builder = aptos_logger::Logger::builder();
+    let mut remote_log_receiver = None;
+    logger_builder
+        .channel_size(node_config.logger.chan_size)
+        .is_async(node_config.logger.is_async)
+        .level(node_config.logger.level)
+        .telemetry_level(node_config.logger.telemetry_level)
+        .enable_telemetry_flush(node_config.logger.enable_telemetry_flush)
+        .tokio_console_port(node_config.logger.tokio_console_port);
+    if node_config.logger.enable_backtrace {
+        logger_builder.enable_backtrace();
+    }
+    if let Some(log_file) = log_file {
+        logger_builder.printer(Box::new(FileWriter::new(log_file)));
+    }
+    if node_config.logger.enable_telemetry_remote_log {
+        let (tx, rx) = mpsc::channel(TELEMETRY_LOG_INGEST_BUFFER_SIZE);
+        logger_builder.remote_log_tx(tx);
+        remote_log_receiver = Some(rx);
+    }
+
+    // Create the logger and the logger filter updater
+    let logger = logger_builder.build();
+    let logger_filter_updater: LoggerFilterUpdater = LoggerFilterUpdater::new(logger, logger_builder);
+
+    // Log the build information and the config
+    // log_config_and_build_information(node_config);
+
+    (remote_log_receiver, logger_filter_updater)
+}
+
+// /// Logs the node config and build information
+// fn log_config_and_build_information(node_config: &NodeConfig) {
+//     // Log the build information
+//     info!("Build information:");
+//     let build_info = build_information!();
+//     for (key, value) in build_info {
+//         info!("{}: {}", key, value);
+//     }
+
+//     // Log the feature information. Note: this should be kept up-to-date
+//     // with the features defined in the aptos-node Cargo.toml file.
+//     info!("Feature information:");
+//     log_feature_info!(
+//         "assert-private-keys-not-cloneable",
+//         "check-vm-features",
+//         "consensus-only-perf-test",
+//         "default",
+//         "failpoints",
+//         "indexer",
+//         "tokio-console"
+//     );
+
+//     // Log the node config
+//     let mut config = node_config;
+//     let mut masked_config;
+//     if let Some(u) = &node_config.indexer.postgres_uri {
+//         let mut parsed_url = url::Url::parse(u).expect("Invalid postgres uri");
+//         if parsed_url.password().is_some() {
+//             masked_config = node_config.clone();
+//             parsed_url.set_password(Some("*")).unwrap();
+//             masked_config.indexer.postgres_uri = Some(parsed_url.to_string());
+//             config = &masked_config;
+//         }
+//     }
+
+//     info!("Loaded node config: {:?}", config);
+// }


### PR DESCRIPTION
## PR Description
[Briefly describe your changes]
This pr enables the process to print detail in the log. You can set the log file path in the validator.yaml file. Then you can see the logs like the following picture.
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/8dd7c481-de63-4118-bdc8-78d77ca2b578">


## Tested?

- [ ] Yes
- [ ] No