### PR TITLE
[feat] add config

### DIFF
--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -49,6 +49,15 @@ pub struct BlockBufferManagerConfig {
     pub max_wait_timeout: Duration,
 }
 
+impl Default for BlockBufferManagerConfig {
+    fn default() -> Self {
+        Self {
+            wait_for_change_timeout: Duration::from_millis(100),
+            max_wait_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
 pub struct BlockBufferManager {
     txn_buffer: TxnBuffer,
     block_state_machine: Mutex<BlockStateMachine>,
@@ -57,7 +66,7 @@ pub struct BlockBufferManager {
 }
 
 impl BlockBufferManager {
-    pub fn new(config: Option<BlockBufferManagerConfig>) -> Self {
+    pub fn new(config: BlockBufferManagerConfig) -> Self {
         let (sender, _recv) = tokio::sync::broadcast::channel(1024);
         Self {
             txn_buffer: TxnBuffer { txns: Mutex::new(Vec::new()) },
@@ -69,12 +78,7 @@ impl BlockBufferManager {
                 block_number_to_block_id: HashMap::new(),
             }),
             buffer_state: AtomicU8::new(BufferState::Uninitialized as u8),
-            config: config.unwrap_or(
-                BlockBufferManagerConfig {
-                    wait_for_change_timeout: Duration::from_millis(100),
-                    max_wait_timeout: Duration::from_secs(5),
-                }
-            ),
+            config,
         }
     }
 

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -44,14 +44,20 @@ pub struct BlockStateMachine {
     block_number_to_block_id: HashMap<u64, BlockId>,
 }
 
+pub struct BlockBufferManagerConfig {
+    pub wait_for_change_timeout: Duration,
+    pub max_wait_timeout: Duration,
+}
+
 pub struct BlockBufferManager {
     txn_buffer: TxnBuffer,
     block_state_machine: Mutex<BlockStateMachine>,
     buffer_state: AtomicU8,
+    config: BlockBufferManagerConfig,
 }
 
 impl BlockBufferManager {
-    pub fn new() -> Self {
+    pub fn new(config: Option<BlockBufferManagerConfig>) -> Self {
         let (sender, _recv) = tokio::sync::broadcast::channel(1024);
         Self {
             txn_buffer: TxnBuffer { txns: Mutex::new(Vec::new()) },
@@ -63,6 +69,12 @@ impl BlockBufferManager {
                 block_number_to_block_id: HashMap::new(),
             }),
             buffer_state: AtomicU8::new(BufferState::Uninitialized as u8),
+            config: config.unwrap_or(
+                BlockBufferManagerConfig {
+                    wait_for_change_timeout: Duration::from_millis(100),
+                    max_wait_timeout: Duration::from_secs(5),
+                }
+            ),
         }
     }
 
@@ -157,9 +169,8 @@ impl BlockBufferManager {
             panic!("Buffer is not ready");
         }
         let start = Instant::now();
-        let timeout = Duration::from_secs(5);
         loop {
-            if start.elapsed() > timeout {
+            if start.elapsed() > self.config.max_wait_timeout {
                 return Err(anyhow::anyhow!("Timeout waiting for ordered blocks"));
             }
 
@@ -182,7 +193,7 @@ impl BlockBufferManager {
                 drop(block_state_machine);
 
                 // Wait for changes and try again
-                match self.wait_for_change(Duration::from_millis(100)).await {
+                match self.wait_for_change(self.config.wait_for_change_timeout).await {
                     Ok(_) => continue,
                     Err(_) => continue, // Timeout on the wait, retry
                 }
@@ -201,10 +212,9 @@ impl BlockBufferManager {
             panic!("Buffer is not ready");
         }
         let start = Instant::now();
-        let timeout = Duration::from_secs(5);
 
         loop {
-            if start.elapsed() > timeout {
+            if start.elapsed() > self.config.max_wait_timeout {
                 return Err(anyhow::anyhow!("get_executed_res timeout for block {:?}", block_id));
             }
 
@@ -226,7 +236,7 @@ impl BlockBufferManager {
                         drop(block_state_machine);
 
                         // Wait for changes and try again
-                        match self.wait_for_change(Duration::from_millis(100)).await {
+                        match self.wait_for_change(self.config.wait_for_change_timeout).await {
                             Ok(_) => continue,
                             Err(_) => continue, // Timeout on the wait, retry
                         }
@@ -324,10 +334,9 @@ impl BlockBufferManager {
             panic!("Buffer is not ready");
         }
         let start = Instant::now();
-        let timeout = Duration::from_secs(2);
 
         loop {
-            if start.elapsed() > timeout {
+            if start.elapsed() > self.config.max_wait_timeout {
                 return Err(anyhow::anyhow!("Timeout waiting for committed blocks"));
             }
 
@@ -353,7 +362,7 @@ impl BlockBufferManager {
                 drop(block_state_machine);
 
                 // Wait for changes and try again
-                match self.wait_for_change(Duration::from_millis(100)).await {
+                match self.wait_for_change(self.config.wait_for_change_timeout).await {
                     Ok(_) => continue,
                     Err(_) => continue, // Timeout on the wait, retry
                 }

--- a/crates/block-buffer-manager/src/lib.rs
+++ b/crates/block-buffer-manager/src/lib.rs
@@ -6,5 +6,5 @@ pub mod block_buffer_manager;
 static GLOBAL_BLOCK_BUFFER_MANAGER : OnceLock<BlockBufferManager> = OnceLock::new();
 
 pub fn get_block_buffer_manager() -> &'static block_buffer_manager::BlockBufferManager {
-    GLOBAL_BLOCK_BUFFER_MANAGER.get_or_init(|| BlockBufferManager::new(None))
+    GLOBAL_BLOCK_BUFFER_MANAGER.get_or_init(|| BlockBufferManager::new(block_buffer_manager::BlockBufferManagerConfig::default()))
 }

--- a/crates/block-buffer-manager/src/lib.rs
+++ b/crates/block-buffer-manager/src/lib.rs
@@ -6,5 +6,5 @@ pub mod block_buffer_manager;
 static GLOBAL_BLOCK_BUFFER_MANAGER : OnceLock<BlockBufferManager> = OnceLock::new();
 
 pub fn get_block_buffer_manager() -> &'static block_buffer_manager::BlockBufferManager {
-    GLOBAL_BLOCK_BUFFER_MANAGER.get_or_init(|| BlockBufferManager::new())
+    GLOBAL_BLOCK_BUFFER_MANAGER.get_or_init(|| BlockBufferManager::new(None))
 }


### PR DESCRIPTION
## PR Description
This pull request introduces a configuration option to the BlockBufferManager by adding a new configuration struct and updating the BlockBufferManager::new() function to accept an optional configuration parameter. The PR replaces hard-coded timeout values with configurable ones and ensures the default behavior is preserved when no configuration is provided.

Add BlockBufferManagerConfig struct to encapsulate timeout settings.
Modify BlockBufferManager::new() to accept an optional configuration and apply default timeout values.
Replace hard-coded timeout values in various buffer-wait loops with values from the configuration.
## Tested?

- [ ] Yes
- [ ] No