### PR TITLE
feat(cli): implement join validator for gravity_cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -200,6 +200,28 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03df5cb3b428ac96b386ad64c11d5c6e87a5505682cf1fbd6f8f773e9eda04f6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1051,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1073,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1086,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1096,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-types",
  "bcs 0.1.4",
@@ -1109,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1120,7 +1142,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-global-constants",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-sdk",
@@ -1150,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1180,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "hex",
@@ -1189,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "proptest",
  "serde",
@@ -1199,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1237,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -1260,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "futures",
  "rustversion",
@@ -1270,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "shadow-rs",
 ]
@@ -1278,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1292,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1303,12 +1325,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1320,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1406,7 +1428,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1415,25 +1437,25 @@ dependencies = [
  "aptos-collections",
  "aptos-config",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-schemadb",
  "aptos-secure-storage",
  "aptos-short-hex-str",
@@ -1484,7 +1506,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -1522,13 +1544,13 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-short-hex-str",
@@ -1550,7 +1572,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -1562,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1616,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1626,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1657,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1683,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1691,7 +1713,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-jellyfish-merkle",
@@ -1729,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1751,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1768,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1800,13 +1822,13 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-enum-conversion-derive",
@@ -1817,7 +1839,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -1839,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1850,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1859,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -1889,15 +1911,15 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-executor-service",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-experimental-runtimes",
  "aptos-indexer-grpc-table-info",
  "aptos-infallible",
@@ -1920,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-block-executor",
  "aptos-block-partitioner",
@@ -1951,16 +1973,16 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-db",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -1984,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2009,7 +2031,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-layered-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "ahash 0.8.12",
  "aptos-crypto",
@@ -2024,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -2037,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2045,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2116,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "either",
  "move-core-types",
@@ -2125,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2140,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -2160,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -2173,17 +2195,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2192,7 +2214,7 @@ dependencies = [
  "aptos-config",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-metrics-core",
  "aptos-moving-average",
  "aptos-protos",
@@ -2219,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2229,7 +2251,7 @@ dependencies = [
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-storage-interface",
@@ -2251,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
@@ -2287,12 +2309,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -2318,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2346,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -2354,7 +2376,7 @@ dependencies = [
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
@@ -2365,7 +2387,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -2384,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2399,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2409,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -2455,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2468,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2478,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2504,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -2545,13 +2567,13 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-event-notifications",
  "aptos-infallible",
@@ -2586,7 +2608,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -2599,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -2610,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2619,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2644,7 +2666,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2665,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2682,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2699,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2748,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2771,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2796,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2813,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2823,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2835,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2848,7 +2870,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2860,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2870,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "pbjson",
  "prost",
@@ -2881,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "ipnet",
 ]
@@ -2889,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2901,11 +2923,11 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-enum-conversion-derive",
  "aptos-infallible",
  "aptos-logger",
@@ -2923,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2938,7 +2960,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2961,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2970,7 +2992,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "rayon",
  "tokio",
@@ -2998,10 +3020,10 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-infallible",
@@ -3022,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-drop-helper",
@@ -3039,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -3059,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -3085,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3103,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -3121,7 +3143,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -3142,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -3153,7 +3175,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3164,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3173,7 +3195,7 @@ dependencies = [
  "aptos-data-client",
  "aptos-data-streaming-service",
  "aptos-event-notifications",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-mempool-notifications",
@@ -3197,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -3225,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -3236,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -3248,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -3264,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -3282,17 +3304,17 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crypto",
  "aptos-db",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-node-resource-metrics",
@@ -3321,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3361,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3370,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3383,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-filter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-protos",
@@ -3401,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "api-types",
@@ -3465,12 +3487,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3483,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3499,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3551,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-environment"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-framework",
  "aptos-gas-algebra",
@@ -3574,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3598,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3613,7 +3635,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -3636,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -7460,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "gaptos"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "api-types",
  "aptos-bitvec",
@@ -7471,9 +7493,9 @@ dependencies = [
  "aptos-collections",
  "aptos-compression",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-crash-handler",
  "aptos-crypto",
  "aptos-crypto-derive",
@@ -7481,9 +7503,9 @@ dependencies = [
  "aptos-dkg-runtime",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-executor-test-helpers",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-global-constants",
@@ -7494,7 +7516,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-log-derive",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-mempool-notifications",
  "aptos-memsocket",
  "aptos-metrics-core",
@@ -7510,7 +7532,7 @@ dependencies = [
  "aptos-reliable-broadcast",
  "aptos-rest-client",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef)",
  "aptos-schemadb",
  "aptos-secure-net",
  "aptos-secure-storage",
@@ -7845,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 
 [[package]]
 name = "gravity-sdk"
@@ -7859,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7885,6 +7907,15 @@ dependencies = [
 name = "gravity_cli"
 version = "0.1.0"
 dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-macro",
+ "alloy-sol-types",
+ "alloy-transport-http",
  "anyhow",
  "bcs 0.1.4",
  "clap 4.5.47",
@@ -7892,11 +7923,13 @@ dependencies = [
  "hex",
  "k256",
  "rand_core 0.6.4",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
  "sha3 0.9.1",
  "thiserror 1.0.69",
+ "tokio",
  "tracing",
 ]
 
@@ -7951,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -10290,7 +10323,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10307,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10322,12 +10355,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10342,7 +10375,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "once_cell",
  "quote",
@@ -10352,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -10364,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -10378,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "clap 4.5.47",
@@ -10393,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "clap 4.5.47",
@@ -10423,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "difference",
@@ -10440,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10463,7 +10496,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10497,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10523,7 +10556,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10542,7 +10575,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "clap 4.5.47",
@@ -10559,7 +10592,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "clap 4.5.47",
@@ -10578,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -10590,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10606,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -10624,7 +10657,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "hex",
@@ -10637,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -10650,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "codespan",
@@ -10677,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "clap 4.5.47",
@@ -10711,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "atty",
@@ -10738,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10767,7 +10800,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10783,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "move-prover-lab"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10801,7 +10834,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "hex",
@@ -10814,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10836,7 +10869,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "hex",
@@ -10859,7 +10892,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "once_cell",
  "serde",
@@ -10868,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "better_any",
  "bytes",
@@ -10883,7 +10916,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "better_any",
@@ -10915,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -10924,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "ambassador",
  "better_any",
@@ -10949,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10966,7 +10999,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=f3ab5a497a498e4a2fffb19e70ba65ad289a73be#f3ab5a497a498e4a2fffb19e70ba65ad289a73be"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=94f5fef#94f5fefc1d44fe1ec6b164916f5912797e9aa7e4"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
@@ -13354,7 +13387,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13400,7 +13433,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13424,7 +13457,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13453,7 +13486,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13473,7 +13506,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.47",
@@ -13487,7 +13520,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13563,7 +13596,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13573,7 +13606,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13591,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13609,7 +13642,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13620,7 +13653,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13635,7 +13668,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13648,7 +13681,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13660,7 +13693,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13686,7 +13719,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -13710,7 +13743,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13735,7 +13768,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13766,7 +13799,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13780,7 +13813,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13806,7 +13839,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13830,7 +13863,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13854,7 +13887,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13884,7 +13917,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -13915,7 +13948,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13937,7 +13970,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13962,7 +13995,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "futures",
  "pin-project",
@@ -13985,7 +14018,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14036,7 +14069,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14064,7 +14097,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14080,7 +14113,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14095,7 +14128,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14117,7 +14150,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14128,7 +14161,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14156,7 +14189,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14177,7 +14210,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "clap 4.5.47",
  "eyre",
@@ -14199,7 +14232,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14215,7 +14248,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14233,7 +14266,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14246,7 +14279,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14275,7 +14308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14294,7 +14327,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14304,7 +14337,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14327,7 +14360,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14349,7 +14382,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14362,7 +14395,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14380,7 +14413,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14418,7 +14451,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14432,7 +14465,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "serde",
  "serde_json",
@@ -14442,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14469,7 +14502,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "bytes",
  "futures",
@@ -14489,7 +14522,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "bitflags 2.9.4",
  "byteorder",
@@ -14505,7 +14538,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -14514,7 +14547,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "futures",
  "metrics",
@@ -14526,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14534,7 +14567,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14548,7 +14581,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14603,7 +14636,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14628,7 +14661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14650,7 +14683,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14665,7 +14698,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14679,7 +14712,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14696,7 +14729,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14720,7 +14753,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14788,7 +14821,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14841,7 +14874,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14879,7 +14912,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14903,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14927,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -14948,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -14960,7 +14993,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14981,7 +15014,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -14993,7 +15026,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15013,7 +15046,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15023,7 +15056,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -15035,7 +15068,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15077,7 +15110,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15102,7 +15135,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15115,7 +15148,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15145,7 +15178,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15187,7 +15220,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15215,7 +15248,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
@@ -15228,7 +15261,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15247,7 +15280,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15274,7 +15307,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15287,7 +15320,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15366,7 +15399,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15394,7 +15427,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15433,7 +15466,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15454,7 +15487,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15484,7 +15517,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15528,7 +15561,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15575,7 +15608,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -15589,7 +15622,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15605,7 +15638,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15648,7 +15681,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15675,7 +15708,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15688,7 +15721,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.4",
@@ -15708,7 +15741,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.47",
@@ -15720,7 +15753,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15750,7 +15783,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15766,7 +15799,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15784,7 +15817,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15794,7 +15827,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "clap 4.5.47",
  "eyre",
@@ -15809,7 +15842,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15851,7 +15884,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15875,7 +15908,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15901,7 +15934,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -15914,7 +15947,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15942,7 +15975,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15961,7 +15994,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15979,7 +16012,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=d620fd0#d620fd0eeb6b0d98dfe01ac0460ff80bcf4f1834"
+source = "git+https://github.com/Galxe/gravity-reth?rev=dd57a14#dd57a14b9ea3f6cf902b2a06ddc4fbd54b7b2aa5"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_cli/Cargo.toml
+++ b/bin/gravity_cli/Cargo.toml
@@ -24,4 +24,14 @@ bcs.workspace = true
 sha3.workspace = true
 rand_core = { version = "0.6", features = ["std"] }
 k256 = { version = "0.13.0", features = ["ecdsa"] }
-
+tokio = { version = "1.35", features = ["full"] }
+alloy-primitives = { version = "1.3.1", default-features = false, features = ["map-foldhash"] }
+alloy-provider = { version = "1.0.37", features = ["reqwest"], default-features = false }
+alloy-signer = { version = "1.0.37", default-features = false }
+alloy-signer-local = { version = "1.0.37", default-features = false }
+alloy-contract = { version = "1.0.37", default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+alloy-sol-macro = "1.3.1"
+alloy-transport-http = { version = "1.0.37", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-rpc-types = { version = "1.0.37", features = ["eth"], default-features = false }
+reqwest = { version = "0.12", features = ["json"] }

--- a/bin/gravity_cli/src/command.rs
+++ b/bin/gravity_cli/src/command.rs
@@ -1,11 +1,17 @@
-use clap::Parser;
-use crate::genesis::GenesisCommand;
+use crate::{genesis::GenesisCommand, validator::ValidatorCommand};
+use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(name = "gravity-cli")]
 pub struct Command {
     #[command(subcommand)]
-    pub genesis: GenesisCommand,
+    pub command: SubCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SubCommands {
+    Genesis(GenesisCommand),
+    Validator(ValidatorCommand),
 }
 
 pub trait Executable {

--- a/bin/gravity_cli/src/genesis/account.rs
+++ b/bin/gravity_cli/src/genesis/account.rs
@@ -1,15 +1,11 @@
 use clap::Parser;
 
-use k256::{
-    ecdsa::{SigningKey, VerifyingKey},
-};
+use k256::ecdsa::SigningKey;
+use rand_core::{OsRng, RngCore};
 use sha3::{Digest, Keccak256};
-use rand_core::{RngCore, OsRng};
 
-
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 use tracing::info;
-use std::fs;
 
 use crate::{command::Executable, genesis::account};
 
@@ -54,7 +50,8 @@ fn generate_eth_account() -> Result<(String, String, String), anyhow::Error> {
     let public_key_hash = hasher.finalize();
 
     // Take the last 20 bytes of the hash as the address
-    // The address is usually the last 20 bytes (least significant bytes) of the hash, prefixed with 0x
+    // The address is usually the last 20 bytes (least significant bytes) of the hash, prefixed with
+    // 0x
     let address_bytes = &public_key_hash[12..]; // Take 20 bytes from the 12th byte
     let account_address = format!("0x{}", hex::encode(address_bytes));
 
@@ -64,11 +61,7 @@ fn generate_eth_account() -> Result<(String, String, String), anyhow::Error> {
 impl Executable for GenerateAccount {
     fn execute(self) -> Result<(), anyhow::Error> {
         let (private_key, public_key, address) = generate_eth_account()?;
-        let account = Account {
-            private_key,
-            public_key,
-            address,
-        };
+        let account = Account { private_key, public_key, address };
         let yaml_string = serde_yaml::to_string(&account)?;
         fs::write(self.output_file, yaml_string)?;
         Ok(())

--- a/bin/gravity_cli/src/genesis/mod.rs
+++ b/bin/gravity_cli/src/genesis/mod.rs
@@ -1,15 +1,19 @@
+mod account;
 mod key;
 mod waypoint;
-mod account;
 
-use clap::Subcommand;
+use clap::{Parser, Subcommand};
 
-use crate::genesis::key::GenerateKey;
-use crate::genesis::waypoint::GenerateWaypoint;
-use crate::genesis::account::GenerateAccount;
+use crate::genesis::{account::GenerateAccount, key::GenerateKey, waypoint::GenerateWaypoint};
+
+#[derive(Debug, Parser)]
+pub struct GenesisCommand {
+    #[command(subcommand)]
+    pub command: SubCommands,
+}
 
 #[derive(Subcommand, Debug)]
-pub enum GenesisCommand {
+pub enum SubCommands {
     GenerateKey(GenerateKey),
     GenerateWaypoint(GenerateWaypoint),
     GenerateAccount(GenerateAccount),

--- a/bin/gravity_cli/src/genesis/waypoint.rs
+++ b/bin/gravity_cli/src/genesis/waypoint.rs
@@ -1,13 +1,15 @@
+use bcs;
 use clap::Parser;
 use gaptos::{
-    aptos_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH}, aptos_types::{
-        account_address::AccountAddress, ledger_info::LedgerInfoWithSignatures, on_chain_config::ValidatorSet, validator_config::ValidatorConfig, validator_info::ValidatorInfo, waypoint::Waypoint
-    }
+    aptos_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH},
+    aptos_types::{
+        account_address::AccountAddress, ledger_info::LedgerInfoWithSignatures,
+        on_chain_config::ValidatorSet, validator_config::ValidatorConfig,
+        validator_info::ValidatorInfo, waypoint::Waypoint,
+    },
 };
-use std::path::PathBuf;
-use std::fs;
-use serde::{Deserialize, Serialize};
-use bcs;
+use serde::Deserialize;
+use std::{fs, path::PathBuf};
 
 use crate::command::Executable;
 
@@ -32,7 +34,7 @@ pub struct GenerateWaypoint {
     /// Input JSON file path
     #[clap(long, value_parser)]
     pub input_file: PathBuf,
-    
+
     /// Output waypoint file path
     #[clap(long, value_parser)]
     pub output_file: PathBuf,
@@ -49,18 +51,20 @@ impl GenerateWaypoint {
     /// Generate validator set from test configuration
     fn generate_validator_set(&self, config: &TestConfig) -> Result<ValidatorSet, anyhow::Error> {
         let mut validators = Vec::new();
-        
+
         for i in 0..config.aptos_addresses.len() {
             // Parse account address
-            let account_address = AccountAddress::from_hex_literal(&format!("0x{}", config.aptos_addresses[i]))?;
+            let account_address =
+                AccountAddress::from_hex_literal(&format!("0x{}", config.aptos_addresses[i]))?;
 
             // Parse consensus public key (BLS12-381)
             let consensus_key_bytes = hex::decode(&config.consensus_public_keys[i])?;
-            let consensus_public_key = gaptos::aptos_crypto::bls12381::PublicKey::try_from(&consensus_key_bytes[..])?;
+            let consensus_public_key =
+                gaptos::aptos_crypto::bls12381::PublicKey::try_from(&consensus_key_bytes[..])?;
 
             // Parse voting power
             let voting_power: u64 = config.voting_powers[i].parse()?;
-            
+
             // Create validator config
             let validator_config = ValidatorConfig::new(
                 consensus_public_key,
@@ -68,12 +72,13 @@ impl GenerateWaypoint {
                 bcs::to_bytes(&vec![config.fullnode_network_addresses[i].clone()]).unwrap(),
                 i as u64,
             );
-            
+
             // Create validator info
-            let validator_info = ValidatorInfo::new(account_address, voting_power, validator_config);
+            let validator_info =
+                ValidatorInfo::new(account_address, voting_power, validator_config);
             validators.push(validator_info);
         }
-        
+
         Ok(ValidatorSet::new(validators))
     }
 
@@ -82,13 +87,14 @@ impl GenerateWaypoint {
         let config = self.load_test_config()?;
         let validator_set = self.generate_validator_set(&config)?;
 
-        
         // For now, generate a simple waypoint hash
         // In a real implementation, this would use the validator set to create a proper waypoint
-        let ledger_info_with_signatures = LedgerInfoWithSignatures::genesis(*ACCUMULATOR_PLACEHOLDER_HASH, validator_set);
-        let waypoint_hash = Waypoint::new_epoch_boundary(&ledger_info_with_signatures.ledger_info())?;
+        let ledger_info_with_signatures =
+            LedgerInfoWithSignatures::genesis(*ACCUMULATOR_PLACEHOLDER_HASH, validator_set);
+        let waypoint_hash =
+            Waypoint::new_epoch_boundary(&ledger_info_with_signatures.ledger_info())?;
         let waypoint_string = format!("{}", waypoint_hash);
-        
+
         Ok(waypoint_string)
     }
 }
@@ -97,15 +103,15 @@ impl Executable for GenerateWaypoint {
     fn execute(self) -> Result<(), anyhow::Error> {
         println!("--- Generate Waypoint Start ---");
         println!("Reading input file: {:?}", self.input_file);
-        
+
         let waypoint_string = self.generate_waypoint()?;
         println!("Generated waypoint: {}", waypoint_string);
-        
+
         println!("--- Write Output File ---");
         fs::write(&self.output_file, &waypoint_string)?;
         println!("Waypoint written to: {:?}", self.output_file);
         println!("--- Generate Waypoint Success ---");
-        
+
         Ok(())
     }
 }

--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -1,25 +1,35 @@
 pub mod command;
 pub mod genesis;
+pub mod validator;
 
 use clap::Parser;
 use command::{Command, Executable};
 
 fn main() {
     let cmd = Command::parse();
-    match cmd.genesis {
- genesis::GenesisCommand::GenerateKey(gck) => {
-            if let Err(e) = gck.execute() {
-                eprintln!("Error: {:?}", e);
+    match cmd.command {
+        command::SubCommands::Genesis(genesis_cmd) => match genesis_cmd.command {
+            genesis::SubCommands::GenerateKey(gck) => {
+                if let Err(e) = gck.execute() {
+                    eprintln!("Error: {:?}", e);
+                }
             }
-        }
-        genesis::GenesisCommand::GenerateWaypoint(gw) => {
-            if let Err(e) = gw.execute() {
-                eprintln!("Error: {:?}", e);
+            genesis::SubCommands::GenerateWaypoint(gw) => {
+                if let Err(e) = gw.execute() {
+                    eprintln!("Error: {:?}", e);
+                }
             }
-        }
-        genesis::GenesisCommand::GenerateAccount(generate_account) => {
-            if let Err(e) = generate_account.execute() {
-                eprintln!("Error: {:?}", e);
+            genesis::SubCommands::GenerateAccount(generate_account) => {
+                if let Err(e) = generate_account.execute() {
+                    eprintln!("Error: {:?}", e);
+                }
+            }
+        },
+        command::SubCommands::Validator(validator_cmd) => match validator_cmd.command {
+            validator::SubCommands::Join(join_cmd) => {
+                if let Err(e) = join_cmd.execute() {
+                    eprintln!("Error: {:?}", e);
+                }
             }
         },
     }

--- a/bin/gravity_cli/src/validator/join.rs
+++ b/bin/gravity_cli/src/validator/join.rs
@@ -1,0 +1,520 @@
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::eth::{TransactionInput, TransactionRequest};
+use alloy_signer::k256::ecdsa::SigningKey;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{SolCall, SolEvent, SolType, SolValue};
+use clap::Parser;
+use std::{
+    fmt::{Debug, Formatter},
+    str::FromStr,
+};
+
+use crate::command::Executable;
+
+// Define contract interface using alloy_sol_macro
+alloy_sol_macro::sol! {
+    // Commission structure
+    struct Commission {
+        uint64 rate; // the commission rate charged to delegators(10000 is 100%)
+        uint64 maxRate; // maximum commission rate which validator can ever charge
+        uint64 maxChangeRate; // maximum daily increase of the validator commission
+    }
+
+    enum ValidatorStatus {
+        PENDING_ACTIVE, // 0
+        ACTIVE, // 1
+        PENDING_INACTIVE, // 2
+        INACTIVE // 3
+    }
+
+    // Validator registration parameters
+    struct ValidatorRegistrationParams {
+        bytes consensusPublicKey;
+        bytes blsProof; // BLS proof
+        Commission commission; // Changed from uint64 commissionRate to Commission struct
+        string moniker;
+        address initialOperator;
+        address initialBeneficiary; // Passed directly to StakeCredit
+        // Network addresses for Aptos compatibility
+        bytes validatorNetworkAddresses; // BCS serialized Vec<NetworkAddress>
+        bytes fullnodeNetworkAddresses; // BCS serialized Vec<NetworkAddress>
+        bytes aptosAddress; // Aptos validator address
+    }
+
+    struct ValidatorInfo {
+        // Basic information (from ValidatorManager)
+        bytes consensusPublicKey;
+        Commission commission;
+        string moniker;
+        bool registered;
+        address stakeCreditAddress;
+        ValidatorStatus status;
+        uint256 votingPower; // Changed from uint64 to uint256 to prevent overflow
+        uint256 validatorIndex;
+        uint256 updateTime;
+        address operator;
+        bytes validatorNetworkAddresses; // BCS serialized Vec<NetworkAddress>
+        bytes fullnodeNetworkAddresses; // BCS serialized Vec<NetworkAddress>
+        bytes aptosAddress; // Aptos validator address
+    }
+
+    struct ValidatorSetData {
+        uint256 totalVotingPower; // Total voting power - Changed from uint128 to uint256
+        uint256 totalJoiningPower; // Total pending voting power - Changed from uint128 to uint256
+    }
+
+    struct ValidatorSet {
+        ValidatorInfo[] activeValidators; // Active validators for the current epoch
+        ValidatorInfo[] pendingInactive; // Pending validators to leave in next epoch (still active)
+        ValidatorInfo[] pendingActive; // Pending validators to join in next epoch
+        uint256 totalVotingPower; // Current total voting power
+        uint256 totalJoiningPower; // Total voting power waiting to join in the next epoch
+    }
+
+    contract ValidatorManager {
+        function registerValidator(
+            ValidatorRegistrationParams calldata params
+        ) external payable;
+
+        function joinValidatorSet(address validator) external;
+
+        function getValidatorInfo(
+            address validator
+        ) external view returns (ValidatorInfo memory);
+
+        function isValidatorRegistered(address validator) external view returns (bool);
+
+        function getValidatorStatus(address validator) external view returns (uint8);
+
+        function getValidatorSetData() external view returns (ValidatorSetData memory);
+
+        function getValidatorSet() external view returns (ValidatorSet memory);
+
+        event ValidatorRegistered(
+            address indexed validator,
+            address indexed operator,
+            bytes consensusPublicKey,
+            string moniker
+        );
+
+        event ValidatorJoinRequested(
+            address indexed validator,
+            uint256 votingPower,
+            uint64 epoch
+        );
+    }
+}
+
+impl Debug for ValidatorStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidatorStatus::PENDING_ACTIVE => write!(f, "PENDING_ACTIVE"),
+            ValidatorStatus::ACTIVE => write!(f, "ACTIVE"),
+            ValidatorStatus::PENDING_INACTIVE => write!(f, "PENDING_INACTIVE"),
+            ValidatorStatus::INACTIVE => write!(f, "INACTIVE"),
+            _ => write!(f, "UNKNOWN"),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct JoinCommand {
+    /// RPC URL for gravity node
+    #[clap(long)]
+    pub rpc_url: String,
+
+    /// ValidatorManager contract address (40 bytes hex string with 0x prefix)
+    #[clap(long)]
+    pub contract_address: String,
+
+    /// Private key for signing transactions (hex string with or without 0x prefix)
+    #[clap(long)]
+    pub private_key: String,
+
+    /// Gas limit for the transaction
+    #[clap(long, default_value = "2000000")]
+    pub gas_limit: u64,
+
+    /// Gas price in wei
+    #[clap(long, default_value = "20")]
+    pub gas_price: u128,
+
+    /// Stake amount in ETH
+    #[clap(long)]
+    pub stake_amount: String,
+
+    /// Moniker
+    #[clap(long, default_value = "Gravity1")]
+    pub moniker: String,
+
+    /// EVM compatible validator address (40 bytes hex string with 0x prefix)
+    #[clap(long)]
+    pub validator_address: String,
+
+    /// Consensus public key
+    #[clap(long)]
+    pub consensus_public_key: String,
+
+    /// Validator network addresses (/ip4/{host}/tcp/{port}/noise-ik/{public-key}/handshake/0)
+    #[clap(long)]
+    pub validator_network_addresses: Vec<String>,
+
+    /// Fullnode network addresses (/ip4/{host}/tcp/{port}/noise-ik/{public-key}/handshake/0)
+    #[clap(long)]
+    pub fullnode_network_addresses: Vec<String>,
+
+    /// Aptos validator identity address (64 characters hex string)
+    #[clap(long)]
+    pub aptos_address: String,
+}
+
+impl Executable for JoinCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        // Use tokio runtime to run async code
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl JoinCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        // 1. Initialize Provider and Wallet
+        println!("1. Initializing connection...");
+
+        println!("   RPC URL: {}", self.rpc_url);
+        let private_key_str = self.private_key.strip_prefix("0x").unwrap_or(&self.private_key);
+        let private_key_bytes = hex::decode(private_key_str)?;
+        let private_key = SigningKey::from_slice(private_key_bytes.as_slice())
+            .map_err(|e| anyhow::anyhow!("Invalid private key: {}", e))?;
+        let signer = PrivateKeySigner::from(private_key);
+        let wallet_address = signer.address();
+        println!("   Wallet address: {:?}", wallet_address);
+
+        let contract_address = Address::from_str(&self.contract_address)?;
+        println!("   Contract address: {:?}", contract_address);
+
+        // Create provider
+        let provider = ProviderBuilder::new().wallet(signer).connect_http(self.rpc_url.parse()?);
+
+        let chain_id = provider.get_chain_id().await?;
+        println!("   Chain ID: {}", chain_id);
+        let balance = provider.get_balance(wallet_address).await?;
+        println!("   Wallet balance: {} ETH\n", format_ether(balance));
+
+        println!("2. Preparing registration parameters...");
+        let validator_address = Address::from_str(&self.validator_address)?;
+        let validator_params = ValidatorRegistrationParams {
+            consensusPublicKey: hex::decode(&self.consensus_public_key)?.into(),
+            blsProof: Bytes::new(),
+            commission: Commission { rate: 0, maxRate: 5000, maxChangeRate: 500 },
+            moniker: self.moniker,
+            initialOperator: wallet_address,
+            initialBeneficiary: wallet_address,
+            validatorNetworkAddresses: bcs::to_bytes(&self.validator_network_addresses)?.into(),
+            fullnodeNetworkAddresses: bcs::to_bytes(&self.fullnode_network_addresses)?.into(),
+            aptosAddress: hex::decode(&self.aptos_address)?.into(),
+        };
+        println!("   Registration parameters:");
+        println!(
+            "   - Consensus public key: {} (length: {} bytes)",
+            self.consensus_public_key,
+            validator_params.consensusPublicKey.len()
+        );
+        println!(
+            "   - Validator moniker: \"{}\" (length: {})",
+            validator_params.moniker,
+            validator_params.moniker.len()
+        );
+        println!("   - Operator address: {}", validator_params.initialOperator);
+        println!("   - Beneficiary address: {}", validator_params.initialBeneficiary);
+        println!(
+            "   - Commission settings: {}% current ({}% max, {}% max daily change)",
+            validator_params.commission.rate / 100,
+            validator_params.commission.maxRate / 100,
+            validator_params.commission.maxChangeRate / 100
+        );
+        let stake_wei = parse_ether(&self.stake_amount)?;
+        println!("   - Stake amount: {} ETH", self.stake_amount);
+        println!(
+            "   - Aptos address: {} (length: {} bytes)",
+            self.aptos_address,
+            validator_params.aptosAddress.len()
+        );
+
+        // 3. Check system status
+        println!("3. Checking system status...");
+        let call = ValidatorManager::getValidatorSetDataCall {};
+        let input: Bytes = call.abi_encode().into();
+        let result = provider
+            .call(TransactionRequest {
+                from: Some(wallet_address),
+                to: Some(TxKind::Call(contract_address)),
+                input: TransactionInput::new(input),
+                ..Default::default()
+            })
+            .await?;
+        let validator_set_data = <ValidatorSetData as SolType>::abi_decode(&result)
+            .map_err(|e| anyhow::anyhow!("Failed to decode validator set data: {}", e))?;
+        println!(
+            "   Current total voting power: {} ETH",
+            format_ether(validator_set_data.totalVotingPower)
+        );
+        println!(
+            "   Current total joining voting power: {} ETH",
+            format_ether(validator_set_data.totalJoiningPower)
+        );
+        let call = ValidatorManager::getValidatorSetCall {};
+        let input: Bytes = call.abi_encode().into();
+        let result = provider
+            .call(TransactionRequest {
+                from: Some(wallet_address),
+                to: Some(TxKind::Call(contract_address)),
+                input: TransactionInput::new(input),
+                ..Default::default()
+            })
+            .await?;
+        let validator_set = <ValidatorSet as SolType>::abi_decode(&result)
+            .map_err(|e| anyhow::anyhow!("Failed to decode validator set: {}", e))?;
+        println!("   Active validators count: {}", validator_set.activeValidators.len());
+        println!("   Pending active validators count: {}", validator_set.pendingActive.len());
+
+        // 4. Check if already registered
+        println!("4. Checking validator status...");
+        let call = ValidatorManager::isValidatorRegisteredCall { validator: validator_address };
+        let input: Bytes = call.abi_encode().into();
+        let result = provider
+            .call(TransactionRequest {
+                from: Some(wallet_address),
+                to: Some(TxKind::Call(contract_address)),
+                input: TransactionInput::new(input),
+                ..Default::default()
+            })
+            .await?;
+        let is_registered = bool::abi_decode(&result)
+            .map_err(|e| anyhow::anyhow!("Failed to decode is registered: {}", e))?;
+        println!("   Is registered: {}", is_registered);
+        if is_registered {
+            println!("   Validator is already registered, skipping registration step\n");
+        } else {
+            println!("5. Registering validator...");
+            let call = ValidatorManager::registerValidatorCall { params: validator_params };
+            let input: Bytes = call.abi_encode().into();
+            let tx_hash = provider
+                .send_transaction(TransactionRequest {
+                    from: Some(wallet_address),
+                    to: Some(TxKind::Call(contract_address)),
+                    input: TransactionInput::new(input),
+                    value: Some(stake_wei),
+                    gas: Some(self.gas_limit),
+                    gas_price: Some(self.gas_price),
+                    ..Default::default()
+                })
+                .await?
+                .with_required_confirmations(2)
+                .with_timeout(Some(std::time::Duration::from_secs(60)))
+                .watch()
+                .await?;
+            println!("   Transaction hash: {}", tx_hash);
+            let receipt = provider
+                .get_transaction_receipt(tx_hash)
+                .await?
+                .ok_or(anyhow::anyhow!("Failed to get transaction receipt"))?;
+            println!(
+                "   Transaction confirmed, block number: {}",
+                receipt.block_number.ok_or(anyhow::anyhow!("Failed to get block number"))?
+            );
+            println!("   Gas used: {}", receipt.gas_used);
+            println!(
+                "   Transaction cost: {} ETH",
+                format_ether(
+                    U256::from(receipt.effective_gas_price) * U256::from(receipt.gas_used)
+                )
+            );
+            // Check registration event
+            let mut found = false;
+            for log in receipt.logs() {
+                match ValidatorManager::ValidatorRegistered::decode_log(&log.inner) {
+                    Ok(event) => {
+                        println!("   Registration successful! Event details:");
+                        println!("   - Validator address: {}", event.validator);
+                        println!("   - Operator address: {}", event.operator);
+                        println!("   - Validator moniker: {}", event.moniker);
+                        found = true;
+                        break;
+                    }
+                    Err(_) => {}
+                }
+            }
+            if !found {
+                println!("   Registration event not found\n");
+                return Err(anyhow::anyhow!("Failed to find register event"));
+            }
+        }
+
+        println!("6. Checking validator information...");
+        let call = ValidatorManager::getValidatorInfoCall { validator: validator_address };
+        let input: Bytes = call.abi_encode().into();
+        let result = provider
+            .call(TransactionRequest {
+                from: Some(wallet_address),
+                to: Some(TxKind::Call(contract_address)),
+                input: TransactionInput::new(input),
+                ..Default::default()
+            })
+            .await?;
+        let validator_info = <ValidatorInfo as SolType>::abi_decode(&result)
+            .map_err(|e| anyhow::anyhow!("Failed to decode validator info: {}", e))?;
+        println!("   Validator information:");
+        println!("   - Registered: {}", validator_info.registered);
+        println!("   - Status: {:?}", validator_info.status);
+        println!("   - Voting power: {}", format_ether(validator_info.votingPower));
+        println!("   - StakeCredit address: {}", validator_info.stakeCreditAddress);
+        println!("   - Operator: {}", validator_info.operator);
+        println!("   - Validator moniker: {}", validator_info.moniker);
+        println!("   - Consensus public key: {}", validator_info.consensusPublicKey);
+        println!(
+            "   - Validator network addresses: {}",
+            bcs::from_bytes::<Vec<String>>(&validator_info.validatorNetworkAddresses)
+                .map_err(|e| anyhow::anyhow!(
+                    "Failed to decode validator network addresses: {}",
+                    e
+                ))?
+                .join(", ")
+        );
+        println!(
+            "   - Fullnode network addresses: {}",
+            bcs::from_bytes::<Vec<String>>(&validator_info.fullnodeNetworkAddresses)
+                .map_err(|e| anyhow::anyhow!("Failed to decode fullnode network addresses: {}", e))?
+                .join(", ")
+        );
+        println!("   - Aptos address: {}", validator_info.aptosAddress);
+        if !matches!(validator_info.status, ValidatorStatus::INACTIVE) {
+            println!("   Validator status is not INACTIVE, skipping join step\n");
+            return Ok(());
+        }
+
+        println!("7. Joining validator set...");
+        let call = ValidatorManager::joinValidatorSetCall { validator: validator_address };
+        let input: Bytes = call.abi_encode().into();
+        let tx_hash = provider
+            .send_transaction(TransactionRequest {
+                from: Some(wallet_address),
+                to: Some(TxKind::Call(contract_address)),
+                input: TransactionInput::new(input),
+                ..Default::default()
+            })
+            .await?
+            .with_required_confirmations(2)
+            .with_timeout(Some(std::time::Duration::from_secs(60)))
+            .watch()
+            .await?;
+        println!("   Transaction hash: {}", tx_hash);
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(anyhow::anyhow!("Failed to get transaction receipt"))?;
+        println!(
+            "   Transaction confirmed, block number: {}",
+            receipt.block_number.ok_or(anyhow::anyhow!("Failed to get block number"))?
+        );
+        println!("   Gas used: {}", receipt.gas_used);
+        println!(
+            "   Transaction cost: {} ETH",
+            format_ether(U256::from(receipt.effective_gas_price) * U256::from(receipt.gas_used))
+        );
+        // Check join event
+        let mut found = false;
+        for log in receipt.logs() {
+            match ValidatorManager::ValidatorJoinRequested::decode_log(&log.inner) {
+                Ok(event) => {
+                    println!("   Join successful! Event details:");
+                    println!("   - Validator address: {}", event.validator);
+                    println!("   - Voting power: {}", format_ether(event.votingPower));
+                    println!("   - Epoch: {}", event.epoch);
+                    found = true;
+                    break;
+                }
+                Err(_) => {}
+            }
+        }
+        if !found {
+            println!("   Join event not found\n");
+            return Err(anyhow::anyhow!("Failed to find join event"));
+        }
+
+        println!("8. Final status check...");
+        let call = ValidatorManager::getValidatorStatusCall { validator: validator_address };
+        let input: Bytes = call.abi_encode().into();
+        let result = provider
+            .call(TransactionRequest {
+                from: Some(wallet_address),
+                to: Some(TxKind::Call(contract_address)),
+                input: TransactionInput::new(input),
+                ..Default::default()
+            })
+            .await?;
+        let validator_status = <ValidatorStatus as SolType>::abi_decode(&result)
+            .map_err(|e| anyhow::anyhow!("Failed to decode validator status: {}", e))?;
+        match validator_status {
+            ValidatorStatus::PENDING_ACTIVE => {
+                println!("   Validator status is PENDING_ACTIVE, please wait for the next epoch to automatically become ACTIVE\n");
+            }
+            ValidatorStatus::ACTIVE => {
+                println!("   Validator status is ACTIVE, successfully joined the validator set\n");
+            }
+            _ => {
+                println!("   Validator status is {:?}, unexpected status\n", validator_status);
+                return Err(anyhow::anyhow!("Unexpected validator status: {:?}", validator_status));
+            }
+        }
+        Ok(())
+    }
+}
+
+// Helper function: format ether amount
+fn format_ether(wei: U256) -> String {
+    let wei_str = wei.to_string();
+    let len = wei_str.len();
+    if len <= 18 {
+        format!("0.{}", "0".repeat(18 - len) + &wei_str)
+    } else {
+        let (integer, decimal) = wei_str.split_at(len - 18);
+        format!("{}.{}", integer, decimal.trim_end_matches('0').trim_end_matches('.'))
+    }
+}
+
+fn parse_ether(eth_amount: &str) -> Result<U256, anyhow::Error> {
+    const DECIMALS: usize = 18; // 1 Ether = 10^18 Wei
+
+    let parts: Vec<&str> = eth_amount.split('.').collect();
+
+    // Check if there is a decimal point
+    if parts.len() == 1 {
+        // If integer, append 18 zeros directly
+        let s = format!("{}{}", parts[0], "0".repeat(DECIMALS));
+        return Ok(U256::from_str(&s).map_err(|e| anyhow::anyhow!("Failed to parse ether: {}", e))?);
+    }
+
+    if parts.len() > 2 {
+        // Multiple decimal points are invalid input
+        return Err(anyhow::anyhow!("Invalid ether amount: {}", eth_amount));
+    }
+
+    let integer_part = parts[0];
+    let fractional_part = parts[1];
+
+    // Check if fractional part length exceeds 18 digits
+    if fractional_part.len() > DECIMALS {
+        // Exceeding 18-digit precision is considered invalid or overflow
+        return Err(anyhow::anyhow!("Invalid ether amount: {}", eth_amount));
+    }
+
+    // Calculate the number of padding zeros needed
+    let padding_zeros = DECIMALS - fractional_part.len();
+
+    // Construct final Wei string: [integer part][fractional part][padding zeros]
+    let wei_str = format!("{}{}{}", integer_part, fractional_part, "0".repeat(padding_zeros));
+
+    Ok(U256::from_str(&wei_str).map_err(|e| anyhow::anyhow!("Failed to parse ether: {}", e))?)
+}

--- a/bin/gravity_cli/src/validator/mod.rs
+++ b/bin/gravity_cli/src/validator/mod.rs
@@ -1,0 +1,17 @@
+mod join;
+
+use clap::{Parser, Subcommand};
+
+use crate::validator::join::JoinCommand;
+
+#[derive(Debug, Parser)]
+pub struct ValidatorCommand {
+    #[command(subcommand)]
+    pub command: SubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SubCommands {
+    Join(JoinCommand),
+    // TODO: other commands
+}


### PR DESCRIPTION
```
Usage: gravity_cli validator join [OPTIONS] --rpc-url <RPC_URL> --contract-address <CONTRACT_ADDRESS> --private-key <PRIVATE_KEY> --stake-amount <STAKE_AMOUNT> --validator-address <VALIDATOR_ADDRESS> --consensus-public-key <CONSENSUS_PUBLIC_KEY> --aptos-address <APTOS_ADDRESS>

Options:
      --rpc-url <RPC_URL>                                          RPC URL for gravity node
      --contract-address <CONTRACT_ADDRESS>                        ValidatorManager contract address (40 bytes hex string with 0x prefix)
      --private-key <PRIVATE_KEY>                                  Private key for signing transactions (hex string with or without 0x prefix)
      --gas-limit <GAS_LIMIT>                                      Gas limit for the transaction [default: 2000000]
      --gas-price <GAS_PRICE>                                      Gas price in wei [default: 20]
      --stake-amount <STAKE_AMOUNT>                                Stake amount in ETH
      --moniker <MONIKER>                                          Moniker [default: Gravity1]
      --validator-address <VALIDATOR_ADDRESS>                      EVM compatible validator address (40 bytes hex string with 0x prefix)
      --consensus-public-key <CONSENSUS_PUBLIC_KEY>                Consensus public key
      --validator-network-addresses <VALIDATOR_NETWORK_ADDRESSES>  Validator network addresses (/ip4/{host}/tcp/{port}/noise-ik/{public-key}/handshake/0)
      --fullnode-network-addresses <FULLNODE_NETWORK_ADDRESSES>    Fullnode network addresses (/ip4/{host}/tcp/{port}/noise-ik/{public-key}/handshake/0)
      --aptos-address <APTOS_ADDRESS>                              Aptos validator identity address (64 characters hex string)
  -h, --help                                                       Print help
```