### PR TITLE
chore(fullnode): set default block_sync_interval to 200ms

### DIFF
--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -1906,7 +1906,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         // FIXME(nekomoto): If the node is current epoch validator, we don't need to advance the block sync.
         let mut block_sync_interval = tokio::time::interval(Duration::from_millis(
             std::env::var("GRAVITY_ADVANCE_BLOCK_SYNC_INTERVAL_MS")
-                .map_or(1000, |s| s.parse::<u64>().unwrap()),
+                .map_or(200, |s| s.parse::<u64>().unwrap()),
         ));
         loop {
             tokio::select! {


### PR DESCRIPTION
The time difference between the full node and validator blocks being processed by the executor under different `GRAVITY_ADVANCE_BLOCK_SYNC_INTERVAL_MS`:
`GRAVITY_ADVANCE_BLOCK_SYNC_INTERVAL_MS=1000`

```
平均时间差: 528.699 ms
---------------------------------
P50 (中位数): 526.409 ms
P90 (90%分位): 924.359 ms
P99 (99%分位): 1012.487 ms
```

`GRAVITY_ADVANCE_BLOCK_SYNC_INTERVAL_MS=200`

```
平均时间差: 114.913 ms
---------------------------------
P50 (中位数): 112.242 ms
P90 (90%分位): 192.135 ms
P99 (99%分位): 213.393 ms
```