### PR TITLE
[feat]: Add enable_pipeline config and construct pipeline builder in block store

### DIFF
--- a/aptos-core/consensus/src/consensus_provider.rs
+++ b/aptos-core/consensus/src/consensus_provider.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gravity_state_computer::{
-    ConsensusAdapterArgs, GravityBlockExecutor, GravityExecutionProxy,
+    ConsensusAdapterArgs, GravityBlockExecutor,
 };
 use crate::{
     consensus_observer::{
@@ -83,8 +83,6 @@ pub fn start_consensus(
         TransactionFilter::new(node_config.execution.transaction_filter.clone()),
         node_config.consensus.enable_pre_commit,
     );
-    let execution_proxy =
-        Arc::new(GravityExecutionProxy::new(Arc::new(execution_proxy), executor.clone()));
 
     let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 
@@ -101,7 +99,7 @@ pub fn start_consensus(
 
     let execution_client = Arc::new(ExecutionProxyClient::new(
         node_config.consensus.clone(),
-        execution_proxy.clone(),
+        Arc::new(execution_proxy),
         node_config.validator_network.as_ref().unwrap().peer_id(),
         self_sender.clone(),
         consensus_network_client.clone(),

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -824,7 +824,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         self.execution_client
             .start_epoch(
-                consensus_key,
+                consensus_key.clone(),
                 epoch_state.clone(),
                 safety_rules_container.clone(),
                 payload_manager.clone(),
@@ -837,7 +837,16 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 recovery_data.root_block().round(),
             )
             .await;
-
+        let consensus_sk = consensus_key;
+        
+        let maybe_pipeline_builder = if self.config.enable_pipeline {
+            info!(epoch = epoch, "Create PipelineBuilder");
+            let signer = Arc::new(ValidatorSigner::new(self.author, consensus_sk));
+            Some(self.execution_client.pipeline_builder(signer))
+        } else {
+            None
+        };
+        
         info!(epoch = epoch, "Create BlockStore");
         // Read the last vote, before "moving" `recovery_data`
         let last_vote = recovery_data.last_vote();

--- a/aptos-core/consensus/src/pipeline/mod.rs
+++ b/aptos-core/consensus/src/pipeline/mod.rs
@@ -36,6 +36,6 @@ pub mod pipeline_phase;
 pub mod signing_phase;
 
 pub mod execution_client;
-mod pipeline_builder;
+pub mod pipeline_builder;
 #[cfg(test)]
 mod tests;

--- a/aptos-core/consensus/src/test_utils/mock_execution_client.rs
+++ b/aptos-core/consensus/src/test_utils/mock_execution_client.rs
@@ -7,8 +7,7 @@ use crate::{
     network::{IncomingCommitRequest, IncomingRandGenRequest},
     payload_manager::{DirectMempoolPayloadManager, TPayloadManager},
     pipeline::{
-        buffer_manager::OrderedBlocks, execution_client::TExecutionClient,
-        signing_phase::CommitSignerProvider,
+        buffer_manager::OrderedBlocks, execution_client::TExecutionClient, pipeline_builder::PipelineBuilder, signing_phase::CommitSignerProvider
     },
     rand::rand_gen::types::RandConfig,
     state_replication::StateComputerCommitCallBackType,
@@ -28,7 +27,7 @@ use aptos_types::{
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
     on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig, OnChainRandomnessConfig},
-    transaction::SignedTransaction,
+    transaction::SignedTransaction, validator_signer::ValidatorSigner,
 };
 use futures::{channel::mpsc, SinkExt};
 use futures_channel::mpsc::UnboundedSender;
@@ -177,4 +176,8 @@ impl TExecutionClient for MockExecutionClient {
     }
 
     async fn end_epoch(&self) {}
+
+    fn pipeline_builder(&self, _signer: Arc<ValidatorSigner>) -> PipelineBuilder {
+        unimplemented!()
+    }
 }

--- a/crates/api/src/bootstrap.rs
+++ b/crates/api/src/bootstrap.rs
@@ -10,7 +10,7 @@ use aptos_config::{
     config::{NetworkConfig, NodeConfig, Peer, PeerRole},
     network_id::NetworkId,
 };
-use aptos_consensus::{consensusdb::ConsensusDB, gravity_state_computer::GravityExecutionProxy};
+use aptos_consensus::consensusdb::ConsensusDB;
 use aptos_consensus::{
     gravity_state_computer::ConsensusAdapterArgs, network_interface::ConsensusMsg,
     persistent_liveness_storage::StorageWriteProxy, quorum_store::quorum_store_db::QuorumStoreDB,

--- a/dependencies/aptos-config/src/config/consensus_config.rs
+++ b/dependencies/aptos-config/src/config/consensus_config.rs
@@ -89,6 +89,7 @@ pub struct ConsensusConfig {
     pub rand_rb_config: ReliableBroadcastConfig,
     pub num_bounded_executor_tasks: u64,
     pub enable_pre_commit: bool,
+    pub enable_pipeline: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -354,6 +355,7 @@ impl Default for ConsensusConfig {
             },
             num_bounded_executor_tasks: 16,
             enable_pre_commit: true,
+            enable_pipeline: false,
         }
     }
 }


### PR DESCRIPTION
## PR Description
[Briefly describe your changes]
Issue Number: closes #xxx

Remove legacy code for GravityExecutionProxy since we use coex now, but unfortunately we have to modify `ExecutionProxy` directly in aptos's code.

## Tested?

- [ ] Yes
- [ ] No