### PR TITLE
[feat]: Able to set leader when using bench & able to control whether to produce txn or not for bench mode

### DIFF
--- a/bin/bench/Cargo.toml
+++ b/bin/bench/Cargo.toml
@@ -16,6 +16,8 @@ tokio.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 async-trait = { workspace = true }
+once_cell = { workspace = true }
+warp = { workspace = true }
 clap = { version = "4.3.9", features = ["derive", "env", "unstable-styles"] }
 clap-verbosity-flag = "2.1.1"
 clap_complete = "4.4.1"

--- a/bin/bench/src/cli.rs
+++ b/bin/bench/src/cli.rs
@@ -11,6 +11,12 @@ pub(crate) struct Cli {
 
     #[arg(long)]
     pub log_dir: String,
+
+    #[arg(long)]
+    pub leader: bool,
+
+    #[arg(long)]
+    pub port: Option<u16>,
 }
 
 impl Cli {

--- a/bin/bench/src/txn.rs
+++ b/bin/bench/src/txn.rs
@@ -48,20 +48,3 @@ impl RawTxn {
         self.sequence_number
     }
 }
-
-mod test {
-    use api_types::account::ExternalAccountAddress;
-
-    use super::RawTxn;
-
-    #[test]
-    fn print_txn_bytes() {
-        let txn = RawTxn {
-            account: ExternalAccountAddress::random(),
-            sequence_number: 1,
-            key: "G_King".to_string(),
-            val: "ByteYue".to_string(),
-        };
-        println!("curl -X POST -H \"Content-Type:application/json\" -d '{{\"tx\": {:?}}}' https://127.0.0.1:1998/tx/submit_tx", txn.to_bytes());
-    }
-}


### PR DESCRIPTION
User can use `./bench --leader --port 8000 --gravity_node_config /tmp/node1/genesis/validator.yaml --log-dir /tmp/node1/bench` to start one leader bench node. And you can control whether to produce txn or not by using `curl "http://127.0.0.1:8000/ProduceTxn?value=true"`.