### PR TITLE
feat(consensus): move epoch change message sending to persisting phase

### DIFF
--- a/aptos-core/consensus/src/pipeline/decoupled_execution_utils.rs
+++ b/aptos-core/consensus/src/pipeline/decoupled_execution_utils.rs
@@ -96,7 +96,8 @@ pub fn prepare_phases_and_buffer_manager(
         create_channel::<CountedRequest<PersistingRequest>>();
     let (persisting_phase_response_tx, persisting_phase_response_rx) = create_channel();
 
-    let persisting_phase_processor = PersistingPhase::new(persisting_proxy);
+    let commit_msg_tx_arc = Arc::new(commit_msg_tx);
+    let persisting_phase_processor = PersistingPhase::new(persisting_proxy, commit_msg_tx_arc.clone());
     let persisting_phase = PipelinePhase::new(
         persisting_phase_request_rx,
         Some(persisting_phase_response_tx),
@@ -117,7 +118,7 @@ pub fn prepare_phases_and_buffer_manager(
             execution_wait_phase_response_rx,
             signing_phase_request_tx,
             signing_phase_response_rx,
-            Arc::new(commit_msg_tx),
+            commit_msg_tx_arc,
             commit_msg_rx,
             persisting_phase_request_tx,
             persisting_phase_response_rx,

--- a/aptos-core/consensus/src/pipeline/persisting_phase.rs
+++ b/aptos-core/consensus/src/pipeline/persisting_phase.rs
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    network::NetworkSender,
     pipeline::pipeline_phase::StatelessPipeline,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
 };
 use aptos_consensus_types::{common::Round, pipelined_block::PipelinedBlock};
 use aptos_executor_types::ExecutorResult;
-use gaptos::aptos_types::ledger_info::LedgerInfoWithSignatures;
+use gaptos::aptos_types::{epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures};
 use async_trait::async_trait;
 use std::{
     fmt::{Debug, Display, Formatter},
@@ -42,11 +43,12 @@ pub type PersistingResponse = ExecutorResult<Round>;
 
 pub struct PersistingPhase {
     persisting_handle: Arc<dyn StateComputer>,
+    commit_msg_tx: Arc<NetworkSender>,
 }
 
 impl PersistingPhase {
-    pub fn new(persisting_handle: Arc<dyn StateComputer>) -> Self {
-        Self { persisting_handle }
+    pub fn new(persisting_handle: Arc<dyn StateComputer>, commit_msg_tx: Arc<NetworkSender>) -> Self {
+        Self { persisting_handle, commit_msg_tx }
     }
 }
 
@@ -65,9 +67,16 @@ impl StatelessPipeline for PersistingPhase {
         } = req;
         let round = commit_ledger_info.ledger_info().round();
 
-        self.persisting_handle
-            .commit(&blocks, commit_ledger_info, callback)
+        let response = self.persisting_handle
+            .commit(&blocks, commit_ledger_info.clone(), callback)
             .await
-            .map(|_| round)
+            .map(|_| round);
+
+        if commit_ledger_info.ledger_info().ends_epoch() {
+            self.commit_msg_tx
+                .send_epoch_change(EpochChangeProof::new(vec![commit_ledger_info], false))
+                .await;
+        }
+        response
     }
 }


### PR DESCRIPTION
Move epoch change message sending from BufferManager to PersistingPhase, ensuring the notification is sent after block persistence completes, which follows a more reasonable architectural design.

Key changes:
- PersistingPhase: add commit_msg_tx field to send epoch change on epoch end
- BufferManager: remove epoch change sending logic, adjust reset timing
- decoupled_execution_utils: share commit_msg_tx between PersistingPhase and BufferManager

This change ensures epoch change messages are only sent after blocks are truly persisted, avoiding potential timing issues.

## PR Description
[Briefly describe your changes]
Issue Number: closes #xxx

## Tested?

- [ ] Yes
- [ ] No