### PR TITLE
[feature]: Use jemalloc in Unix & able to control dump heap profile using http interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -542,6 +542,3 @@ serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }
-
-[workspace.features]
-jemalloc-profiling = ["tikv-jemallocator/profiling", "tikv-jemalloc-sys/profiling"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,6 @@ members = [
     "bin/gravity_node"
 ]
 
-
-
-
-
 [workspace.dependencies]
 aptos-consensus = { path = "./aptos-core/consensus" }
 
@@ -303,8 +299,8 @@ internment = { version = "0.5.0", features = ["arc"] }
 ipnet = "2.5.0"
 itertools = "0.13"
 tikv-jemalloc-ctl = "0.6"
-tikv-jemallocator = { version = "0.6", features = ["profiling"] }
-tikv-jemalloc-sys = { version = "0.6", features = ["profiling"] }
+tikv-jemallocator = { version = "0.6" }
+tikv-jemalloc-sys = { version = "0.6" }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"
@@ -546,3 +542,6 @@ serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 x25519-dalek = { git = "https://github.com/aptos-labs/x25519-dalek", branch = "zeroize_v1" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }
+
+[workspace.features]
+jemalloc-profiling = ["tikv-jemallocator/profiling", "tikv-jemalloc-sys/profiling"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,11 +302,9 @@ inferno = "0.11.14"
 internment = { version = "0.5.0", features = ["arc"] }
 ipnet = "2.5.0"
 itertools = "0.13"
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
-jemalloc-sys = "0.5.4"
+tikv-jemalloc-ctl = "0.6"
+tikv-jemallocator = { version = "0.6", features = ["profiling"] }
+tikv-jemalloc-sys = { version = "0.6", features = ["profiling"] }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,15 @@ CARGO_FEATURES := $(if $(FEATURE),--features $(FEATURE),)
 all: $(BINARY)
 
 gravity_node:
-    cd bin/gravity_node && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
+	cargo build -p gravity_node $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 bench:
-    cd bin/bench && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
+	cargo build -p bench $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 kvstore:
-    cd bin/kvstore && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
+	cargo build -p kvstore $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 clean:
-    for dir in $(BIN_PATHS); do \
-        (cd $$dir && cargo clean); \
-    done
+	for dir in $(BIN_PATHS); do \
+		(cd $$dir && cargo clean); \
+	done

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,15 @@ CARGO_FEATURES := $(if $(FEATURE),--features $(FEATURE),)
 all: $(BINARY)
 
 gravity_node:
-	cd bin/gravity_node && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
+    cd bin/gravity_node && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 bench:
-	cd bin/bench && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
+    cd bin/bench && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 kvstore:
-	cd bin/kvstore && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
+    cd bin/kvstore && cargo build $(CARGO_FLAGS) $(CARGO_FEATURES)
 
 clean:
-	for dir in $(BIN_PATHS); do \
-	    (cd $$dir && cargo clean); \
-	done
+    for dir in $(BIN_PATHS); do \
+        (cd $$dir && cargo clean); \
+    done

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -65,6 +65,10 @@ rcgen = "0.9"
 tokio-test = "*"
 reqwest = { version = "0.12.9", features = ["rustls-tls", "json"] }
 coex-bridge = { path = "../coex-bridge" }
+tikv-jemallocator.workspace = true
+tikv-jemalloc-ctl.workspace = true
+tikv-jemalloc-sys.workspace = true
+once_cell = { workspace = true }
 
 [features]
 default = []

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -73,3 +73,4 @@ once_cell = { workspace = true }
 [features]
 default = []
 failpoints = ["fail/failpoints", "aptos-consensus/failpoints", "aptos-mempool/failpoints", "aptos-config/failpoints"]
+jemalloc-profiling = ["tikv-jemallocator/profiling", "tikv-jemalloc-sys/profiling"]

--- a/crates/api/src/https/heap_profiler.rs
+++ b/crates/api/src/https/heap_profiler.rs
@@ -20,7 +20,7 @@ pub static PROFILER: Lazy<HeapProfiler> = Lazy::new(|| HeapProfiler::new());
 
 #[derive(Deserialize, Serialize)]
 pub struct ControlProfileRequest {
-    start: bool,
+    enable: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -28,9 +28,11 @@ pub struct ControlProfileResponse {
     pub response: String,
 }
 
+/// User should use binary with feature api/jemalloc-profiling enabled.
+/// This feature can be enabled by ```Cargo build --features api/jemalloc-profiling```
 pub async fn control_profiler(request: ControlProfileRequest) -> impl IntoResponse {
     #[cfg(feature = "jemalloc-profiling")]
-    match PROFILER.set_prof_active(request.start) {
+    match PROFILER.set_prof_active(request.enable) {
         Ok(_) => Json(ControlProfileResponse { response: "success".to_string() }),
         Err(e) => Json(ControlProfileResponse { response: e }),
     }

--- a/crates/api/src/https/heap_profiler.rs
+++ b/crates/api/src/https/heap_profiler.rs
@@ -1,0 +1,159 @@
+use aptos_logger::info;
+use aptos_logger::warn;
+use axum::response::IntoResponse;
+use axum::Json;
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use serde::Serialize;
+use std::env;
+use std::ffi::CString;
+use std::process;
+use std::ptr;
+use std::sync::{Arc, Mutex};
+use tikv_jemalloc_ctl::raw;
+use tikv_jemallocator;
+
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+pub struct HeapProfiler {
+    mutex: Arc<Mutex<()>>,
+}
+
+const PROF_ACTIVE: &[u8] = b"prof.active\0";
+const PROF_THREAD_ACTIVE_INIT: &[u8] = b"prof.thread_active_init\0";
+
+pub static PROFILER: Lazy<HeapProfiler> = Lazy::new(|| {
+    HeapProfiler::new()
+});
+
+#[derive(Deserialize, Serialize)]
+pub struct ControlProfileRequest {
+    start: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ControlProfileResponse {
+    pub response: String,
+}
+
+pub async fn control_profiler(
+    request: ControlProfileRequest,
+) -> impl IntoResponse {
+    match PROFILER.set_prof_active(request.start) {
+        Ok(_) => Json(ControlProfileResponse {
+            response: "success".to_string(),
+        }),
+        Err(e) => Json(ControlProfileResponse {
+            response: e,
+        }),
+    }
+}
+
+fn dump_prof(path: &CString) {
+    let option_name = CString::new("prof.dump").unwrap();
+    let r = unsafe {
+        tikv_jemalloc_sys::mallctl(
+            option_name.as_ptr() as *const _,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if r != 0 {
+        panic!("jemalloc heap profiling dump failed: {}", r);
+    }
+}
+
+impl HeapProfiler {
+    pub fn new() -> Self {
+        Self { mutex: Arc::new(Mutex::new(())) }
+    }
+
+    pub fn set_prof_active(&self, prof: bool) -> Result<(), String> {
+        let _guard = self.mutex.lock().unwrap();
+        if let Err(err) = unsafe { raw::write(PROF_ACTIVE, prof) } {
+            warn!("jemalloc heap profiling active failed: {}", err);
+            return Err(String::from(format!("jemalloc heap profiling active failed: {}", err)));
+        }
+        if let Err(err) = unsafe { raw::write(PROF_THREAD_ACTIVE_INIT, prof) } {
+            warn!("jemalloc heap profiling thread_active_init failed: {}", err);
+            return Err(String::from(format!(
+                "jemalloc heap profiling thread_active_init failed: {}",
+                err
+            )));
+        }
+        if prof {
+            info!("jemalloc heap profiling started");
+        } else {
+            info!("jemalloc heap profiling stopped");
+        }
+        Ok(())
+    }
+
+    fn get_prof_dump(&self, profile_file_name: &CString) {
+        let _guard = self.mutex.lock().unwrap();
+        dump_prof(profile_file_name);
+    }
+
+    pub fn dump_heap_profile(&self) -> String {
+        let jeprofile_dir = env::var("JEPROFILE_DIR")
+            .unwrap_or_else(|_| String::from("/home/jingyue/projects/gravity-sdk/jemalloc"));
+        let profile_file_name = format!(
+            "{}/jeheap_dump.{}.{}.{}.heap",
+            jeprofile_dir,
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+            process::id(),
+            rand::random::<u32>()
+        );
+        let profile_file_name1 = profile_file_name.clone();
+        let profile_file_name_c =
+            CString::new(profile_file_name).expect("Invalid characters in profile path");
+        self.get_prof_dump(&profile_file_name_c);
+        info!("the name is {:?}", profile_file_name_c);
+        profile_file_name1
+    }
+}
+
+// async fn start_profiling() -> impl Responder {
+//     let profiler = HeapProfiler::new();
+//     profiler.set_prof_active(true);
+//     HttpResponse::Ok().body("Heap profiling started")
+// }
+
+// async fn stop_profiling() -> impl Responder {
+//     let profiler = HeapProfiler::new();
+//     profiler.set_prof_active(false);
+//     HttpResponse::Ok().body("Heap profiling stopped")
+// }
+
+// async fn dump_profile() -> impl Responder {
+//     let profiler = HeapProfiler::new();
+//     let file_name = profiler.dump_heap_profile();
+//     HttpResponse::Ok().body(format!("Heap profile dumped to {}", file_name))
+// }
+
+// async fn dump_profile_to_dot() -> impl Responder {
+//     let profiler = HeapProfiler::new();
+//     let file_name = profiler.dump_heap_profile_to_dot();
+//     HttpResponse::Ok().body(format!("Heap profile dumped to dot format: {}", file_name))
+// }
+
+// #[actix_web::main]
+// async fn main() -> std::io::Result<()> {
+//     let profiler = Arc::new(Mutex::new(HeapProfiler::new()));
+
+//     HttpServer::new(move || {
+//         App::new()
+//             .app_data(web::Data::new(profiler.clone()))
+//             .route("/start", web::post().to(start_profiling))
+//             .route("/stop", web::post().to(stop_profiling))
+//             .route("/dump", web::post().to(dump_profile))
+//             .route("/dump_dot", web::post().to(dump_profile_to_dot))
+//     })
+//     .bind("0.0.0.0:8080")?
+//     .run()
+//     .await
+// }
+// export _RJEM_MALLOC_CONF=prof:true,lg_prof_interval:30,lg_prof_sample:21,prof_prefix:/home/jingyue/projects/gravity-sdk/jemalloc

--- a/crates/api/src/https/heap_profiler.rs
+++ b/crates/api/src/https/heap_profiler.rs
@@ -94,7 +94,7 @@ impl HeapProfiler {
 
     fn get_prof_dump(&self, profile_file_name: &CString) {
         let _guard = self.mutex.lock().unwrap();
-        dump_prof(profile_file_name);
+        // dump_prof(profile_file_name);
     }
 
     pub fn dump_heap_profile(&self) -> String {
@@ -156,4 +156,3 @@ impl HeapProfiler {
 //     .run()
 //     .await
 // }
-// export _RJEM_MALLOC_CONF=prof:true,lg_prof_interval:30,lg_prof_sample:21,prof_prefix:/home/jingyue/projects/gravity-sdk/jemalloc

--- a/crates/api/src/https/heap_profiler.rs
+++ b/crates/api/src/https/heap_profiler.rs
@@ -6,15 +6,8 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde::Serialize;
 use std::env;
-use std::ffi::CString;
-use std::process;
-use std::ptr;
 use std::sync::{Arc, Mutex};
 use tikv_jemalloc_ctl::raw;
-use tikv_jemallocator;
-
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 pub struct HeapProfiler {
     mutex: Arc<Mutex<()>>,
@@ -23,9 +16,7 @@ pub struct HeapProfiler {
 const PROF_ACTIVE: &[u8] = b"prof.active\0";
 const PROF_THREAD_ACTIVE_INIT: &[u8] = b"prof.thread_active_init\0";
 
-pub static PROFILER: Lazy<HeapProfiler> = Lazy::new(|| {
-    HeapProfiler::new()
-});
+pub static PROFILER: Lazy<HeapProfiler> = Lazy::new(|| HeapProfiler::new());
 
 #[derive(Deserialize, Serialize)]
 pub struct ControlProfileRequest {
@@ -37,33 +28,16 @@ pub struct ControlProfileResponse {
     pub response: String,
 }
 
-pub async fn control_profiler(
-    request: ControlProfileRequest,
-) -> impl IntoResponse {
+pub async fn control_profiler(request: ControlProfileRequest) -> impl IntoResponse {
+    #[cfg(feature = "jemalloc-profiling")]
     match PROFILER.set_prof_active(request.start) {
-        Ok(_) => Json(ControlProfileResponse {
-            response: "success".to_string(),
-        }),
-        Err(e) => Json(ControlProfileResponse {
-            response: e,
-        }),
+        Ok(_) => Json(ControlProfileResponse { response: "success".to_string() }),
+        Err(e) => Json(ControlProfileResponse { response: e }),
     }
-}
-
-fn dump_prof(path: &CString) {
-    let option_name = CString::new("prof.dump").unwrap();
-    let r = unsafe {
-        tikv_jemalloc_sys::mallctl(
-            option_name.as_ptr() as *const _,
-            ptr::null_mut(),
-            ptr::null_mut(),
-            ptr::null_mut(),
-            0,
-        )
-    };
-    if r != 0 {
-        panic!("jemalloc heap profiling dump failed: {}", r);
-    }
+    #[cfg(not(feature = "jemalloc-profiling"))]
+    Json(ControlProfileResponse {
+        response: "jemalloc profiling is not enabled".to_string(),
+    })
 }
 
 impl HeapProfiler {
@@ -74,15 +48,15 @@ impl HeapProfiler {
     pub fn set_prof_active(&self, prof: bool) -> Result<(), String> {
         let _guard = self.mutex.lock().unwrap();
         if let Err(err) = unsafe { raw::write(PROF_ACTIVE, prof) } {
-            warn!("jemalloc heap profiling active failed: {}", err);
-            return Err(String::from(format!("jemalloc heap profiling active failed: {}", err)));
+            let err = String::from(format!("jemalloc heap profiling active failed: {}", err));
+            warn!("{}", err);
+            return Err(err);
         }
         if let Err(err) = unsafe { raw::write(PROF_THREAD_ACTIVE_INIT, prof) } {
-            warn!("jemalloc heap profiling thread_active_init failed: {}", err);
-            return Err(String::from(format!(
-                "jemalloc heap profiling thread_active_init failed: {}",
-                err
-            )));
+            let err =
+                String::from(format!("jemalloc heap profiling thread_active_init failed: {}", err));
+            warn!("{}", err);
+            return Err(err);
         }
         if prof {
             info!("jemalloc heap profiling started");
@@ -91,68 +65,4 @@ impl HeapProfiler {
         }
         Ok(())
     }
-
-    fn get_prof_dump(&self, profile_file_name: &CString) {
-        let _guard = self.mutex.lock().unwrap();
-        // dump_prof(profile_file_name);
-    }
-
-    pub fn dump_heap_profile(&self) -> String {
-        let jeprofile_dir = env::var("JEPROFILE_DIR")
-            .unwrap_or_else(|_| String::from("/home/jingyue/projects/gravity-sdk/jemalloc"));
-        let profile_file_name = format!(
-            "{}/jeheap_dump.{}.{}.{}.heap",
-            jeprofile_dir,
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
-            process::id(),
-            rand::random::<u32>()
-        );
-        let profile_file_name1 = profile_file_name.clone();
-        let profile_file_name_c =
-            CString::new(profile_file_name).expect("Invalid characters in profile path");
-        self.get_prof_dump(&profile_file_name_c);
-        info!("the name is {:?}", profile_file_name_c);
-        profile_file_name1
-    }
 }
-
-// async fn start_profiling() -> impl Responder {
-//     let profiler = HeapProfiler::new();
-//     profiler.set_prof_active(true);
-//     HttpResponse::Ok().body("Heap profiling started")
-// }
-
-// async fn stop_profiling() -> impl Responder {
-//     let profiler = HeapProfiler::new();
-//     profiler.set_prof_active(false);
-//     HttpResponse::Ok().body("Heap profiling stopped")
-// }
-
-// async fn dump_profile() -> impl Responder {
-//     let profiler = HeapProfiler::new();
-//     let file_name = profiler.dump_heap_profile();
-//     HttpResponse::Ok().body(format!("Heap profile dumped to {}", file_name))
-// }
-
-// async fn dump_profile_to_dot() -> impl Responder {
-//     let profiler = HeapProfiler::new();
-//     let file_name = profiler.dump_heap_profile_to_dot();
-//     HttpResponse::Ok().body(format!("Heap profile dumped to dot format: {}", file_name))
-// }
-
-// #[actix_web::main]
-// async fn main() -> std::io::Result<()> {
-//     let profiler = Arc::new(Mutex::new(HeapProfiler::new()));
-
-//     HttpServer::new(move || {
-//         App::new()
-//             .app_data(web::Data::new(profiler.clone()))
-//             .route("/start", web::post().to(start_profiling))
-//             .route("/stop", web::post().to(stop_profiling))
-//             .route("/dump", web::post().to(dump_profile))
-//             .route("/dump_dot", web::post().to(dump_profile_to_dot))
-//     })
-//     .bind("0.0.0.0:8080")?
-//     .run()
-//     .await
-// }

--- a/crates/api/src/https/mod.rs
+++ b/crates/api/src/https/mod.rs
@@ -23,8 +23,8 @@ use tx::{get_tx_by_hash, submit_tx, TxRequest};
 pub struct HttpsServerArgs {
     pub address: String,
     pub execution_api: Arc<dyn ExecutionChannel>,
-    pub cert_pem: PathBuf,
-    pub key_pem: PathBuf,
+    pub cert_pem: Option<PathBuf>,
+    pub key_pem: Option<PathBuf>,
 }
 
 async fn ensure_https(req: Request<Body>, next: Next) -> Response {
@@ -61,19 +61,32 @@ pub async fn https_server(args: HttpsServerArgs) {
         .route("/set_failpoint", post(set_fail_point_lambda))
         .route("/mem_prof", post(control_profiler_lambda));
     let app = Router::new().merge(https_app).merge(http_app);
-    // configure certificate and private key used by https
-    let config = RustlsConfig::from_pem_file(args.cert_pem.clone(), args.key_pem.clone())
-        .await
-        .unwrap_or_else(|e| {
-            panic!("error {:?}, cert {:?}, key {:?} doesn't work", e, args.cert_pem, args.key_pem)
-        });
     let addr: SocketAddr = args.address.parse().unwrap();
-    info!("https server listen address {}", addr);
-    axum_server::bind_rustls(addr, config).serve(app.into_make_service()).await.unwrap_or_else(
-        |e| {
-            panic!("failed to bind rustls due to {:?}", e);
-        },
-    );
+    match (args.cert_pem.clone(), args.key_pem.clone()) {
+        (Some(cert_path), Some(key_path)) => {
+            // configure certificate and private key used by https
+            let config =
+                RustlsConfig::from_pem_file(cert_path, key_path).await.unwrap_or_else(|e| {
+                    panic!(
+                        "error {:?}, cert {:?}, key {:?} doesn't work",
+                        e, args.cert_pem, args.key_pem
+                    )
+                });
+            info!("https server listen address {}", addr);
+            axum_server::bind_rustls(addr, config)
+                .serve(app.into_make_service())
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("failed to bind rustls due to {:?}", e);
+                });
+        }
+        _ => {
+            info!("http server listen address {}", addr);
+            axum_server::bind(addr).serve(app.into_make_service()).await.unwrap_or_else(|e| {
+                panic!("failed to bind http due to {:?}", e);
+            });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -104,15 +117,15 @@ mod test {
         let cert_pem = cert.serialize_pem().unwrap();
         let key_pem = cert.serialize_private_key_pem();
         let dir = env!("CARGO_MANIFEST_DIR").to_owned();
-        fs::create_dir(dir.clone() + "/src/https/test");
-        fs::write(dir.clone() + "/src/https/test/cert.pem", cert_pem);
-        fs::write(dir.clone() + "/src/https/test/key.pem", key_pem);
+        fs::create_dir(dir.clone() + "/src/https/test").unwrap();
+        fs::write(dir.clone() + "/src/https/test/cert.pem", cert_pem).unwrap();
+        fs::write(dir.clone() + "/src/https/test/key.pem", key_pem).unwrap();
 
         let args = HttpsServerArgs {
             address: "127.0.0.1:5425".to_owned(),
             execution_api: Arc::new(MockExecutionApi {}),
-            cert_pem: PathBuf::from(dir.clone() + "/src/https/test/cert.pem"),
-            key_pem: PathBuf::from(dir.clone() + "/src/https/test/key.pem"),
+            cert_pem: Some(PathBuf::from(dir.clone() + "/src/https/test/cert.pem")),
+            key_pem: Some(PathBuf::from(dir.clone() + "/src/https/test/key.pem")),
         };
         let _handler = tokio::spawn(https_server(args));
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;


### PR DESCRIPTION
## PR Description
[Briefly describe your changes]
Issue Number: closes #xxx

Users can use the curl command to access the /mem_prof HTTP interface (assuming it's on port 9000) to control whether heap profiling is printed.  For example:
```shell
curl -X POST -H "Content-Type: application/json" -d '{"start": true}' http://127.0.0.1:9001/mem_prof
```

**Note** Users need to ensure that jemalloc-profiling is enabled during compilation. This can be done by using ```make FEATURE="api/jemalloc-profiling"```. Also, note that this project uses tikv-jemalloc. Users need to set the following environment variables before starting the program for it to take effect: 
```shell 
export _RJEM_MALLOC_CONF=prof:true,lg_prof_interval:30,lg_prof_sample:21,prof_prefix:${USER_PREFIX}
```
 (Note that the directory corresponding to this prefix must already exist).

## Tested?

- [ ] Yes
- [ ] No