### PR TITLE
feat: non-blocking epoch change and fix deprecated try_next()

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -39,27 +39,26 @@ jobs:
             exit 0
           fi
 
-          # Use PR branch instead of head_sha so that the check is PR-wide,
-          # not commit-specific.  Once CI passes on any commit in the PR,
-          # subsequent approvals (even after new pushes) will be skipped.
-          # The author can always re-run manually if needed.
+          # Use head_sha (commit-specific) so that new pushes invalidate
+          # previous CI results and require a fresh run after re-approval.
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           PR_BRANCH="${{ github.event.pull_request.head.ref }}"
 
-          # Check for in-progress runs on this PR (any commit)
+          # Check for in-progress runs on the same commit
           IN_PROGRESS=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/${{ inputs.workflow_file }}/runs?branch=${PR_BRANCH}" \
+            "repos/${{ github.repository }}/actions/workflows/${{ inputs.workflow_file }}/runs?head_sha=${HEAD_SHA}" \
             --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .status == \"in_progress\")] | length")
           if [ "$IN_PROGRESS" -gt "0" ]; then
-            echo "CI already in progress for branch ${PR_BRANCH}. Skipping."
+            echo "CI already in progress for commit ${HEAD_SHA}. Skipping."
             echo "should_run=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Check for successful runs on this PR (any commit) — but only
+          # Check for successful runs on the same commit — but only
           # count runs where real test jobs actually ran (not just gate +
           # skipped downstream jobs)
           SUCCESSFUL_RUN_IDS=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/${{ inputs.workflow_file }}/runs?branch=${PR_BRANCH}" \
+            "repos/${{ github.repository }}/actions/workflows/${{ inputs.workflow_file }}/runs?head_sha=${HEAD_SHA}" \
             --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .conclusion == \"success\")] | .[].id")
 
           HAS_REAL_SUCCESS=false
@@ -69,14 +68,14 @@ jobs:
               "repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs" \
               --jq '[.jobs[] | select(.conclusion == "success" and (.name | test("(?i)gate") | not))] | length')
             if [ "$REAL_JOBS" -gt "0" ]; then
-              echo "Found previous run #$RUN_ID with real test execution on branch ${PR_BRANCH}."
+              echo "Found previous run #$RUN_ID with real test execution for commit ${HEAD_SHA}."
               HAS_REAL_SUCCESS=true
               break
             fi
           done
 
           if [ "$HAS_REAL_SUCCESS" = "true" ]; then
-            echo "CI already passed for branch ${PR_BRANCH}. Skipping."
+            echo "CI already passed for commit ${HEAD_SHA}. Skipping."
             echo "should_run=false" >> $GITHUB_OUTPUT
           else
             echo "should_run=true" >> $GITHUB_OUTPUT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-types",
  "bcs 0.1.4",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1142,7 +1142,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-global-constants",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-sdk",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "proptest",
  "serde",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "futures",
  "rustversion",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "shadow-rs",
 ]
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1325,12 +1325,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1442,25 +1442,25 @@ dependencies = [
  "aptos-collections",
  "aptos-config",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-schemadb",
  "aptos-secure-storage",
  "aptos-short-hex-str",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -1549,13 +1549,13 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-short-hex-str",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1718,7 +1718,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-jellyfish-merkle",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1827,13 +1827,13 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-enum-conversion-derive",
@@ -1844,7 +1844,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "api-types",
@@ -1916,15 +1916,15 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-executor-service",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-experimental-runtimes",
  "aptos-indexer-grpc-table-info",
  "aptos-infallible",
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-block-executor",
  "aptos-block-partitioner",
@@ -1978,16 +1978,16 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-db",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2036,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-layered-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "ahash 0.8.12",
  "aptos-crypto",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -2064,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2143,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "either",
  "move-core-types",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -2200,17 +2200,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2219,7 +2219,7 @@ dependencies = [
  "aptos-config",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-metrics-core",
  "aptos-moving-average",
  "aptos-protos",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2256,7 +2256,7 @@ dependencies = [
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-storage-interface",
@@ -2278,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
@@ -2314,12 +2314,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "api-types",
@@ -2381,7 +2381,7 @@ dependencies = [
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
@@ -2392,7 +2392,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2426,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2436,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -2572,13 +2572,13 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-event-notifications",
  "aptos-infallible",
@@ -2613,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2798,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "pbjson",
  "prost",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "ipnet",
 ]
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2928,11 +2928,11 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-enum-conversion-derive",
  "aptos-infallible",
  "aptos-logger",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "rayon",
  "tokio",
@@ -3025,10 +3025,10 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-infallible",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-drop-helper",
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3200,7 +3200,7 @@ dependencies = [
  "aptos-data-client",
  "aptos-data-streaming-service",
  "aptos-event-notifications",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-mempool-notifications",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -3309,17 +3309,17 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crypto",
  "aptos-db",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-node-resource-metrics",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3388,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-filter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-protos",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "api-types",
@@ -3492,12 +3492,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-environment"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-framework",
  "aptos-gas-algebra",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "gaptos"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "api-types",
  "aptos-bitvec",
@@ -7460,9 +7460,9 @@ dependencies = [
  "aptos-collections",
  "aptos-compression",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-crash-handler",
  "aptos-crypto",
  "aptos-crypto-derive",
@@ -7470,9 +7470,9 @@ dependencies = [
  "aptos-dkg-runtime",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-executor-test-helpers",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-global-constants",
@@ -7483,7 +7483,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-log-derive",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-mempool-notifications",
  "aptos-memsocket",
  "aptos-metrics-core",
@@ -7499,7 +7499,7 @@ dependencies = [
  "aptos-reliable-broadcast",
  "aptos-rest-client",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7)",
  "aptos-schemadb",
  "aptos-secure-net",
  "aptos-secure-storage",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 
 [[package]]
 name = "gravity-sdk"
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7948,7 +7948,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -8679,7 +8679,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10293,7 +10293,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10325,12 +10325,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10345,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "once_cell",
  "quote",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10396,7 +10396,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "difference",
@@ -10443,7 +10443,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10500,7 +10500,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10526,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10562,7 +10562,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10581,7 +10581,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -10640,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "codespan",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "atty",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "move-prover-lab"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10804,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "hex",
@@ -10862,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "once_cell",
  "serde",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "better_any",
  "bytes",
@@ -10886,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "better_any",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -10927,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "ambassador",
  "better_any",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=16ed314689713d84995ac484210630292d6633c7#16ed314689713d84995ac484210630292d6633c7"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
@@ -13391,7 +13391,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13437,7 +13437,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13461,7 +13461,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13490,7 +13490,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13510,7 +13510,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13524,7 +13524,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13601,7 +13601,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13611,7 +13611,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13629,7 +13629,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13647,7 +13647,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13658,7 +13658,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13686,7 +13686,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13698,7 +13698,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13724,7 +13724,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13745,7 +13745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13770,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13801,7 +13801,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13815,7 +13815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13841,7 +13841,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13865,7 +13865,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13889,7 +13889,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13919,7 +13919,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -13950,7 +13950,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13972,7 +13972,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13997,7 +13997,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "futures",
  "pin-project",
@@ -14020,7 +14020,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14072,7 +14072,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14100,7 +14100,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14116,7 +14116,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14131,7 +14131,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14153,7 +14153,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14164,7 +14164,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14192,7 +14192,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14213,7 +14213,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14235,7 +14235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14251,7 +14251,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14269,7 +14269,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14282,7 +14282,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14311,7 +14311,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14330,7 +14330,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14340,7 +14340,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14363,7 +14363,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14385,7 +14385,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14398,7 +14398,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14416,7 +14416,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14454,7 +14454,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14468,7 +14468,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "serde",
  "serde_json",
@@ -14478,7 +14478,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14505,7 +14505,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "bytes",
  "futures",
@@ -14525,7 +14525,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "futures",
  "metrics",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14545,7 +14545,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14614,7 +14614,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14639,7 +14639,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14661,7 +14661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14690,7 +14690,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14707,7 +14707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14731,7 +14731,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14853,7 +14853,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14891,7 +14891,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14915,7 +14915,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14939,7 +14939,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -14960,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -14972,7 +14972,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14993,7 +14993,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15005,7 +15005,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15025,7 +15025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15035,7 +15035,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15048,7 +15048,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15118,7 +15118,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15131,7 +15131,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15161,7 +15161,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15204,7 +15204,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15232,7 +15232,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15245,7 +15245,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15264,7 +15264,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15291,7 +15291,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15304,7 +15304,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15383,7 +15383,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15411,7 +15411,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15450,7 +15450,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15471,7 +15471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15501,7 +15501,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15545,7 +15545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15592,7 +15592,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15606,7 +15606,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15622,7 +15622,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15666,7 +15666,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15693,7 +15693,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15706,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15726,7 +15726,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15738,7 +15738,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15768,7 +15768,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15784,7 +15784,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15802,7 +15802,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15812,7 +15812,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15827,7 +15827,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15869,7 +15869,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15893,7 +15893,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15920,7 +15920,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15939,7 +15939,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15964,7 +15964,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15983,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16001,7 +16001,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
+source = "git+https://github.com/Galxe/gravity-reth?rev=76e91d06722edc93b5f8868d8191c09069bd6857#76e91d06722edc93b5f8868d8191c09069bd6857"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1073,7 +1073,7 @@ dependencies = [
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1095,7 +1095,7 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1118,7 +1118,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-types",
  "bcs 0.1.4",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1142,7 +1142,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-global-constants",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-sdk",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "hex",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "proptest",
  "serde",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "futures",
  "rustversion",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "shadow-rs",
 ]
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1325,12 +1325,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1442,25 +1442,25 @@ dependencies = [
  "aptos-collections",
  "aptos-config",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-schemadb",
  "aptos-secure-storage",
  "aptos-short-hex-str",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -1549,13 +1549,13 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-short-hex-str",
@@ -1577,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1643,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1718,7 +1718,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-jellyfish-merkle",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1827,13 +1827,13 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-enum-conversion-derive",
@@ -1844,7 +1844,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "api-types",
@@ -1916,15 +1916,15 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-executor-service",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-experimental-runtimes",
  "aptos-indexer-grpc-table-info",
  "aptos-infallible",
@@ -1947,7 +1947,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-block-executor",
  "aptos-block-partitioner",
@@ -1978,16 +1978,16 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-db",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2036,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-layered-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "ahash 0.8.12",
  "aptos-crypto",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -2064,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2072,7 +2072,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2143,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "either",
  "move-core-types",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -2200,17 +2200,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2219,7 +2219,7 @@ dependencies = [
  "aptos-config",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-metrics-core",
  "aptos-moving-average",
  "aptos-protos",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2256,7 +2256,7 @@ dependencies = [
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-storage-interface",
@@ -2278,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
@@ -2314,12 +2314,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "api-types",
@@ -2381,7 +2381,7 @@ dependencies = [
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
@@ -2392,7 +2392,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2426,7 +2426,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2436,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -2572,13 +2572,13 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-event-notifications",
  "aptos-infallible",
@@ -2613,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2692,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2775,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2798,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2823,7 +2823,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "pbjson",
  "prost",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "ipnet",
 ]
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2928,11 +2928,11 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-enum-conversion-derive",
  "aptos-infallible",
  "aptos-logger",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "rayon",
  "tokio",
@@ -3025,10 +3025,10 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-infallible",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-drop-helper",
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3200,7 +3200,7 @@ dependencies = [
  "aptos-data-client",
  "aptos-data-streaming-service",
  "aptos-event-notifications",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-mempool-notifications",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -3309,17 +3309,17 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crypto",
  "aptos-db",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-node-resource-metrics",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3388,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-filter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-protos",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "api-types",
@@ -3492,12 +3492,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-environment"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-framework",
  "aptos-gas-algebra",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -4605,7 +4605,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -7449,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "gaptos"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "api-types",
  "aptos-bitvec",
@@ -7460,9 +7460,9 @@ dependencies = [
  "aptos-collections",
  "aptos-compression",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-crash-handler",
  "aptos-crypto",
  "aptos-crypto-derive",
@@ -7470,9 +7470,9 @@ dependencies = [
  "aptos-dkg-runtime",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-executor-test-helpers",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-global-constants",
@@ -7483,7 +7483,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-log-derive",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-mempool-notifications",
  "aptos-memsocket",
  "aptos-metrics-core",
@@ -7499,7 +7499,7 @@ dependencies = [
  "aptos-reliable-broadcast",
  "aptos-rest-client",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix)",
  "aptos-schemadb",
  "aptos-secure-net",
  "aptos-secure-storage",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 
 [[package]]
 name = "gravity-sdk"
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7948,7 +7948,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -8679,7 +8679,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -10293,7 +10293,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10325,12 +10325,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10345,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "once_cell",
  "quote",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10396,7 +10396,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "difference",
@@ -10443,7 +10443,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10500,7 +10500,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10526,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10545,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10562,7 +10562,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10581,7 +10581,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "hex",
@@ -10640,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "codespan",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "atty",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10786,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "move-prover-lab"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10804,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "hex",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "hex",
@@ -10862,7 +10862,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "once_cell",
  "serde",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "better_any",
  "bytes",
@@ -10886,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "better_any",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -10927,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "ambassador",
  "better_any",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "anyhow",
  "bytes",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=7f8fdbb320fe2e4a94804d7334d59bf784aef3e1#7f8fdbb320fe2e4a94804d7334d59bf784aef3e1"
+source = "git+https://github.com/Galxe/gravity-aptos.git?branch=dev-0411-fix#ae1a40eebfc5504e684748bb19ec22ea772769da"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
@@ -11441,7 +11441,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12656,7 +12656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13391,7 +13391,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13437,7 +13437,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13461,7 +13461,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13490,7 +13490,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13510,7 +13510,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13524,7 +13524,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13601,7 +13601,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13611,7 +13611,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13629,7 +13629,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13647,7 +13647,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13658,7 +13658,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13673,7 +13673,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13686,7 +13686,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13698,7 +13698,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13724,7 +13724,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13745,7 +13745,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13770,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13801,7 +13801,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13815,7 +13815,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13841,7 +13841,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13865,7 +13865,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13889,7 +13889,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13919,7 +13919,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -13950,7 +13950,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13972,7 +13972,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13997,7 +13997,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "futures",
  "pin-project",
@@ -14020,7 +14020,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14072,7 +14072,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14100,7 +14100,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14116,7 +14116,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14131,7 +14131,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14153,7 +14153,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14164,7 +14164,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14192,7 +14192,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14213,7 +14213,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14235,7 +14235,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14251,7 +14251,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14269,7 +14269,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14282,7 +14282,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14311,7 +14311,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14330,7 +14330,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14340,7 +14340,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14363,7 +14363,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14385,7 +14385,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14398,7 +14398,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14416,7 +14416,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14454,7 +14454,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14468,7 +14468,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "serde",
  "serde_json",
@@ -14478,7 +14478,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14505,7 +14505,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "bytes",
  "futures",
@@ -14525,7 +14525,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "futures",
  "metrics",
@@ -14537,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14545,7 +14545,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14614,7 +14614,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14639,7 +14639,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14661,7 +14661,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14676,7 +14676,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14690,7 +14690,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14707,7 +14707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14731,7 +14731,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14853,7 +14853,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14891,7 +14891,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14915,7 +14915,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14939,7 +14939,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -14960,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -14972,7 +14972,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14993,7 +14993,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15005,7 +15005,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15025,7 +15025,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15035,7 +15035,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15048,7 +15048,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15094,7 +15094,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15118,7 +15118,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15131,7 +15131,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15161,7 +15161,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15204,7 +15204,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15232,7 +15232,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15245,7 +15245,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15264,7 +15264,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15291,7 +15291,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15304,7 +15304,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15383,7 +15383,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15411,7 +15411,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15450,7 +15450,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15471,7 +15471,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15501,7 +15501,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15545,7 +15545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15592,7 +15592,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15606,7 +15606,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15622,7 +15622,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15666,7 +15666,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15693,7 +15693,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15706,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15726,7 +15726,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15738,7 +15738,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15768,7 +15768,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15784,7 +15784,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15802,7 +15802,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15812,7 +15812,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15827,7 +15827,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15869,7 +15869,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15893,7 +15893,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15920,7 +15920,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15939,7 +15939,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15964,7 +15964,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15983,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16001,7 +16001,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a5d6a892375480f4cef8e35db91377e502883f79#a5d6a892375480f4cef8e35db91377e502883f79"
+source = "git+https://github.com/Galxe/gravity-reth?branch=dev-0411-fix#ba434157e8e8b5ba9f877c444efd391ba7f4936c"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ["cfg(mirai)"] }
 aptos-consensus = { path = "./aptos-core/consensus" }
 
 #  from aptos =======================
-gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", rev = "7f8fdbb320fe2e4a94804d7334d59bf784aef3e1" }
+gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", branch = "dev-0411-fix" }
 aptos-executor-types = { path = "dependencies/aptos-executor-types" }
 aptos-executor = { path = "dependencies/aptos-executor" }
 api = { path = "./crates/api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ["cfg(mirai)"] }
 aptos-consensus = { path = "./aptos-core/consensus" }
 
 #  from aptos =======================
-gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", branch = "dev-0411-fix" }
+gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", rev = "16ed314689713d84995ac484210630292d6633c7" }
 aptos-executor-types = { path = "dependencies/aptos-executor-types" }
 aptos-executor = { path = "dependencies/aptos-executor" }
 api = { path = "./crates/api" }

--- a/aptos-core/consensus/consensus-types/src/block.rs
+++ b/aptos-core/consensus/consensus-types/src/block.rs
@@ -188,14 +188,27 @@ impl Block {
     }
 
     /// Construct new genesis block for next epoch deterministically from the end-epoch LedgerInfo
-    /// We carry over most fields except round and block id
+    /// We carry over most fields except round and block id.
+    /// IMPORTANT: We must use epoch_block_info to get the block_number of the actual reconfig
+    /// block, because different nodes may commit different suffix blocks (with different
+    /// block_numbers) after the reconfig, but epoch_block_info always points to the same
+    /// reconfig block, ensuring deterministic genesis construction across all nodes.
     pub fn make_genesis_block_from_ledger_info(ledger_info: &LedgerInfo) -> Self {
         let block_data = BlockData::new_genesis_from_ledger_info(ledger_info);
+        let block_number = match ledger_info.commit_info().epoch_block_info() {
+            Some(info) => info.block_number,
+            None => {
+                // epoch_block_info should always be present for epoch-ending ledger infos.
+                // If missing, fall back to ledger_info.block_number() but this may cause
+                // divergence if different nodes committed different suffix blocks.
+                ledger_info.block_number()
+            }
+        };
         Block {
             id: block_data.hash(),
             block_data,
             signature: None,
-            block_number: OnceCell::with_value(ledger_info.block_number()),
+            block_number: OnceCell::with_value(block_number),
         }
     }
 

--- a/aptos-core/consensus/consensus-types/src/block_data.rs
+++ b/aptos-core/consensus/consensus-types/src/block_data.rs
@@ -189,14 +189,10 @@ impl BlockData {
 
         // Use epoch_block_info to get the actual reconfig block's values, ensuring
         // deterministic genesis construction even when different nodes commit different
-        // suffix blocks after the reconfig. Only use epoch_block_info if
-        // epoch_start_timestamp_usecs is non-zero (meaning it was properly patched
-        // by buffer_manager with consensus-layer data).
+        // suffix blocks after the reconfig.
         let (version, timestamp) = match ledger_info.commit_info().epoch_block_info() {
-            Some(info) if info.epoch_start_timestamp_usecs > 0 => {
-                (info.block_number, info.epoch_start_timestamp_usecs)
-            }
-            _ => (ledger_info.version(), ledger_info.timestamp_usecs()),
+            Some(info) => (info.block_number, info.epoch_start_timestamp_usecs),
+            None => (ledger_info.version(), ledger_info.timestamp_usecs()),
         };
 
         let ancestor = BlockInfo::new(

--- a/aptos-core/consensus/consensus-types/src/block_data.rs
+++ b/aptos-core/consensus/consensus-types/src/block_data.rs
@@ -186,13 +186,26 @@ impl BlockData {
 
     pub fn new_genesis_from_ledger_info(ledger_info: &LedgerInfo) -> Self {
         assert!(ledger_info.ends_epoch());
+
+        // Use epoch_block_info to get the actual reconfig block's values, ensuring
+        // deterministic genesis construction even when different nodes commit different
+        // suffix blocks after the reconfig. Only use epoch_block_info if
+        // epoch_start_timestamp_usecs is non-zero (meaning it was properly patched
+        // by buffer_manager with consensus-layer data).
+        let (version, timestamp) = match ledger_info.commit_info().epoch_block_info() {
+            Some(info) if info.epoch_start_timestamp_usecs > 0 => {
+                (info.block_number, info.epoch_start_timestamp_usecs)
+            }
+            _ => (ledger_info.version(), ledger_info.timestamp_usecs()),
+        };
+
         let ancestor = BlockInfo::new(
             ledger_info.epoch(),
             0,                 /* round */
             HashValue::zero(), /* parent block id */
             ledger_info.transaction_accumulator_hash(),
-            ledger_info.version(),
-            ledger_info.timestamp_usecs(),
+            version,
+            timestamp,
             None,
         );
 
@@ -206,7 +219,7 @@ impl BlockData {
             ),
         );
 
-        BlockData::new_genesis(ledger_info.timestamp_usecs(), genesis_quorum_cert)
+        BlockData::new_genesis(timestamp, genesis_quorum_cert)
     }
 
     #[cfg(any(test, feature = "fuzzing"))]

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -666,6 +666,25 @@ impl BlockStore {
                 commit_decision,
             );
         } else {
+            // `BATCH_COMMIT_SIZE` env var: when set and the accumulated path is still
+            // small, defer sending so the execution layer can process blocks in larger
+            // batches. Because we return early without touching `ordered_root`, the next
+            // `send_for_execution` call will see the same root and `path_from_ordered_root`
+            // will grow until it exceeds the batch size, at which point we flush.
+            // Used by `gravity_e2e/cluster_test_cases/single_node/test_batch_exec.py`.
+            let batch_commit_size = std::env::var("BATCH_COMMIT_SIZE")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0);
+            if batch_commit_size > 0 && blocks_to_commit.len() <= batch_commit_size {
+                info!(
+                    "blocks_to_commit len {} <= BATCH_COMMIT_SIZE {}, defer for batch accumulation",
+                    blocks_to_commit.len(),
+                    batch_commit_size
+                );
+                return Ok(());
+            }
+
             info!("send the blocks to execution {:?}", blocks_to_commit);
             self.execution_client
                 .finalize_order(

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -630,7 +630,7 @@ impl BlockStore {
                     enable_randomness: self.enable_randomness,
                 };
                 get_block_buffer_manager()
-                    .set_ordered_blocks(BlockId(*p_block.parent_id()), block)
+                    .set_ordered_blocks(BlockId(*p_block.parent_id()), block, p_block.round())
                     .await
                     .context("Failed to set ordered blocks during recovery")?;
                 let compute_res = get_block_buffer_manager()

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -229,35 +229,70 @@ impl BlockStore {
         LedgerInfoWithSignatures::new(LedgerInfo::dummy(), AggregateSignature::empty())
     }
 
+    /// Replays uncommitted quorum certificates after a node restart.
+    ///
+    /// Retrieves all QCs with commit info from the block tree, sorts them by round,
+    /// and re-sends each one for execution in order. This reproduces the same commit
+    /// batches that were in-flight before the restart.
+    ///
+    /// If the latest ledger info carries `epoch_block_info` (indicating a non-blocking
+    /// epoch change was in progress), recovery stops at the epoch change block's round.
+    /// Suffix blocks beyond that point would never receive execution results from reth,
+    /// so attempting to recover them would cause the pipeline to hang.
     async fn recover_blocks(&self) {
         RECOVERY_GAUGE.set_with(&[], 1);
-        // reproduce the same batches (important for the commit phase)
+
         let mut certs = self.inner.read().get_all_quorum_certs_with_commit_info();
         let last_ledger_info =
             self.storage.consensus_db().ledger_db.metadata_db().get_latest_ledger_info();
-        info!("recover blocks, last_ledger_info: {:?}", last_ledger_info);
+        info!("recover_blocks: last_ledger_info={:?}", last_ledger_info);
+
+        // Determine the upper-bound round for recovery when a non-blocking epoch change
+        // was in progress. Blocks after this round are suffix blocks that reth will discard.
+        let epoch_change_limit_round =
+            last_ledger_info.as_ref().and_then(|li| {
+                let info = li.ledger_info().commit_info().epoch_block_info()?;
+                let block = self.get_block(info.block_id)?;
+                info!(
+                "recover_blocks: epoch change detected at block_id={}, block_number={}, round={}",
+                info.block_id, info.block_number, block.round(),
+            );
+                Some(block.round())
+            });
+
         certs.sort_unstable_by_key(|qc| qc.commit_info().round());
+
         for qc in certs {
-            if qc.commit_info().round() > self.commit_root().round() {
-                if let Some(last_ledger_info) = &last_ledger_info {
-                    if last_ledger_info.ledger_info().epoch() == qc.commit_info().epoch() &&
-                        qc.commit_info().round() <= last_ledger_info.commit_info().round()
-                    {
-                        info!(
-                            "sending qc {} to execution, current commit round {}",
-                            qc.commit_info().round(),
-                            self.commit_root().round()
-                        );
-                        if let Err(e) =
-                            self.send_for_execution(qc.into_wrapped_ledger_info(), true).await
-                        {
-                            error!("Error in try-committing blocks. {}", e.to_string());
-                            break;
-                        }
-                    }
-                }
+            let commit_round = qc.commit_info().round();
+
+            if commit_round <= self.commit_root().round() {
+                continue;
+            }
+
+            // Stop once we pass the epoch change boundary.
+            if epoch_change_limit_round.is_some_and(|ec| commit_round > ec) {
+                info!("recover_blocks: stopping before round {commit_round} (epoch change limit)");
+                break;
+            }
+
+            let Some(last_li) = &last_ledger_info else { continue };
+            if last_li.ledger_info().epoch() != qc.commit_info().epoch() ||
+                commit_round > last_li.commit_info().round()
+            {
+                continue;
+            }
+
+            info!(
+                "recover_blocks: sending round {} to execution (commit_root={})",
+                commit_round,
+                self.commit_root().round(),
+            );
+            if let Err(e) = self.send_for_execution(qc.into_wrapped_ledger_info(), true).await {
+                error!("recover_blocks: failed to commit blocks: {e}");
+                break;
             }
         }
+
         RECOVERY_GAUGE.set_with(&[], 0);
     }
 
@@ -630,83 +665,30 @@ impl BlockStore {
                 finality_proof,
                 commit_decision,
             );
-            self.inner.write().update_ordered_root(block_to_commit.id());
-            self.inner.write().insert_ordered_cert(finality_proof_clone.clone());
         } else {
-            let batch_commit_size = std::env::var("BATCH_COMMIT_SIZE")
-                .ok()
-                .and_then(|v| v.parse::<usize>().ok())
-                .unwrap_or(0);
-            if batch_commit_size > 0 && blocks_to_commit.len() <= batch_commit_size {
-                info!(
-                    "blocks_to_commit len {} <= BATCH_COMMIT_SIZE {}, skip sending for batch accumulation",
-                    blocks_to_commit.len(),
-                    batch_commit_size
-                );
-                return Ok(());
-            }
-
-            // Send blocks one by one: for each block, find the QC whose commit_info
-            // matches it. The QC that commits block[i] is the QC certifying block[i+1]
-            // (per 2-chain rule: QC(B_{i+1}).commit_info = B_i when rounds are consecutive).
-            // Blocks without a matching QC get batched with the next block that has one
-            // via path_from_ordered_root.
-            for (i, block) in blocks_to_commit.iter().enumerate() {
-                let proof = if block.id() == block_id_to_commit {
-                    // Last block: use the original finality_proof
-                    finality_proof.clone()
-                } else {
-                    // Look up the QC certifying the next block in the chain.
-                    // That QC's commit_info should point to this block (2-chain rule).
-                    let next_qc = (i + 1 < blocks_to_commit.len())
-                        .then(|| self.get_quorum_cert_for_block(blocks_to_commit[i + 1].id()))
-                        .flatten();
-                    match next_qc {
-                        Some(qc) if qc.commit_info().id() == block.id() => {
-                            qc.into_wrapped_ledger_info()
-                        }
-                        _ => {
-                            // No matching QC → this block will be included in the
-                            // next block's path_from_ordered_root batch.
-                            continue;
-                        }
-                    }
-                };
-
-                let path = self.path_from_ordered_root(block.id()).unwrap_or_default();
-                if path.is_empty() {
-                    continue;
-                }
-
-                let bt = self.inner.clone();
-                let st = self.storage.clone();
-                let proof_for_cb = proof.clone();
-
-                info!("send block to execution one-by-one {:?}", path);
-                self.execution_client
-                    .finalize_order(
-                        &path,
-                        proof.ledger_info().clone(),
-                        Box::new(
-                            move |committed_blocks: &[Arc<PipelinedBlock>],
-                                  commit_decision: LedgerInfoWithSignatures| {
-                                bt.write().commit_callback(
-                                    st,
-                                    committed_blocks,
-                                    proof_for_cb,
-                                    commit_decision,
-                                );
-                            },
-                        ),
-                    )
-                    .await
-                    .expect("Failed to persist commit");
-
-                self.inner.write().update_ordered_root(block.id());
-                self.inner.write().insert_ordered_cert(proof);
-            }
+            info!("send the blocks to execution {:?}", blocks_to_commit);
+            self.execution_client
+                .finalize_order(
+                    &blocks_to_commit,
+                    finality_proof.ledger_info().clone(),
+                    Box::new(
+                        move |committed_blocks: &[Arc<PipelinedBlock>],
+                              commit_decision: LedgerInfoWithSignatures| {
+                            block_tree.write().commit_callback(
+                                storage,
+                                committed_blocks,
+                                finality_proof,
+                                commit_decision,
+                            );
+                        },
+                    ),
+                )
+                .await
+                .expect("Failed to persist commit");
         }
 
+        self.inner.write().update_ordered_root(block_to_commit.id());
+        self.inner.write().insert_ordered_cert(finality_proof_clone.clone());
         update_counters_for_ordered_blocks(&blocks_to_commit);
         Ok(())
     }

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -665,6 +665,8 @@ impl BlockStore {
                 finality_proof,
                 commit_decision,
             );
+            self.inner.write().update_ordered_root(block_to_commit.id());
+            self.inner.write().insert_ordered_cert(finality_proof_clone.clone());
         } else {
             // `BATCH_COMMIT_SIZE` env var: when set and the accumulated path is still
             // small, defer sending so the execution layer can process blocks in larger
@@ -678,36 +680,74 @@ impl BlockStore {
                 .unwrap_or(0);
             if batch_commit_size > 0 && blocks_to_commit.len() <= batch_commit_size {
                 info!(
-                    "blocks_to_commit len {} <= BATCH_COMMIT_SIZE {}, defer for batch accumulation",
+                    "blocks_to_commit len {} <= BATCH_COMMIT_SIZE {}, skip sending for batch accumulation",
                     blocks_to_commit.len(),
                     batch_commit_size
                 );
                 return Ok(());
             }
 
-            info!("send the blocks to execution {:?}", blocks_to_commit);
-            self.execution_client
-                .finalize_order(
-                    &blocks_to_commit,
-                    finality_proof.ledger_info().clone(),
-                    Box::new(
-                        move |committed_blocks: &[Arc<PipelinedBlock>],
-                              commit_decision: LedgerInfoWithSignatures| {
-                            block_tree.write().commit_callback(
-                                storage,
-                                committed_blocks,
-                                finality_proof,
-                                commit_decision,
-                            );
-                        },
-                    ),
-                )
-                .await
-                .expect("Failed to persist commit");
+            // Send blocks one by one: for each block, find the QC whose commit_info
+            // matches it. The QC that commits block[i] is the QC certifying block[i+1]
+            // (per 2-chain rule: QC(B_{i+1}).commit_info = B_i when rounds are consecutive).
+            // Blocks without a matching QC get batched with the next block that has one
+            // via path_from_ordered_root.
+            for (i, block) in blocks_to_commit.iter().enumerate() {
+                let proof = if block.id() == block_id_to_commit {
+                    // Last block: use the original finality_proof
+                    finality_proof.clone()
+                } else {
+                    // Look up the QC certifying the next block in the chain.
+                    // That QC's commit_info should point to this block (2-chain rule).
+                    let next_qc = (i + 1 < blocks_to_commit.len())
+                        .then(|| self.get_quorum_cert_for_block(blocks_to_commit[i + 1].id()))
+                        .flatten();
+                    match next_qc {
+                        Some(qc) if qc.commit_info().id() == block.id() => {
+                            qc.into_wrapped_ledger_info()
+                        }
+                        _ => {
+                            // No matching QC → this block will be included in the
+                            // next block's path_from_ordered_root batch.
+                            continue;
+                        }
+                    }
+                };
+
+                let path = self.path_from_ordered_root(block.id()).unwrap_or_default();
+                if path.is_empty() {
+                    continue;
+                }
+
+                let bt = self.inner.clone();
+                let st = self.storage.clone();
+                let proof_for_cb = proof.clone();
+
+                info!("send block to execution one-by-one {:?}", path);
+                self.execution_client
+                    .finalize_order(
+                        &path,
+                        proof.ledger_info().clone(),
+                        Box::new(
+                            move |committed_blocks: &[Arc<PipelinedBlock>],
+                                  commit_decision: LedgerInfoWithSignatures| {
+                                bt.write().commit_callback(
+                                    st,
+                                    committed_blocks,
+                                    proof_for_cb,
+                                    commit_decision,
+                                );
+                            },
+                        ),
+                    )
+                    .await
+                    .expect("Failed to persist commit");
+
+                self.inner.write().update_ordered_root(block.id());
+                self.inner.write().insert_ordered_cert(proof);
+            }
         }
 
-        self.inner.write().update_ordered_root(block_to_commit.id());
-        self.inner.write().insert_ordered_cert(finality_proof_clone.clone());
         update_counters_for_ordered_blocks(&blocks_to_commit);
         Ok(())
     }

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -544,18 +544,20 @@ impl BlockStore {
             ledger_info.commit_info().round()
         );
 
-        // if the block exists between commit root and ordered root
+        // Step 1: If the block already exists between commit root and ordered root,
+        // send a commit decision to buffer_manager to unblock the commit pipeline.
         if self.commit_root().round() < ledger_info.commit_info().round() &&
             self.block_exists(ledger_info.commit_info().id()) &&
-            self.ordered_root().round() >= ledger_info.commit_info().round() &&
-            !has_missing_randomness
+            self.ordered_root().round() >= ledger_info.commit_info().round()
         {
             info!("sync_to_highest_commit_cert: block exists between commit root and ordered root {:?}, {:?}", self.commit_root().round(), ledger_info.commit_info().round());
             let proof = ledger_info.clone();
             let network = retriever.network.clone();
             tokio::spawn(async move { network.send_commit_proof(proof).await });
-            return Ok(());
-        } else if self.ordered_root().round() < ledger_info.commit_info().round() &&
+        }
+
+        // Step 2: If blocks are missing, sync them
+        if self.ordered_root().round() < ledger_info.commit_info().round() &&
             !self.block_exists(ledger_info.commit_info().id()) ||
             has_missing_randomness
         {
@@ -563,25 +565,23 @@ impl BlockStore {
             // highest_commit_cert
             let sync_from_cert = sync_from_cert_opt.unwrap_or_else(|| self.highest_commit_cert());
 
-            if sync_from_cert.commit_info().round() >= ledger_info.commit_info().round() {
-                return Ok(());
+            if sync_from_cert.commit_info().round() < ledger_info.commit_info().round() {
+                // if the block doesnt exist after ordered root
+                let highest_commit_cert_qc =
+                    highest_commit_cert.clone().into_quorum_cert(self.order_vote_enabled).unwrap();
+                let (blocks, quorum_certs) = Self::fast_forward_sync(
+                    &highest_commit_cert_qc,
+                    &sync_from_cert,
+                    retriever,
+                    self.storage.clone(),
+                    self.payload_manager.clone(),
+                    self.order_vote_enabled,
+                    self.is_validator,
+                )
+                .await?;
+
+                self.append_blocks_for_sync(blocks, quorum_certs).await;
             }
-
-            // if the block doesnt exist after ordered root
-            let highest_commit_cert =
-                highest_commit_cert.into_quorum_cert(self.order_vote_enabled).unwrap();
-            let (blocks, quorum_certs) = Self::fast_forward_sync(
-                &highest_commit_cert,
-                &sync_from_cert,
-                retriever,
-                self.storage.clone(),
-                self.payload_manager.clone(),
-                self.order_vote_enabled,
-                self.is_validator,
-            )
-            .await?;
-
-            self.append_blocks_for_sync(blocks, quorum_certs).await;
         }
         Ok(())
     }

--- a/aptos-core/consensus/src/consensusdb/ledger_db/ledger_metadata_db.rs
+++ b/aptos-core/consensus/src/consensusdb/ledger_db/ledger_metadata_db.rs
@@ -139,14 +139,17 @@ impl LedgerMetadataDb {
         batch: &mut SchemaBatch,
     ) -> Result<()> {
         let ledger_info = ledger_info_with_sigs.ledger_info();
+        let block_number = match ledger_info.commit_info().epoch_block_info() {
+            Some(info) => info.block_number,
+            None => ledger_info.block_number(),
+        };
+
         if ledger_info.ends_epoch() {
+            info!("put ledger_info when epoch change {:?}", ledger_info_with_sigs);
             // This is the last version of the current epoch, update the epoch by version index.
-            batch.put::<EpochByBlockNumberSchema>(
-                &ledger_info.block_number(),
-                &ledger_info.epoch(),
-            )?;
+            batch.put::<EpochByBlockNumberSchema>(&block_number, &ledger_info.epoch())?;
         }
-        batch.put::<LedgerInfoSchema>(&ledger_info.block_number(), ledger_info_with_sigs)
+        batch.put::<LedgerInfoSchema>(&block_number, ledger_info_with_sigs)
     }
 
     pub(crate) fn get_latest_ledger_infos(&self) -> Result<Vec<LedgerInfoWithSignatures>> {

--- a/aptos-core/consensus/src/dag/tests/order_rule_tests.rs
+++ b/aptos-core/consensus/src/dag/tests/order_rule_tests.rs
@@ -15,6 +15,7 @@ use crate::dag::{
 };
 use aptos_consensus_types::common::{Author, Round};
 use async_trait::async_trait;
+use futures::StreamExt;
 use futures_channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use gaptos::{
     aptos_infallible::Mutex,
@@ -147,7 +148,7 @@ proptest! {
                         order_rule.process_new_node(flatten_nodes[idx].metadata());
                     }
                     let mut ordered = vec![];
-                    while let Ok(mut ordered_nodes) = receiver.try_recv() {
+                    while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
                         ordered.append(&mut ordered_nodes);
                     }
                     all_ordered.lock().push(ordered);
@@ -159,7 +160,7 @@ proptest! {
         let (mut order_rule, mut receiver) = create_order_rule(epoch_state.clone(), dag);
         order_rule.process_all();
         let mut ordered = vec![];
-        while let Ok(mut ordered_nodes) = receiver.try_recv() {
+        while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
             ordered.append(&mut ordered_nodes);
         }
         let display = |node: &Arc<CertifiedNode>| {
@@ -247,7 +248,7 @@ fn test_order_rule_basic() {
         vec![(4, 1), (4, 0), (5, 2)],
     ];
     let mut batch = 0;
-    while let Ok(ordered_nodes) = receiver.try_recv() {
+    while let Ok(Some(ordered_nodes)) = receiver.try_next() {
         assert_eq!(
             ordered_nodes.iter().map(|node| display(node.metadata())).collect::<Vec<_>>(),
             expected_order[batch]

--- a/aptos-core/consensus/src/dag/tests/order_rule_tests.rs
+++ b/aptos-core/consensus/src/dag/tests/order_rule_tests.rs
@@ -147,7 +147,7 @@ proptest! {
                         order_rule.process_new_node(flatten_nodes[idx].metadata());
                     }
                     let mut ordered = vec![];
-                    while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
+                    while let Ok(mut ordered_nodes) = receiver.try_recv() {
                         ordered.append(&mut ordered_nodes);
                     }
                     all_ordered.lock().push(ordered);
@@ -159,7 +159,7 @@ proptest! {
         let (mut order_rule, mut receiver) = create_order_rule(epoch_state.clone(), dag);
         order_rule.process_all();
         let mut ordered = vec![];
-        while let Ok(Some(mut ordered_nodes)) = receiver.try_next() {
+        while let Ok(mut ordered_nodes) = receiver.try_recv() {
             ordered.append(&mut ordered_nodes);
         }
         let display = |node: &Arc<CertifiedNode>| {
@@ -247,7 +247,7 @@ fn test_order_rule_basic() {
         vec![(4, 1), (4, 0), (5, 2)],
     ];
     let mut batch = 0;
-    while let Ok(Some(ordered_nodes)) = receiver.try_next() {
+    while let Ok(ordered_nodes) = receiver.try_recv() {
         assert_eq!(
             ordered_nodes.iter().map(|node| display(node.metadata())).collect::<Vec<_>>(),
             expected_order[batch]

--- a/aptos-core/consensus/src/gravity_state_computer.rs
+++ b/aptos-core/consensus/src/gravity_state_computer.rs
@@ -160,10 +160,24 @@ impl BlockExecutorTrait for GravityBlockExecutor {
 
         // Persist randomness data
         if !randomness_data.is_empty() {
-            self.consensus_db
-                .put_randomness(&randomness_data)
-                .map_err(|e| anyhow::anyhow!("Failed to persist randomness: {:?}", e))?;
-            debug!("Persisted randomness data: {:?}", randomness_data);
+            let randomness_to_persist = if let Some(info) =
+                ledger_info_with_sigs.ledger_info().commit_info().epoch_block_info()
+            {
+                let epoch_change_block = info.block_number;
+                randomness_data
+                    .into_iter()
+                    .filter(|(num, _)| *num <= epoch_change_block)
+                    .collect::<Vec<_>>()
+            } else {
+                randomness_data
+            };
+
+            if !randomness_to_persist.is_empty() {
+                self.consensus_db
+                    .put_randomness(&randomness_to_persist)
+                    .map_err(|e| anyhow::anyhow!("Failed to persist randomness: {:?}", e))?;
+                debug!("Persisted randomness data: {:?}", randomness_to_persist);
+            }
         }
 
         self.runtime.block_on(async move {

--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -183,6 +183,7 @@ impl BufferItem {
         validator: &ValidatorVerifier,
         epoch_end_timestamp: Option<u64>,
         order_vote_enabled: bool,
+        epoch_block_info: Option<gaptos::aptos_types::block_info::EpochBlockInfo>,
     ) -> Self {
         match self {
             Self::Ordered(ordered_item) => {
@@ -204,6 +205,9 @@ impl BufferItem {
                         commit_info.change_timestamp(timestamp);
                     }
                     _ => (),
+                }
+                if let Some(info) = epoch_block_info {
+                    commit_info.set_epoch_block_info(info);
                 }
                 if let Some(commit_proof) = commit_proof {
                     // We have already received the commit proof in fast forward sync path,

--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -30,16 +30,16 @@ fn generate_commit_ledger_info(
     block_hash: HashValue,
     block_number: u64,
 ) -> LedgerInfo {
-    let mut ledger_info = LedgerInfo::new(
+    let mut ledger_info = LedgerInfo::new_with_block_info(
         commit_info.clone(),
         if order_vote_enabled {
             HashValue::zero()
         } else {
             ordered_proof.ledger_info().consensus_data_hash()
         },
+        block_hash,
+        block_number,
     );
-    ledger_info.set_block_hash(block_hash);
-    ledger_info.set_block_number(block_number);
     ledger_info
 }
 
@@ -206,9 +206,16 @@ impl BufferItem {
                     }
                     _ => (),
                 }
-                if let Some(info) = epoch_block_info {
-                    commit_info.set_epoch_block_info(info);
-                }
+                let commit_info = BlockInfo::new_with_epoch_block_info(
+                    commit_info.epoch(),
+                    commit_info.round(),
+                    commit_info.id(),
+                    commit_info.executed_state_id(),
+                    commit_info.version(),
+                    commit_info.timestamp_usecs(),
+                    commit_info.next_epoch_state().cloned(),
+                    epoch_block_info.or_else(|| commit_info.epoch_block_info().cloned()),
+                );
                 if let Some(commit_proof) = commit_proof {
                     // We have already received the commit proof in fast forward sync path,
                     // we can just use that proof and proceed to aggregated

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -271,18 +271,37 @@ impl BufferManager {
         let round = commit_proof.commit_info().round();
         let block_id = commit_proof.commit_info().id();
         if self.highest_committed_round < round {
-            if self.pending_commit_proofs.len() < MAX_PENDING_COMMIT_PROOFS {
-                self.pending_commit_proofs.insert(round, commit_proof);
-                info!(round = round, block_id = block_id, "Added pending commit proof.");
-                true
-            } else {
-                warn!(
-                    round = round,
-                    block_id = block_id,
-                    "Too many pending commit proofs, ignored."
-                );
-                false
+            if self.pending_commit_proofs.len() >= MAX_PENDING_COMMIT_PROOFS {
+                // Cache full. Older pending proofs are more likely to be stale
+                // (the local pipeline may have moved past them), so evict the
+                // smallest round to make room — but only if the incoming proof
+                // is newer than that oldest entry, otherwise we'd drop a newer
+                // proof in favor of an older one.
+                let oldest_round = *self
+                    .pending_commit_proofs
+                    .keys()
+                    .next()
+                    .expect("pending_commit_proofs is full, must be non-empty");
+                if round <= oldest_round {
+                    warn!(
+                        round = round,
+                        block_id = block_id,
+                        oldest_round = oldest_round,
+                        "Pending commit proof cache full and incoming proof not newer than oldest, ignored."
+                    );
+                    return false;
+                }
+                if let Some((evicted_round, _)) = self.pending_commit_proofs.pop_first() {
+                    warn!(
+                        evicted_round = evicted_round,
+                        incoming_round = round,
+                        "Pending commit proof cache full, evicted oldest to make room."
+                    );
+                }
             }
+            self.pending_commit_proofs.insert(round, commit_proof);
+            info!(round = round, block_id = block_id, "Added pending commit proof.");
+            true
         } else {
             debug!(
                 round = round,

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -488,7 +488,7 @@ impl BufferManager {
         self.previous_commit_time = Instant::now();
         self.commit_proof_rb_handle.take();
         // purge the incoming blocks queue
-        while let Ok(_) = self.block_rx.try_recv() {}
+        while let Ok(Some(_)) = self.block_rx.try_next() {}
         // Wait for ongoing tasks to finish before sending back ack.
         get_block_buffer_manager().release_inflight_blocks().await;
         while self.ongoing_tasks.load(Ordering::SeqCst) > 0 {
@@ -571,27 +571,10 @@ impl BufferManager {
             .get_epoch_change_block_info(block_number, epoch)
             .await
         {
-            // Reth provides block_id and block_number, but epoch_start_round and
-            // epoch_start_timestamp_usecs are zero — patch with consensus-layer data.
-            if epoch_info.epoch_start_round == 0 || epoch_info.epoch_start_timestamp_usecs == 0 {
-                if let Some(timestamp) = self.end_epoch_timestamp.get().cloned() {
-                    epoch_info.epoch_start_timestamp_usecs = timestamp;
-                }
-                // Find the reconfig block's round from the executed blocks in this batch
-                for eb in executed_blocks.iter().rev() {
-                    if eb.block_info().has_reconfiguration() {
-                        epoch_info.epoch_start_round = eb.round();
-                        if epoch_info.epoch_start_timestamp_usecs == 0 {
-                            epoch_info.epoch_start_timestamp_usecs = eb.timestamp_usecs();
-                        }
-                        break;
-                    }
-                }
-                info!(
-                    "[EpochChange] Patched EpochBlockInfo for suffix block {}: round={}, timestamp={}",
-                    block_number, epoch_info.epoch_start_round, epoch_info.epoch_start_timestamp_usecs,
-                );
-            }
+            info!(
+                "[EpochChange] EpochBlockInfo for suffix block {}: round={}, timestamp={}",
+                block_number, epoch_info.epoch_start_round, epoch_info.epoch_start_timestamp_usecs,
+            );
             return Some(epoch_info);
         }
 

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -55,7 +55,7 @@ use gaptos::{
 };
 use once_cell::sync::OnceCell;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     f32::consts::E,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -167,6 +167,11 @@ pub struct BufferManager {
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
 
     commit_vote_cache: HashMap<HashValue, HashMap<HashValue, CommitVote>>,
+
+    // Cache for commit proofs that arrive before the block enters the buffer.
+    // When a CommitMessage::Decision arrives but the block is not yet in the buffer,
+    // the proof is cached here and applied when the block finishes execution.
+    pending_commit_proofs: BTreeMap<Round, LedgerInfoWithSignatures>,
 }
 
 impl BufferManager {
@@ -256,7 +261,50 @@ impl BufferManager {
             consensus_observer_config,
             consensus_publisher,
             commit_vote_cache: HashMap::new(),
+            pending_commit_proofs: BTreeMap::new(),
         }
+    }
+
+    fn try_add_pending_commit_proof(&mut self, commit_proof: LedgerInfoWithSignatures) -> bool {
+        const MAX_PENDING_COMMIT_PROOFS: usize = 100;
+
+        let round = commit_proof.commit_info().round();
+        let block_id = commit_proof.commit_info().id();
+        if self.highest_committed_round < round {
+            if self.pending_commit_proofs.len() < MAX_PENDING_COMMIT_PROOFS {
+                self.pending_commit_proofs.insert(round, commit_proof);
+                info!(round = round, block_id = block_id, "Added pending commit proof.");
+                true
+            } else {
+                warn!(
+                    round = round,
+                    block_id = block_id,
+                    "Too many pending commit proofs, ignored."
+                );
+                false
+            }
+        } else {
+            debug!(
+                round = round,
+                highest_committed_round = self.highest_committed_round,
+                block_id = block_id,
+                "Commit proof too old, ignored."
+            );
+            false
+        }
+    }
+
+    fn drain_pending_commit_proof_till(
+        &mut self,
+        round: Round,
+    ) -> Option<LedgerInfoWithSignatures> {
+        // split at `round + 1`, keeping everything after
+        let mut remainder = self.pending_commit_proofs.split_off(&(round + 1));
+        // swap: self now has everything > round, to_remove has everything <= round
+        std::mem::swap(&mut self.pending_commit_proofs, &mut remainder);
+        let to_remove = remainder;
+        // return the last (highest round) proof from the removed set
+        to_remove.into_iter().last().map(|(_, proof)| proof)
     }
 
     fn do_reliable_broadcast(&self, message: CommitMessage) -> Option<DropGuard> {
@@ -436,10 +484,11 @@ impl BufferManager {
         self.execution_root = None;
         self.signing_root = None;
         self.commit_vote_cache.clear();
+        self.pending_commit_proofs.clear();
         self.previous_commit_time = Instant::now();
         self.commit_proof_rb_handle.take();
         // purge the incoming blocks queue
-        while let Ok(Some(_)) = self.block_rx.try_next() {}
+        while let Ok(_) = self.block_rx.try_recv() {}
         // Wait for ongoing tasks to finish before sending back ack.
         get_block_buffer_manager().release_inflight_blocks().await;
         while self.ongoing_tasks.load(Ordering::SeqCst) > 0 {
@@ -495,6 +544,86 @@ impl BufferManager {
         info!("Reschedule {} execution requests from {:?}", count, self.execution_root);
     }
 
+    /// Resolves the `EpochBlockInfo` for a batch of executed blocks.
+    ///
+    /// This is needed to populate epoch transition metadata on the committed `LedgerInfo`,
+    /// which downstream consumers (e.g., genesis block construction) rely on for determinism.
+    ///
+    /// Resolution follows three paths:
+    /// 1. **Suffix block (reth cache hit)**: The BlockBufferManager already cached the reconfig
+    ///    block's `EpochBlockInfo` with correct `block_id` and `block_number`, but
+    ///    `epoch_start_round` and `epoch_start_timestamp_usecs` are zero (reth lacks
+    ///    consensus-layer data). We patch these using `end_epoch_timestamp` and the reconfig
+    ///    block's round from the current batch.
+    /// 2. **Epoch change block**: The last block in the batch triggers reconfiguration itself. We
+    ///    construct `EpochBlockInfo` directly from its metadata.
+    /// 3. **Normal block**: No epoch change — returns `None`.
+    async fn resolve_epoch_block_info(
+        &self,
+        executed_blocks: &[PipelinedBlock],
+        last_block: &PipelinedBlock,
+    ) -> Option<gaptos::aptos_types::block_info::EpochBlockInfo> {
+        let block_number = last_block.block().block_number().unwrap_or(0);
+        let epoch = last_block.block().epoch();
+
+        // Path 1: Check if reth-side BlockBufferManager has cached epoch info (suffix block case).
+        if let Some(mut epoch_info) = block_buffer_manager::get_block_buffer_manager()
+            .get_epoch_change_block_info(block_number, epoch)
+            .await
+        {
+            // Reth provides block_id and block_number, but epoch_start_round and
+            // epoch_start_timestamp_usecs are zero — patch with consensus-layer data.
+            if epoch_info.epoch_start_round == 0 || epoch_info.epoch_start_timestamp_usecs == 0 {
+                if let Some(timestamp) = self.end_epoch_timestamp.get().cloned() {
+                    epoch_info.epoch_start_timestamp_usecs = timestamp;
+                }
+                // Find the reconfig block's round from the executed blocks in this batch
+                for eb in executed_blocks.iter().rev() {
+                    if eb.block_info().has_reconfiguration() {
+                        epoch_info.epoch_start_round = eb.round();
+                        if epoch_info.epoch_start_timestamp_usecs == 0 {
+                            epoch_info.epoch_start_timestamp_usecs = eb.timestamp_usecs();
+                        }
+                        break;
+                    }
+                }
+                info!(
+                    "[EpochChange] Patched EpochBlockInfo for suffix block {}: round={}, timestamp={}",
+                    block_number, epoch_info.epoch_start_round, epoch_info.epoch_start_timestamp_usecs,
+                );
+            }
+            return Some(epoch_info);
+        }
+
+        // Path 2: This block itself triggers an epoch change.
+        let compute_result = last_block.compute_result();
+        if compute_result.has_reconfiguration() {
+            let block_info = last_block.block_info();
+            let mut epoch_info = gaptos::aptos_types::block_info::EpochBlockInfo {
+                block_id: last_block.id(),
+                block_number,
+                epoch_start_round: last_block.round(),
+                epoch_start_timestamp_usecs: block_info.timestamp_usecs(),
+            };
+            // For suffix blocks with reconfiguration flag, use the cached epoch end timestamp
+            if let Some(timestamp) = self.end_epoch_timestamp.get().cloned() {
+                if block_info.timestamp_usecs() != timestamp &&
+                    last_block.is_reconfiguration_suffix()
+                {
+                    epoch_info.epoch_start_timestamp_usecs = timestamp;
+                }
+            }
+            info!(
+                "[EpochChange] Built EpochBlockInfo for reconfig block {}: id={}, round={}, timestamp={}",
+                block_number, epoch_info.block_id, epoch_info.epoch_start_round, epoch_info.epoch_start_timestamp_usecs,
+            );
+            return Some(epoch_info);
+        }
+
+        // Path 3: Normal block — no epoch change.
+        None
+    }
+
     /// If the response is successful, advance the item to Executed, otherwise panic (TODO fix).
     #[allow(clippy::unwrap_used)]
     async fn process_execution_response(&mut self, response: ExecutionResponse) {
@@ -544,13 +673,26 @@ impl BufferManager {
             }
         }
 
+        let mut iter_block = executed_blocks.last().expect("execute_blocks should not be empty!");
+        let compute_result = iter_block.compute_result();
+        let epoch_block_info = self.resolve_epoch_block_info(&executed_blocks, iter_block).await;
+
         let item = self.buffer.take(&current_cursor);
-        let new_item = item.advance_to_executed_or_aggregated(
+        let round = item.commit_info().round();
+        let mut new_item = item.advance_to_executed_or_aggregated(
             executed_blocks,
             &self.epoch_state.verifier,
             self.end_epoch_timestamp.get().cloned(),
             self.order_vote_enabled,
+            epoch_block_info,
         );
+        // Check if we have a cached commit proof for this round
+        if let Some(commit_proof) = self.drain_pending_commit_proof_till(round) {
+            if !new_item.is_aggregated() && commit_proof.commit_info().id() == block_id {
+                info!("Applying pending commit proof for round {} block {}", round, block_id);
+                new_item = new_item.try_advance_to_aggregated_with_ledger_info(commit_proof);
+            }
+        }
         let aggregated = new_item.is_aggregated();
         self.buffer.set(&current_cursor, new_item);
         if aggregated {
@@ -692,6 +834,8 @@ impl BufferManager {
                         }
                         return Some(target_block_id);
                     }
+                } else if self.try_add_pending_commit_proof(commit_proof.ledger_info().clone()) {
+                    // Cached for later use when the block arrives
                 }
                 reply_nack(protocol, response_sender); // TODO: send_commit_proof() doesn't care
                                                        // about the response and this should be

--- a/aptos-core/consensus/src/pipeline/pipeline_builder.rs
+++ b/aptos-core/consensus/src/pipeline/pipeline_builder.rs
@@ -41,7 +41,7 @@ use gaptos::{
     aptos_logger::{error, info, warn},
     aptos_types::{
         block_executor::config::BlockExecutorConfigFromOnchain,
-        block_info::EpochBlockInfo,
+        block_info::{BlockInfo, EpochBlockInfo},
         block_metadata_ext::BlockMetadataExt,
         ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
         randomness::Randomness,
@@ -442,7 +442,6 @@ impl PipelineBuilder {
                     ExternalAccountAddress::new(txn.sender().into_bytes()),
                     txn.sequence_number(),
                     ExternalChainId::new(txn.chain_id().id()),
-                    TxnHash::from_bytes(&txn.get_hash().to_vec()),
                 )
             })
             .collect();
@@ -640,7 +639,7 @@ impl PipelineBuilder {
         // We first check if the block is a suffix block by querying the buffer manager.
         // This is necessary because both the epoch change block and its suffix blocks
         // have a StateComputeResult where `has_reconfiguration()` is true.
-        if let Some(epoch_info) = get_block_buffer_manager()
+        let epoch_block_info = if let Some(epoch_info) = get_block_buffer_manager()
             .get_epoch_change_block_info(block.block_number().unwrap_or(0), block.epoch())
             .await
         {
@@ -649,7 +648,7 @@ impl PipelineBuilder {
                 "[EpochChange] Setting EpochBlockInfo for suffix block (block_number={:?}): epoch_change_block_id={}, epoch_change_block_number={}",
                 block.block_number(), epoch_info.block_id, epoch_info.block_number,
             );
-            block_info.set_epoch_block_info(epoch_info);
+            Some(epoch_info)
         } else if compute_result.has_reconfiguration() {
             // This is the actual epoch change block
             let epoch_info = EpochBlockInfo {
@@ -662,8 +661,20 @@ impl PipelineBuilder {
                 "[EpochChange] Setting EpochBlockInfo for epoch change block: id={}, number={}, round={}, timestamp={}",
                 epoch_info.block_id, epoch_info.block_number, epoch_info.epoch_start_round, epoch_info.epoch_start_timestamp_usecs,
             );
-            block_info.set_epoch_block_info(epoch_info);
-        }
+            Some(epoch_info)
+        } else {
+            None
+        };
+        let block_info = BlockInfo::new_with_epoch_block_info(
+            block_info.epoch(),
+            block_info.round(),
+            block_info.id(),
+            block_info.executed_state_id(),
+            block_info.version(),
+            block_info.timestamp_usecs(),
+            block_info.next_epoch_state().cloned(),
+            epoch_block_info,
+        );
         let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
         info!("[Pipeline] Signed ledger info {ledger_info}");
         let signature = signer.sign(&ledger_info).expect("Signing should succeed");

--- a/aptos-core/consensus/src/pipeline/pipeline_builder.rs
+++ b/aptos-core/consensus/src/pipeline/pipeline_builder.rs
@@ -41,6 +41,7 @@ use gaptos::{
     aptos_logger::{error, info, warn},
     aptos_types::{
         block_executor::config::BlockExecutorConfigFromOnchain,
+        block_info::EpochBlockInfo,
         block_metadata_ext::BlockMetadataExt,
         ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
         randomness::Randomness,
@@ -633,6 +634,34 @@ impl PipelineBuilder {
                 timestamp
             );
             block_info.change_timestamp(timestamp);
+        }
+        // Populate EpochBlockInfo when this block triggers an epoch change.
+        // We first check if the block is a suffix block by querying the buffer manager.
+        // This is necessary because both the epoch change block and its suffix blocks
+        // have a StateComputeResult where `has_reconfiguration()` is true.
+        if let Some(epoch_info) = get_block_buffer_manager()
+            .get_epoch_change_block_info(block.block_number().unwrap_or(0), block.epoch())
+            .await
+        {
+            // Suffix block after an epoch change: carry the epoch change block's info
+            info!(
+                "[EpochChange] Setting EpochBlockInfo for suffix block (block_number={:?}): epoch_change_block_id={}, epoch_change_block_number={}",
+                block.block_number(), epoch_info.block_id, epoch_info.block_number,
+            );
+            block_info.set_epoch_block_info(epoch_info);
+        } else if compute_result.has_reconfiguration() {
+            // This is the actual epoch change block
+            let epoch_info = EpochBlockInfo {
+                block_id: block.id(),
+                block_number: block.block_number().unwrap_or(0),
+                epoch_start_round: block.round(),
+                epoch_start_timestamp_usecs: block_info.timestamp_usecs(),
+            };
+            info!(
+                "[EpochChange] Setting EpochBlockInfo for epoch change block: id={}, number={}, round={}, timestamp={}",
+                epoch_info.block_id, epoch_info.block_number, epoch_info.epoch_start_round, epoch_info.epoch_start_timestamp_usecs,
+            );
+            block_info.set_epoch_block_info(epoch_info);
         }
         let ledger_info = LedgerInfo::new(block_info, HashValue::zero());
         info!("[Pipeline] Signed ledger info {ledger_info}");

--- a/aptos-core/consensus/src/pipeline/pipeline_builder.rs
+++ b/aptos-core/consensus/src/pipeline/pipeline_builder.rs
@@ -481,6 +481,7 @@ impl PipelineBuilder {
                     extra_data: vec![],
                     enable_randomness: is_randomness_enabled,
                 },
+                block.round(),
             )
             .await
             .map_err(|e| anyhow::anyhow!("Failed to push ordered blocks: {}", e))?;

--- a/aptos-core/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/rand_manager.rs
@@ -385,7 +385,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                     self.process_incoming_blocks(blocks);
                 }
                 Some(reset) = reset_rx.next() => {
-                    while matches!(incoming_blocks.try_next(), Ok(Some(_))) {}
+                    while matches!(incoming_blocks.try_recv(), Ok(_)) {}
                     self.process_reset(reset);
                 }
                 Some(randomness) = self.decision_rx.next()  => {

--- a/aptos-core/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/rand_manager.rs
@@ -385,7 +385,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                     self.process_incoming_blocks(blocks);
                 }
                 Some(reset) = reset_rx.next() => {
-                    while matches!(incoming_blocks.try_recv(), Ok(_)) {}
+                    while matches!(incoming_blocks.try_next(), Ok(Some(_))) {}
                     self.process_reset(reset);
                 }
                 Some(randomness) = self.decision_rx.next()  => {

--- a/aptos-core/consensus/src/rand/rand_gen/rand_store.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/rand_store.rs
@@ -491,7 +491,7 @@ mod tests {
         {
             rand_store.add_share(share, PathType::Slow).unwrap();
         }
-        assert!(decision_rx.try_next().is_err());
+        assert!(decision_rx.try_recv().is_err());
         for metadata in blocks_1.all_rand_metadata() {
             rand_store.add_rand_metadata(metadata);
         }
@@ -501,7 +501,7 @@ mod tests {
         for metadata in blocks_2.all_rand_metadata() {
             rand_store.add_rand_metadata(metadata);
         }
-        assert!(decision_rx.try_next().is_err());
+        assert!(decision_rx.try_recv().is_err());
 
         for share in ctxt.authors[1..6]
             .iter()

--- a/aptos-core/consensus/src/rand/rand_gen/rand_store.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/rand_store.rs
@@ -491,7 +491,7 @@ mod tests {
         {
             rand_store.add_share(share, PathType::Slow).unwrap();
         }
-        assert!(decision_rx.try_recv().is_err());
+        assert!(decision_rx.try_next().is_err());
         for metadata in blocks_1.all_rand_metadata() {
             rand_store.add_rand_metadata(metadata);
         }
@@ -501,7 +501,7 @@ mod tests {
         for metadata in blocks_2.all_rand_metadata() {
             rand_store.add_rand_metadata(metadata);
         }
-        assert!(decision_rx.try_recv().is_err());
+        assert!(decision_rx.try_next().is_err());
 
         for share in ctxt.authors[1..6]
             .iter()

--- a/aptos-core/consensus/src/state_computer.rs
+++ b/aptos-core/consensus/src/state_computer.rs
@@ -575,12 +575,21 @@ impl StateComputer for ExecutionProxy {
             }
             committed_block_ids.push(block.id());
 
+            let this_block_num = block.block().block_number().unwrap_or(0);
+            let is_suffix = if let Some(info) = finality_proof.commit_info().epoch_block_info() {
+                this_block_num > info.block_number
+            } else {
+                false
+            };
+
             let commit_transactions =
                 self.transactions_to_commit(block, &validators, is_randomness_enabled);
             if !commit_transactions.is_empty() {
                 txns.extend(commit_transactions);
             }
-            subscribable_txn_events.extend(block.subscribable_events());
+            if !is_suffix {
+                subscribable_txn_events.extend(block.subscribable_events());
+            }
             // pre_commit_futs.push(block.take_pre_commit_fut());
             block_ids.push(block.id());
 
@@ -612,12 +621,16 @@ impl StateComputer for ExecutionProxy {
         .expect("spawn_blocking failed");
 
         let blocks = blocks.to_vec();
-        let block_number = blocks
+        let mut block_number = blocks
             .last()
             .unwrap()
             .block()
             .block_number()
             .unwrap_or_else(|| panic!("No block number"));
+
+        if let Some(info) = finality_proof.commit_info().epoch_block_info() {
+            block_number = info.block_number;
+        }
         let wrapped_callback = move || {
             payload_manager.notify_commit(block_timestamp, payloads);
             callback(&blocks, finality_proof);

--- a/aptos-core/consensus/src/state_computer.rs
+++ b/aptos-core/consensus/src/state_computer.rs
@@ -482,6 +482,7 @@ impl StateComputer for ExecutionProxy {
         APTOS_EXECUTION_TXNS.observe(real_txns.len() as f64);
         let txn_notifier = self.txn_notifier.clone();
         let block_id_hashvalue = block.id();
+        let block_round = block.round();
         let enable_randomness = self.state.read().as_ref().unwrap().is_randomness_enabled;
         Box::pin(async move {
             let block_id = meta_data.block_id;
@@ -497,6 +498,7 @@ impl StateComputer for ExecutionProxy {
                         extra_data,
                         enable_randomness,
                     },
+                    block_round,
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to push ordered blocks: {}", e))?;

--- a/aptos-core/consensus/src/state_computer.rs
+++ b/aptos-core/consensus/src/state_computer.rs
@@ -475,7 +475,6 @@ impl StateComputer for ExecutionProxy {
                     ExternalAccountAddress::new(txn.sender().into_bytes()),
                     txn.sequence_number(),
                     ExternalChainId::new(txn.chain_id().id()),
-                    TxnHash::from_bytes(&txn.get_hash().to_vec()),
                 )
             })
             .collect();

--- a/aptos-core/consensus/src/twins/basic_twins_test.rs
+++ b/aptos-core/consensus/src/twins/basic_twins_test.rs
@@ -98,8 +98,8 @@ async fn drop_config_test() {
         assert!(node0_commit.is_some());
 
         // Check that the commit log for n2 is empty
-        let node2_commit = match nodes[2].commit_cb_receiver.try_recv() {
-            Ok(node_commit) => Some(node_commit),
+        let node2_commit = match nodes[2].commit_cb_receiver.try_next() {
+            Ok(node_commit) => node_commit,
             _ => None,
         };
         assert!(node2_commit.is_none());
@@ -158,7 +158,7 @@ async fn twins_vote_dedup_test() {
         // have been created
         let mut commit_seen = false;
         for node in &mut nodes {
-            if let Ok(_node_commit) = node.commit_cb_receiver.try_recv() {
+            if let Ok(Some(_node_commit)) = node.commit_cb_receiver.try_next() {
                 commit_seen = true;
             }
         }

--- a/aptos-core/consensus/src/twins/basic_twins_test.rs
+++ b/aptos-core/consensus/src/twins/basic_twins_test.rs
@@ -98,8 +98,8 @@ async fn drop_config_test() {
         assert!(node0_commit.is_some());
 
         // Check that the commit log for n2 is empty
-        let node2_commit = match nodes[2].commit_cb_receiver.try_next() {
-            Ok(Some(node_commit)) => Some(node_commit),
+        let node2_commit = match nodes[2].commit_cb_receiver.try_recv() {
+            Ok(node_commit) => Some(node_commit),
             _ => None,
         };
         assert!(node2_commit.is_none());
@@ -158,7 +158,7 @@ async fn twins_vote_dedup_test() {
         // have been created
         let mut commit_seen = false;
         for node in &mut nodes {
-            if let Ok(Some(_node_commit)) = node.commit_cb_receiver.try_next() {
+            if let Ok(_node_commit) = node.commit_cb_receiver.try_recv() {
                 commit_seen = true;
             }
         }

--- a/aptos-core/mempool/src/core_mempool/transaction.rs
+++ b/aptos-core/mempool/src/core_mempool/transaction.rs
@@ -138,10 +138,10 @@ impl From<gaptos::api_types::VerifiedTxn> for VerifiedTxn {
     fn from(value: gaptos::api_types::VerifiedTxn) -> Self {
         let committed_hash = HashValue::new(value.committed_hash());
         VerifiedTxn {
-            bytes: value.bytes,
-            sender: AccountAddress::new(value.sender.bytes()),
-            sequence_number: value.sequence_number,
-            chain_id: value.chain_id.into_u64().into(),
+            bytes: value.bytes().to_vec(),
+            sender: AccountAddress::new(value.sender().bytes()),
+            sequence_number: value.seq_number(),
+            chain_id: value.chain_id().into_u64().into(),
             committed_hash,
         }
     }
@@ -154,7 +154,6 @@ impl From<VerifiedTxn> for gaptos::api_types::VerifiedTxn {
             ExternalAccountAddress::new(value.sender.into_bytes()),
             value.sequence_number,
             ExternalChainId::new(value.chain_id.into()),
-            TxnHash::new(*value.committed_hash),
         )
     }
 }

--- a/aptos-core/mempool/src/core_mempool/transaction.rs
+++ b/aptos-core/mempool/src/core_mempool/transaction.rs
@@ -4,10 +4,7 @@
 
 use crate::network::BroadcastPeerPriority;
 use gaptos::{
-    api_types::{
-        account::{ExternalAccountAddress, ExternalChainId},
-        u256_define::TxnHash,
-    },
+    api_types::account::{ExternalAccountAddress, ExternalChainId},
     aptos_crypto::{HashValue, Uniform},
     aptos_mempool::counters,
     aptos_types::{

--- a/bin/bench/src/txn.rs
+++ b/bin/bench/src/txn.rs
@@ -1,7 +1,5 @@
 use gaptos::api_types::{
     account::{ExternalAccountAddress, ExternalChainId},
-    simple_hash,
-    u256_define::TxnHash,
     VerifiedTxn,
 };
 use serde::{Deserialize, Serialize};
@@ -41,14 +39,7 @@ impl RawTxn {
 
     pub fn into_verified(self) -> VerifiedTxn {
         let bytes = self.to_bytes();
-        let hash = simple_hash::hash_to_fixed_array(&bytes);
-        VerifiedTxn::new(
-            bytes,
-            self.account,
-            self.sequence_number,
-            ExternalChainId::new(0),
-            TxnHash::new(hash),
-        )
+        VerifiedTxn::new(bytes, self.account, self.sequence_number, ExternalChainId::new(0))
     }
 
     pub fn account(&self) -> ExternalAccountAddress {

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "a5d6a892375480f4cef8e35db91377e502883f79" }
+greth = { git = "https://github.com/Galxe/gravity-reth", branch = "dev-0411-fix" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", branch = "dev-0411-fix" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "76e91d06722edc93b5f8868d8191c09069bd6857" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -43,7 +43,6 @@ alloy-rpc-types-eth = "=1.0.37"
 async-trait.workspace = true
 api.workspace = true
 gaptos.workspace = true
-# api-types.workspace = true
 block-buffer-manager.workspace = true
 proposer-reth-map.workspace = true
 build-info.workspace = true

--- a/bin/gravity_node/src/consensus/mock_consensus/mock.rs
+++ b/bin/gravity_node/src/consensus/mock_consensus/mock.rs
@@ -167,7 +167,10 @@ impl MockConsensus {
                     .await;
 
                     let head_meta = block.block_meta.clone();
-                    get_block_buffer_manager().set_ordered_blocks(parent_id, block).await.unwrap();
+                    get_block_buffer_manager()
+                        .set_ordered_blocks(parent_id, block, 0)
+                        .await
+                        .unwrap();
                     parent_id = head_meta.block_id;
                     let _ = block_meta_tx.send(head_meta).await;
                     // wait if there's large gap between executed block and ordered block

--- a/bin/gravity_node/src/main.rs
+++ b/bin/gravity_node/src/main.rs
@@ -101,6 +101,20 @@ fn run_reth(
                         })
                         .await?;
                     let chain_spec = handle.node.chain_spec();
+
+                    // Initialize consensus-layer hardforks from genesis.json extra_fields.
+                    {
+                        use gaptos::api_types::on_chain_config::consensus_hardfork::{
+                            init_consensus_hardforks, ConsensusHardforks,
+                        };
+                        let extra = &chain_spec.genesis.config.extra_fields;
+                        let hardforks = ConsensusHardforks::from_genesis_extra_fields(|key| {
+                            extra.get(key).and_then(|v| v.as_u64())
+                        });
+                        info!("Consensus hardforks:\n{}", hardforks);
+                        init_consensus_hardforks(hardforks);
+                    }
+
                     let eth_api = handle.node.rpc_registry.eth_api().clone();
                     let pending_listener: tokio::sync::mpsc::Receiver<TxHash> =
                         handle.node.pool.pending_transactions_listener();

--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -100,13 +100,12 @@ fn to_verified_txn(
     let sender = pool_txn.sender();
     let nonce = pool_txn.nonce();
     let txn = pool_txn.transaction.transaction().inner();
-    VerifiedTxn {
-        bytes: txn.encoded_2718(),
-        sender: convert_account(sender),
-        sequence_number: nonce,
-        chain_id: ExternalChainId::new(chain_id),
-        committed_hash: TxnHash::from_bytes(txn.hash().as_slice()).into(),
-    }
+    VerifiedTxn::new(
+        txn.encoded_2718(),
+        convert_account(sender),
+        nonce,
+        ExternalChainId::new(chain_id),
+    )
 }
 
 fn to_verified_txn_from_reth_txn(
@@ -116,13 +115,12 @@ fn to_verified_txn_from_reth_txn(
     let sender = pool_txn.signer();
     let nonce = pool_txn.inner().nonce();
     let txn = pool_txn.inner();
-    VerifiedTxn {
-        bytes: txn.encoded_2718(),
-        sender: convert_account(sender),
-        sequence_number: nonce,
-        chain_id: ExternalChainId::new(chain_id),
-        committed_hash: TxnHash::from_bytes(txn.hash().as_slice()).into(),
-    }
+    VerifiedTxn::new(
+        txn.encoded_2718(),
+        convert_account(sender),
+        nonce,
+        ExternalChainId::new(chain_id),
+    )
 }
 
 impl TxPool for Mempool {
@@ -219,7 +217,7 @@ impl TxPool for Mempool {
     }
 
     fn add_external_txn(&self, txn: VerifiedTxn) -> bool {
-        let txn = TransactionSigned::decode_2718(&mut txn.bytes.as_ref());
+        let txn = TransactionSigned::decode_2718(&mut txn.bytes().as_slice());
         match txn {
             Ok(txn) => {
                 let signer = match txn.recover_signer() {
@@ -262,7 +260,7 @@ impl TxPool for Mempool {
 
         let mut eth_txn_hashes = Vec::with_capacity(txns.len());
         for txn in txns {
-            let txn = TransactionSigned::decode_2718(&mut txn.bytes.as_ref());
+            let txn = TransactionSigned::decode_2718(&mut txn.bytes().as_slice());
             match txn {
                 Ok(txn) => {
                     eth_txn_hashes.push(*txn.hash());

--- a/bin/gravity_node/src/reth_cli.rs
+++ b/bin/gravity_node/src/reth_cli.rs
@@ -335,11 +335,11 @@ impl<EthApi: RethEthCall> RethCli<EthApi> {
                 if e.to_string().contains("Buffer is in epoch change") ||
                     current_epoch != get_block_buffer_manager().get_current_epoch().await
                 {
-                    // consume_epoch_change returns the new epoch
-                    let new_epoch = get_block_buffer_manager().consume_epoch_change().await;
-                    let latest_epoch_change_block_number =
-                        get_block_buffer_manager().latest_epoch_change_block_number().await;
-                    start_ordered_block = latest_epoch_change_block_number + 1;
+                    // consume_epoch_change returns (new_epoch, epoch_change_block_number)
+                    // and resets latest_epoch_change_block_number to 0 atomically.
+                    let (new_epoch, epoch_change_block_number) =
+                        get_block_buffer_manager().consume_epoch_change().await;
+                    start_ordered_block = epoch_change_block_number + 1;
                     let old_epoch = self.current_epoch.swap(new_epoch, Ordering::SeqCst);
                     info!("Buffer is in epoch change, reset start_ordered_block from {} to {}, epoch from {} to {}", 
                         from, start_ordered_block, old_epoch, new_epoch);

--- a/bin/gravity_node/src/reth_cli.rs
+++ b/bin/gravity_node/src/reth_cli.rs
@@ -124,11 +124,8 @@ impl<EthApi: RethEthCall> RethCli<EthApi> {
         self.chain_id
     }
 
-    fn txn_to_signed(
-        bytes: &mut [u8],
-        _chain_id: u64,
-    ) -> Result<(Address, TransactionSigned), String> {
-        let mut slice = &bytes[..];
+    fn txn_to_signed(bytes: &[u8], _chain_id: u64) -> Result<(Address, TransactionSigned), String> {
+        let mut slice = bytes;
         let txn = TransactionSigned::decode_2718(&mut slice)
             .map_err(|e| format!("Failed to decode transaction: {e}"))?;
         let signer = txn
@@ -207,7 +204,7 @@ impl<EthApi: RethEthCall> RethCli<EthApi> {
             .par_iter_mut()
             .enumerate()
             .filter(|(idx, _)| senders[*idx].is_none())
-            .map(|(idx, txn)| match Self::txn_to_signed(&mut txn.bytes, self.chain_id) {
+            .map(|(idx, txn)| match Self::txn_to_signed(txn.bytes().as_slice(), self.chain_id) {
                 Ok((sender, transaction)) => Some((idx, sender, transaction)),
                 Err(e) => {
                     warn!("Skipping malformed transaction at index {}: {}", idx, e);

--- a/crates/api/src/consensus_mempool_handler.rs
+++ b/crates/api/src/consensus_mempool_handler.rs
@@ -97,12 +97,16 @@ impl<M: MempoolNotificationSender> ConsensusToMempoolHandler<M> {
                 self.handle_consensus_commit_notification(commit_notification).await
             }
             ConsensusNotification::SyncToTarget(sync_notification) => {
-                let target_block = sync_notification.get_target().ledger_info().block_number();
+                let ledger_info = sync_notification.get_target().ledger_info();
+                let block_number = match ledger_info.commit_info().epoch_block_info() {
+                    Some(info) => info.block_number,
+                    None => ledger_info.block_number(),
+                };
                 match self
                     .event_subscription_service
                     .lock()
                     .await
-                    .notify_initial_configs(target_block)
+                    .notify_initial_configs(block_number)
                 {
                     Ok(_) => {}
                     Err(e) => {
@@ -110,7 +114,7 @@ impl<M: MempoolNotificationSender> ConsensusToMempoolHandler<M> {
                             "Failed to notify initial configs for block {}: {:?}. \
                              This is expected after a cross-epoch unwind; \
                              the node will re-sync missing blocks via block sync.",
-                            target_block, e
+                            block_number, e
                         );
                     }
                 }

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -2,7 +2,9 @@ use anyhow::format_err;
 use aptos_executor_types::StateComputeResult;
 use gaptos::{
     api_types::{self, account::ExternalAccountAddress, u256_define::TxnHash},
-    aptos_types::{epoch_state::EpochState, idl::convert_validator_set},
+    aptos_types::{
+        block_info::EpochBlockInfo, epoch_state::EpochState, idl::convert_validator_set,
+    },
 };
 use std::{
     collections::HashMap,
@@ -173,6 +175,34 @@ pub struct BlockStateMachine {
     next_epoch: Option<u64>,
     /// Moved from separate Mutex to eliminate nested locking.
     latest_epoch_change_block_number: u64,
+    /// Cached epoch change metadata for suffix block handling.
+    /// Set when a reconfig block is detected in `set_compute_res`, cleared in
+    /// `release_inflight_blocks`. Note: `epoch_block_info.epoch_start_round` and
+    /// `epoch_start_timestamp_usecs` are initially 0 because reth doesn't have consensus-layer
+    /// data. They are patched downstream by `BufferManager::resolve_epoch_block_info`.
+    epoch_change_block_info: Option<EpochChangeCache>,
+}
+
+impl BlockStateMachine {
+    /// Returns true if the given block is a suffix block after an epoch change.
+    fn is_suffix_block(&self, block_num: u64) -> bool {
+        self.epoch_change_block_info
+            .as_ref()
+            .map_or(false, |cache| block_num > cache.epoch_block_info.block_number)
+    }
+
+    /// Record a profile measurement for the given block key.
+    fn record_profile(&mut self, key: BlockKey, f: impl FnOnce(&mut BlockProfile)) {
+        f(self.profile.entry(key).or_default());
+    }
+}
+
+/// Caches the epoch change block's metadata and compute result.
+/// Used by suffix blocks to carry consistent epoch transition info.
+#[derive(Clone, Debug)]
+pub struct EpochChangeCache {
+    pub epoch_block_info: EpochBlockInfo,
+    pub compute_result: StateComputeResult,
 }
 
 pub struct BlockBufferManagerConfig {
@@ -232,6 +262,7 @@ impl BlockBufferManager {
                 current_epoch: 0,
                 next_epoch: None,
                 latest_epoch_change_block_number: 0,
+                epoch_change_block_info: None,
             }),
             buffer_state: AtomicU8::new(BufferState::Uninitialized as u8),
             config,
@@ -256,10 +287,6 @@ impl BlockBufferManager {
         }
         let latest_persist_block_num = block_state_machine.latest_finalized_block_number;
         info!("remove_committed_blocks latest_persist_block_num: {:?}", latest_persist_block_num);
-        block_state_machine.latest_finalized_block_number = std::cmp::max(
-            block_state_machine.latest_finalized_block_number,
-            latest_persist_block_num,
-        );
         block_state_machine.blocks.retain(|key, _| key.block_number >= latest_persist_block_num);
         block_state_machine.profile.retain(|key, _| key.block_number >= latest_persist_block_num);
         let _ = block_state_machine.sender.send(());
@@ -302,7 +329,7 @@ impl BlockBufferManager {
                 BlockState::Historical { id: commit_block_id },
             );
             // Access via block_state_machine instead of separate mutex
-            block_state_machine.latest_epoch_change_block_number = latest_commit_block_number;
+            block_state_machine.latest_epoch_change_block_number = 0;
         }
         self.buffer_state.store(BufferState::Ready as u8, Ordering::SeqCst);
         // Notify all waiters that buffer is ready
@@ -352,15 +379,42 @@ impl BlockBufferManager {
         self.buffer_state.load(Ordering::SeqCst) == BufferState::EpochChange as u8
     }
 
-    pub async fn consume_epoch_change(&self) -> u64 {
+    /// Consume the epoch change and return (new_epoch, epoch_change_block_number).
+    /// Also resets `latest_epoch_change_block_number` to 0 so that
+    /// `get_committed_blocks` no longer skips new-epoch blocks.
+    pub async fn consume_epoch_change(&self) -> (u64, u64) {
         // Acquire lock first to prevent TOCTOU race.
         // Other tasks checking is_epoch_change() will still see EpochChange
         // until we have fully read the new epoch and are ready to proceed.
-        let block_state_machine = self.block_state_machine.lock().await;
-        let epoch = block_state_machine.current_epoch;
-        // Only now signal that the epoch change has been consumed
+        let mut block_state_machine = self.block_state_machine.lock().await;
+        let epoch_change_block_number = block_state_machine.latest_epoch_change_block_number;
+
+        // Use next_epoch if available (set by calculate_new_epoch_state),
+        // otherwise fall back to current_epoch.
+        let new_epoch = block_state_machine.next_epoch.unwrap_or(block_state_machine.current_epoch);
+
+        // DO NOT advance current_epoch here. It MUST only be advanced in `release_inflight_blocks`
+        // when the consensus pipeline officially transitions.
+
+        // Reset so get_committed_blocks stops skipping new-epoch blocks.
+        block_state_machine.latest_epoch_change_block_number = 0;
+
+        // DO NOT clear epoch_change_block_info here. Suffix handling in get_executed_res relies
+        // on it to return dummy execution results for suffix blocks. It will be cleared in
+        // release_inflight_blocks. Only now signal that the epoch change has been consumed
         self.buffer_state.store(BufferState::Ready as u8, Ordering::SeqCst);
-        epoch
+
+        // If epoch_change_block_number is 0, it means this is a redundant call
+        // (release_inflight_blocks can set buffer_state=EpochChange again after
+        // a previous consume). Use latest_commit_block_number as fallback to
+        // prevent the caller from resetting start_ordered_block to 1.
+        let effective_block_number = if epoch_change_block_number == 0 {
+            block_state_machine.latest_commit_block_number
+        } else {
+            epoch_change_block_number
+        };
+
+        (new_epoch, effective_block_number)
     }
 
     // Access via block_state_machine instead of separate mutex
@@ -548,6 +602,12 @@ impl BlockBufferManager {
             }
 
             let mut block_state_machine = self.block_state_machine.lock().await;
+
+            // Check if epoch has already advanced (e.g., release_inflight_blocks was called)
+            if self.is_epoch_change() {
+                return Err(anyhow::anyhow!("Buffer is in epoch change"));
+            }
+
             // get block num, block num + 1
             let mut result = Vec::new();
             let mut current_num = start_num;
@@ -557,16 +617,14 @@ impl BlockBufferManager {
                     Some(BlockState::Ordered { block, parent_id }) => {
                         result.push((block.clone(), *parent_id));
                         // Record time for get_ordered_blocks
-                        let profile = block_state_machine
-                            .profile
-                            .entry(block_key)
-                            .or_insert_with(BlockProfile::default);
-                        profile.get_ordered_blocks_time = Some(SystemTime::now());
+                        block_state_machine.record_profile(block_key, |p| {
+                            p.get_ordered_blocks_time = Some(SystemTime::now());
+                        });
                     }
-                    Some(state) => {
-                        return Err(anyhow::anyhow!(
-                            "get_ordered_blocks: found block (epoch: {expected_epoch}, num: {current_num}) in non-Ordered state: {state:?}"
-                        ));
+                    Some(_state) => {
+                        // Block exists but is not Ordered (e.g., already Computed as a suffix
+                        // after epoch change). Stop collecting — don't error, just break.
+                        break;
                     }
                     None => {
                         // No more blocks available
@@ -579,7 +637,10 @@ impl BlockBufferManager {
                 current_num += 1;
             }
 
-            // If no blocks available, wait and retry
+            // If no blocks available, wait.
+            // If start_num is a suffix block, we purposefully don't return an error here anymore
+            // so that release_inflight_blocks is the sole driver of the epoch change. We will just
+            // wait until release_inflight_blocks updates current_epoch and wakes us up.
             if result.is_empty() {
                 // Release lock before waiting
                 drop(block_state_machine);
@@ -628,11 +689,9 @@ impl BlockBufferManager {
 
                         // Record time for get_executed_res
                         let compute_res_clone = compute_result.clone();
-                        let profile = block_state_machine
-                            .profile
-                            .entry(block_key)
-                            .or_insert_with(BlockProfile::default);
-                        profile.get_executed_res_time = Some(SystemTime::now());
+                        block_state_machine.record_profile(block_key, |p| {
+                            p.get_executed_res_time = Some(SystemTime::now());
+                        });
                         info!(
                             "get_executed_res done with id {:?} num {:?} res {:?}",
                             block_id, block_num, compute_res_clone,
@@ -640,6 +699,30 @@ impl BlockBufferManager {
                         return Ok(compute_res_clone);
                     }
                     BlockState::Ordered { .. } => {
+                        // Suffix blocks after epoch change: reth won't compute them,
+                        // so return a dummy result to unblock consensus.
+                        if block_state_machine.is_suffix_block(block_num) {
+                            let dummy_result = block_state_machine
+                                .epoch_change_block_info
+                                .as_ref()
+                                .unwrap()
+                                .compute_result
+                                .clone();
+                            info!(
+                                "[EpochChange] get_executed_res: suffix block {:?} num {:?}",
+                                block_id, block_num,
+                            );
+                            block_state_machine.blocks.insert(
+                                block_key,
+                                BlockState::Computed {
+                                    id: block_id,
+                                    compute_result: dummy_result.clone(),
+                                },
+                            );
+                            let _ = block_state_machine.sender.send(());
+                            return Ok(dummy_result);
+                        }
+
                         // Release lock before waiting
                         drop(block_state_machine);
 
@@ -669,6 +752,19 @@ impl BlockBufferManager {
                     }
                 }
             } else {
+                if epoch < block_state_machine.current_epoch {
+                    let dummy_result = block_state_machine
+                        .epoch_change_block_info
+                        .as_ref()
+                        .map_or_else(StateComputeResult::new_dummy, |c| c.compute_result.clone());
+                    info!(
+                        "[EpochChange] get_executed_res: bypassed old epoch block {:?} num {:?} \
+                         (epoch {} < current {})",
+                        block_id, block_num, epoch, block_state_machine.current_epoch
+                    );
+                    return Ok(dummy_result);
+                }
+
                 // invariant: the missed block is removed after epoch change
                 // Access via block_state_machine (already held)
                 let latest_epoch_change_block_number =
@@ -731,6 +827,70 @@ impl BlockBufferManager {
         Ok(Some(EpochState::new(*new_epoch, (&validator_set).into())))
     }
 
+    /// Called when an epoch change is detected in `set_compute_res`.
+    /// Stores the epoch change cache and sets dummy compute results for all
+    /// already-ordered suffix blocks in the same epoch, unblocking consensus.
+    fn handle_epoch_change_suffix_blocks(
+        block_state_machine: &mut BlockStateMachine,
+        epoch_change_block_num: u64,
+        epoch: u64,
+        block_id: BlockId,
+        compute_result: &StateComputeResult,
+    ) {
+        // Store the epoch change block's info so suffix blocks and
+        // sign_commit_vote can reference it.
+        block_state_machine.epoch_change_block_info = Some(EpochChangeCache {
+            epoch_block_info: EpochBlockInfo {
+                block_id: gaptos::aptos_crypto::HashValue::new(block_id.0),
+                block_number: epoch_change_block_num,
+                epoch_start_round: 0, /* not available here; patched by
+                                       * BufferManager::resolve_epoch_block_info */
+                epoch_start_timestamp_usecs: 0, /* not available here; patched by
+                                                 * BufferManager::resolve_epoch_block_info */
+            },
+            compute_result: compute_result.clone(),
+        });
+
+        let suffix_keys: Vec<(BlockKey, BlockId)> = block_state_machine
+            .blocks
+            .iter()
+            .filter_map(|(key, state)| {
+                if key.epoch == epoch &&
+                    key.block_number > epoch_change_block_num &&
+                    matches!(state, BlockState::Ordered { .. })
+                {
+                    Some((*key, state.get_block_id()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for (suffix_key, suffix_block_id) in &suffix_keys {
+            let dummy_result = StateComputeResult::new_dummy();
+            block_state_machine.blocks.insert(
+                *suffix_key,
+                BlockState::Computed { id: *suffix_block_id, compute_result: dummy_result },
+            );
+            block_state_machine.record_profile(*suffix_key, |p| {
+                p.set_compute_res_time = Some(SystemTime::now());
+            });
+            info!(
+                "[EpochChange] set_compute_res: suffix block {:?} num {:?} epoch {:?} \
+                 (dummy result, epoch change at block {})",
+                suffix_block_id, suffix_key.block_number, suffix_key.epoch, epoch_change_block_num,
+            );
+        }
+
+        if !suffix_keys.is_empty() {
+            info!(
+                "[EpochChange] epoch change at block {}, set {} suffix blocks with dummy results",
+                epoch_change_block_num,
+                suffix_keys.len(),
+            );
+        }
+    }
+
     pub async fn set_compute_res(
         &self,
         block_id: BlockId,
@@ -761,19 +921,22 @@ impl BlockBufferManager {
             let new_epoch_state = self
                 .calculate_new_epoch_state(&events, block_num, &mut block_state_machine)
                 .await?;
+            let has_epoch_change = new_epoch_state.is_some();
             let compute_result = StateComputeResult::new(
                 ComputeRes { data: block_hash, txn_num: txn_len as u64, txn_status, events },
                 new_epoch_state,
                 None,
             );
-            block_state_machine
-                .blocks
-                .insert(block_key, BlockState::Computed { id: block_id, compute_result });
+            block_state_machine.blocks.insert(
+                block_key,
+                BlockState::Computed { id: block_id, compute_result: compute_result.clone() },
+            );
 
             // Record time for set_compute_res
-            let profile =
-                block_state_machine.profile.entry(block_key).or_insert_with(BlockProfile::default);
-            profile.set_compute_res_time = Some(SystemTime::now());
+            block_state_machine.record_profile(block_key, |p| {
+                p.set_compute_res_time = Some(SystemTime::now());
+            });
+            let profile = block_state_machine.profile.get(&block_key);
             info!(
                 "set_compute_res id {:?} num {:?} hash {:?} and exec time {:?}ms for {:?} txns and {:?} events",
                 block_id,
@@ -786,6 +949,22 @@ impl BlockBufferManager {
                 txn_len,
                 events_len,
             );
+
+            // Non-blocking epoch change: when an epoch change is detected, immediately
+            // set dummy compute results for all subsequent Ordered blocks in the same epoch.
+            // This avoids blocking consensus while waiting for reth to process (and discard)
+            // these suffix blocks. Reth will independently detect the stale epoch and silently
+            // discard them without sending any ExecutionResult, so there is no conflict.
+            if has_epoch_change {
+                Self::handle_epoch_change_suffix_blocks(
+                    &mut block_state_machine,
+                    block_num,
+                    epoch,
+                    block_id,
+                    &compute_result,
+                );
+            }
+
             let _ = block_state_machine.sender.send(());
             return Ok(());
         }
@@ -810,12 +989,15 @@ impl BlockBufferManager {
                 block_id_num_hash.block_id, block_id_num_hash.num
             );
             let block_key = BlockKey::new(epoch, block_id_num_hash.num);
+
+            let is_suffix = block_state_machine.is_suffix_block(block_id_num_hash.num);
+
             if let Some(state) = block_state_machine.blocks.get_mut(&block_key) {
                 match state {
                     BlockState::Computed { id, compute_result } => {
                         if *id == block_id_num_hash.block_id {
                             let mut persist_notifier = None;
-                            if compute_result.epoch_state().is_some() {
+                            if compute_result.epoch_state().is_some() && !is_suffix {
                                 info!(
                                     "push_commit_blocks num {:?} push persist_notifier",
                                     block_id_num_hash.num
@@ -832,11 +1014,9 @@ impl BlockBufferManager {
                             };
 
                             // Record time for set_commit_blocks
-                            let profile = block_state_machine
-                                .profile
-                                .entry(block_key)
-                                .or_insert_with(BlockProfile::default);
-                            profile.set_commit_blocks_time = Some(SystemTime::now());
+                            block_state_machine.record_profile(block_key, |p| {
+                                p.set_commit_blocks_time = Some(SystemTime::now());
+                            });
                         } else {
                             return Err(anyhow::anyhow!(
                                 "Computed Block id and number is not equal id: {:?}={:?} num: {:?}",
@@ -915,6 +1095,17 @@ impl BlockBufferManager {
             let mut result = Vec::new();
             let mut current_num = start_num;
             loop {
+                // Non-blocking epoch change: skip suffix blocks after epoch change.
+                // These blocks have dummy execution results and were never executed by reth,
+                // so they must not enter the reth commit path (which would panic on get_block_id).
+                if block_state_machine.is_suffix_block(current_num) {
+                    info!(
+                        "[EpochChange] get_committed_blocks: skipping suffix block {}",
+                        current_num,
+                    );
+                    break;
+                }
+
                 let block_key = BlockKey::new(epoch, current_num);
                 match block_state_machine.blocks.get_mut(&block_key) {
                     Some(BlockState::Committed {
@@ -931,11 +1122,9 @@ impl BlockBufferManager {
                         });
 
                         // Record time for get_committed_blocks
-                        let profile = block_state_machine
-                            .profile
-                            .entry(block_key)
-                            .or_insert_with(BlockProfile::default);
-                        profile.get_committed_blocks_time = Some(SystemTime::now());
+                        block_state_machine.record_profile(block_key, |p| {
+                            p.get_committed_blocks_time = Some(SystemTime::now());
+                        });
                     }
                     _ => {
                         break;
@@ -1002,6 +1191,26 @@ impl BlockBufferManager {
         block_state_machine.current_epoch
     }
 
+    /// Returns the stored EpochBlockInfo if the given block is a suffix block
+    /// (same epoch as the epoch change, block_number > epoch change block number).
+    /// Returns None for normal blocks or blocks in a different epoch.
+    pub async fn get_epoch_change_block_info(
+        &self,
+        block_num: u64,
+        epoch: u64,
+    ) -> Option<EpochBlockInfo> {
+        let block_state_machine = self.block_state_machine.lock().await;
+        let epoch_change_bn = block_state_machine.latest_epoch_change_block_number;
+        if epoch_change_bn > 0 &&
+            block_num > epoch_change_bn &&
+            epoch == block_state_machine.current_epoch
+        {
+            block_state_machine.epoch_change_block_info.as_ref().map(|c| c.epoch_block_info.clone())
+        } else {
+            None
+        }
+    }
+
     pub async fn release_inflight_blocks(&self) {
         let mut block_state_machine = self.block_state_machine.lock().await;
         // Access via block_state_machine instead of separate mutex
@@ -1022,15 +1231,18 @@ impl BlockBufferManager {
             latest_epoch_change_block_number, block_state_machine.current_epoch
         );
 
-        self.buffer_state.store(BufferState::EpochChange as u8, Ordering::SeqCst);
-
         block_state_machine
             .blocks
             .retain(|key, _| key.block_number <= latest_epoch_change_block_number);
 
+        // Clear epoch change block info — epoch transition is complete,
+        // new epoch blocks should not carry stale epoch info.
+        block_state_machine.epoch_change_block_info = None;
+
         block_state_machine
             .profile
             .retain(|key, _| key.block_number <= latest_epoch_change_block_number);
+        self.buffer_state.store(BufferState::EpochChange as u8, Ordering::SeqCst);
         let _ = block_state_machine.sender.send(());
     }
 }

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -205,6 +205,13 @@ impl BlockStateMachine {
 #[derive(Clone, Debug)]
 pub struct EpochChangeCache {
     pub epoch_block_info: EpochBlockInfo,
+    /// The new `EpochState` produced by the reconfig block. Suffix blocks reuse this
+    /// when returning their dummy compute result so `has_reconfiguration() == true`,
+    /// keeping the consensus-side `is_reconfiguration_suffix()` invariant intact
+    /// (see `BufferItem::advance_to_executed_or_aggregated`). We intentionally do
+    /// NOT reuse the reconfig block's full `StateComputeResult` — that would leak
+    /// per-block execution output (root hash, txn status, events) to unrelated blocks.
+    pub epoch_state: EpochState,
 }
 
 pub struct BlockBufferManagerConfig {
@@ -706,13 +713,21 @@ impl BlockBufferManager {
                     }
                     BlockState::Ordered { .. } => {
                         // Suffix blocks after epoch change: reth won't compute them,
-                        // so return a dummy result to unblock consensus. Must match the
-                        // result written in `handle_epoch_change_suffix_blocks` — cloning
-                        // the epoch change block's real result here would leak
-                        // `has_reconfiguration() == true` to suffix blocks and any downstream
-                        // consumer that forgets to check `is_suffix_block`.
+                        // so return a dummy result to unblock consensus. We carry only
+                        // the new `epoch_state` through (not the reconfig block's full
+                        // `StateComputeResult`) so suffix blocks satisfy
+                        // `is_reconfiguration_suffix()` without leaking per-block
+                        // execution output (root hash, txn status, events) to unrelated
+                        // blocks — see `BufferItem::advance_to_executed_or_aggregated`.
                         if block_state_machine.is_suffix_block(block_num) {
-                            let dummy_result = StateComputeResult::new_dummy();
+                            let dummy_result = StateComputeResult::new_dummy_with_epoch_state(
+                                block_state_machine
+                                    .epoch_change_block_info
+                                    .as_ref()
+                                    .expect("is_suffix_block implies epoch_change_block_info set")
+                                    .epoch_state
+                                    .clone(),
+                            );
                             info!(
                                 "[EpochChange] get_executed_res: suffix block {:?} num {:?}",
                                 block_id, block_num,
@@ -842,6 +857,7 @@ impl BlockBufferManager {
         block_id: BlockId,
         block_timestamp_usecs: u64,
         block_round: u64,
+        epoch_state: EpochState,
     ) {
         // Store the epoch change block's info so suffix blocks and
         // sign_commit_vote can reference it.
@@ -852,6 +868,7 @@ impl BlockBufferManager {
                 epoch_start_round: block_round,
                 epoch_start_timestamp_usecs: block_timestamp_usecs,
             },
+            epoch_state: epoch_state.clone(),
         });
 
         let suffix_keys: Vec<(BlockKey, BlockId)> = block_state_machine
@@ -870,7 +887,7 @@ impl BlockBufferManager {
             .collect();
 
         for (suffix_key, suffix_block_id) in &suffix_keys {
-            let dummy_result = StateComputeResult::new_dummy();
+            let dummy_result = StateComputeResult::new_dummy_with_epoch_state(epoch_state.clone());
             block_state_machine.blocks.insert(
                 *suffix_key,
                 BlockState::Computed { id: *suffix_block_id, compute_result: dummy_result },
@@ -926,7 +943,7 @@ impl BlockBufferManager {
             let new_epoch_state = self
                 .calculate_new_epoch_state(&events, block_num, &mut block_state_machine)
                 .await?;
-            let has_epoch_change = new_epoch_state.is_some();
+            let epoch_change_state = new_epoch_state.clone();
             let compute_result = StateComputeResult::new(
                 ComputeRes { data: block_hash, txn_num: txn_len as u64, txn_status, events },
                 new_epoch_state,
@@ -960,7 +977,7 @@ impl BlockBufferManager {
             // This avoids blocking consensus while waiting for reth to process (and discard)
             // these suffix blocks. Reth will independently detect the stale epoch and silently
             // discard them without sending any ExecutionResult, so there is no conflict.
-            if has_epoch_change {
+            if let Some(epoch_state) = epoch_change_state {
                 Self::handle_epoch_change_suffix_blocks(
                     &mut block_state_machine,
                     block_num,
@@ -968,6 +985,7 @@ impl BlockBufferManager {
                     block_id,
                     block_timestamp_usecs,
                     block_round,
+                    epoch_state,
                 );
             }
 

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -118,6 +118,7 @@ pub enum BlockState {
     Ordered {
         block: ExternalBlock,
         parent_id: BlockId,
+        round: u64,
     },
     Computed {
         id: BlockId,
@@ -188,7 +189,7 @@ impl BlockStateMachine {
     fn is_suffix_block(&self, block_num: u64) -> bool {
         self.epoch_change_block_info
             .as_ref()
-            .map_or(false, |cache| block_num > cache.epoch_block_info.block_number)
+            .is_some_and(|cache| block_num > cache.epoch_block_info.block_number)
     }
 
     /// Record a profile measurement for the given block key.
@@ -471,6 +472,7 @@ impl BlockBufferManager {
         &self,
         parent_id: BlockId,
         block: ExternalBlock,
+        round: u64,
     ) -> Result<(), anyhow::Error> {
         if !self.is_ready() {
             self.ready_notifier.notified().await;
@@ -562,7 +564,7 @@ impl BlockBufferManager {
 
         block_state_machine
             .blocks
-            .insert(block_key, BlockState::Ordered { block: block.clone(), parent_id });
+            .insert(block_key, BlockState::Ordered { block: block.clone(), parent_id, round });
 
         // Record time for set_ordered_blocks
         let profile =
@@ -614,7 +616,7 @@ impl BlockBufferManager {
             loop {
                 let block_key = BlockKey::new(expected_epoch, current_num);
                 match block_state_machine.blocks.get(&block_key) {
-                    Some(BlockState::Ordered { block, parent_id }) => {
+                    Some(BlockState::Ordered { block, parent_id, .. }) => {
                         result.push((block.clone(), *parent_id));
                         // Record time for get_ordered_blocks
                         block_state_machine.record_profile(block_key, |p| {
@@ -835,6 +837,8 @@ impl BlockBufferManager {
         epoch_change_block_num: u64,
         epoch: u64,
         block_id: BlockId,
+        block_timestamp_usecs: u64,
+        block_round: u64,
         compute_result: &StateComputeResult,
     ) {
         // Store the epoch change block's info so suffix blocks and
@@ -843,10 +847,8 @@ impl BlockBufferManager {
             epoch_block_info: EpochBlockInfo {
                 block_id: gaptos::aptos_crypto::HashValue::new(block_id.0),
                 block_number: epoch_change_block_num,
-                epoch_start_round: 0, /* not available here; patched by
-                                       * BufferManager::resolve_epoch_block_info */
-                epoch_start_timestamp_usecs: 0, /* not available here; patched by
-                                                 * BufferManager::resolve_epoch_block_info */
+                epoch_start_round: block_round,
+                epoch_start_timestamp_usecs: block_timestamp_usecs,
             },
             compute_result: compute_result.clone(),
         });
@@ -906,7 +908,7 @@ impl BlockBufferManager {
 
         let mut block_state_machine = self.block_state_machine.lock().await;
         let block_key = BlockKey::new(epoch, block_num);
-        if let Some(BlockState::Ordered { block, parent_id: _ }) =
+        if let Some(BlockState::Ordered { block, round, .. }) =
             block_state_machine.blocks.get(&block_key)
         {
             if block.block_meta.block_id != block_id {
@@ -917,6 +919,8 @@ impl BlockBufferManager {
                 ));
             }
             let txn_len = block.txns.len();
+            let block_timestamp_usecs = block.block_meta.usecs;
+            let block_round = *round;
             let events_len = events.len();
             let new_epoch_state = self
                 .calculate_new_epoch_state(&events, block_num, &mut block_state_machine)
@@ -942,8 +946,8 @@ impl BlockBufferManager {
                 block_id,
                 block_num,
                 BlockId::from_bytes(block_hash.as_slice()),
-                profile.set_compute_res_time.unwrap_or(SystemTime::UNIX_EPOCH)
-                    .duration_since(profile.get_ordered_blocks_time.unwrap_or(SystemTime::UNIX_EPOCH))
+                profile.and_then(|p| p.set_compute_res_time).unwrap_or(SystemTime::UNIX_EPOCH)
+                    .duration_since(profile.and_then(|p| p.get_ordered_blocks_time).unwrap_or(SystemTime::UNIX_EPOCH))
                     .unwrap_or(Duration::ZERO)
                     .as_millis(),
                 txn_len,
@@ -961,6 +965,8 @@ impl BlockBufferManager {
                     block_num,
                     epoch,
                     block_id,
+                    block_timestamp_usecs,
+                    block_round,
                     &compute_result,
                 );
             }
@@ -1037,7 +1043,7 @@ impl BlockBufferManager {
                             ));
                         }
                     }
-                    BlockState::Ordered { block: _, parent_id: _ } => {
+                    BlockState::Ordered { .. } => {
                         return Err(anyhow::anyhow!(
                             "Set commit block meet ordered block for block id {:?} num {}",
                             block_id_num_hash.block_id,

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -178,9 +178,11 @@ pub struct BlockStateMachine {
     latest_epoch_change_block_number: u64,
     /// Cached epoch change metadata for suffix block handling.
     /// Set when a reconfig block is detected in `set_compute_res`, cleared in
-    /// `release_inflight_blocks`. Note: `epoch_block_info.epoch_start_round` and
-    /// `epoch_start_timestamp_usecs` are initially 0 because reth doesn't have consensus-layer
-    /// data. They are patched downstream by `BufferManager::resolve_epoch_block_info`.
+    /// `release_inflight_blocks`. The `epoch_block_info` is fully populated at
+    /// creation — `epoch_start_round` and `epoch_start_timestamp_usecs` are
+    /// passed down from the consensus layer via `set_ordered_blocks`.
+    /// Also serves as the source of truth for `is_suffix_block` and
+    /// `get_epoch_change_block_info`, so the reth and consensus sides stay in sync.
     epoch_change_block_info: Option<EpochChangeCache>,
 }
 
@@ -198,12 +200,11 @@ impl BlockStateMachine {
     }
 }
 
-/// Caches the epoch change block's metadata and compute result.
+/// Caches the epoch change block's metadata.
 /// Used by suffix blocks to carry consistent epoch transition info.
 #[derive(Clone, Debug)]
 pub struct EpochChangeCache {
     pub epoch_block_info: EpochBlockInfo,
-    pub compute_result: StateComputeResult,
 }
 
 pub struct BlockBufferManagerConfig {
@@ -381,8 +382,11 @@ impl BlockBufferManager {
     }
 
     /// Consume the epoch change and return (new_epoch, epoch_change_block_number).
-    /// Also resets `latest_epoch_change_block_number` to 0 so that
-    /// `get_committed_blocks` no longer skips new-epoch blocks.
+    /// Also resets `latest_epoch_change_block_number` to 0: this field doubles as a
+    /// pending-epoch-change flag, and `release_inflight_blocks` uses it to decide
+    /// which blocks to retain (reset-to-0 means "drop everything leftover").
+    /// Suffix-block lookups no longer depend on this field — they use
+    /// `epoch_change_block_info` directly, which lives until `release_inflight_blocks`.
     pub async fn consume_epoch_change(&self) -> (u64, u64) {
         // Acquire lock first to prevent TOCTOU race.
         // Other tasks checking is_epoch_change() will still see EpochChange
@@ -397,12 +401,12 @@ impl BlockBufferManager {
         // DO NOT advance current_epoch here. It MUST only be advanced in `release_inflight_blocks`
         // when the consensus pipeline officially transitions.
 
-        // Reset so get_committed_blocks stops skipping new-epoch blocks.
         block_state_machine.latest_epoch_change_block_number = 0;
 
-        // DO NOT clear epoch_change_block_info here. Suffix handling in get_executed_res relies
-        // on it to return dummy execution results for suffix blocks. It will be cleared in
-        // release_inflight_blocks. Only now signal that the epoch change has been consumed
+        // DO NOT clear epoch_change_block_info here. Suffix handling in get_executed_res and
+        // get_epoch_change_block_info relies on it to identify suffix blocks and return dummy
+        // execution results. It will be cleared in release_inflight_blocks. Only now signal
+        // that the epoch change has been consumed.
         self.buffer_state.store(BufferState::Ready as u8, Ordering::SeqCst);
 
         // If epoch_change_block_number is 0, it means this is a redundant call
@@ -702,14 +706,13 @@ impl BlockBufferManager {
                     }
                     BlockState::Ordered { .. } => {
                         // Suffix blocks after epoch change: reth won't compute them,
-                        // so return a dummy result to unblock consensus.
+                        // so return a dummy result to unblock consensus. Must match the
+                        // result written in `handle_epoch_change_suffix_blocks` — cloning
+                        // the epoch change block's real result here would leak
+                        // `has_reconfiguration() == true` to suffix blocks and any downstream
+                        // consumer that forgets to check `is_suffix_block`.
                         if block_state_machine.is_suffix_block(block_num) {
-                            let dummy_result = block_state_machine
-                                .epoch_change_block_info
-                                .as_ref()
-                                .unwrap()
-                                .compute_result
-                                .clone();
+                            let dummy_result = StateComputeResult::new_dummy();
                             info!(
                                 "[EpochChange] get_executed_res: suffix block {:?} num {:?}",
                                 block_id, block_num,
@@ -755,10 +758,10 @@ impl BlockBufferManager {
                 }
             } else {
                 if epoch < block_state_machine.current_epoch {
-                    let dummy_result = block_state_machine
-                        .epoch_change_block_info
-                        .as_ref()
-                        .map_or_else(StateComputeResult::new_dummy, |c| c.compute_result.clone());
+                    // Old-epoch bypass: same reasoning as the suffix block branch above —
+                    // never leak the epoch change block's real compute_result (which carries
+                    // `has_reconfiguration() == true`) to an unrelated block.
+                    let dummy_result = StateComputeResult::new_dummy();
                     info!(
                         "[EpochChange] get_executed_res: bypassed old epoch block {:?} num {:?} \
                          (epoch {} < current {})",
@@ -839,7 +842,6 @@ impl BlockBufferManager {
         block_id: BlockId,
         block_timestamp_usecs: u64,
         block_round: u64,
-        compute_result: &StateComputeResult,
     ) {
         // Store the epoch change block's info so suffix blocks and
         // sign_commit_vote can reference it.
@@ -850,7 +852,6 @@ impl BlockBufferManager {
                 epoch_start_round: block_round,
                 epoch_start_timestamp_usecs: block_timestamp_usecs,
             },
-            compute_result: compute_result.clone(),
         });
 
         let suffix_keys: Vec<(BlockKey, BlockId)> = block_state_machine
@@ -967,7 +968,6 @@ impl BlockBufferManager {
                     block_id,
                     block_timestamp_usecs,
                     block_round,
-                    &compute_result,
                 );
             }
 
@@ -1200,18 +1200,22 @@ impl BlockBufferManager {
     /// Returns the stored EpochBlockInfo if the given block is a suffix block
     /// (same epoch as the epoch change, block_number > epoch change block number).
     /// Returns None for normal blocks or blocks in a different epoch.
+    ///
+    /// Uses `epoch_change_block_info` as the source of truth — the same predicate as
+    /// `is_suffix_block` — so that the reth side and the consensus side always agree
+    /// on whether a block is a suffix block, including in the window between
+    /// `consume_epoch_change` and `release_inflight_blocks`.
     pub async fn get_epoch_change_block_info(
         &self,
         block_num: u64,
         epoch: u64,
     ) -> Option<EpochBlockInfo> {
         let block_state_machine = self.block_state_machine.lock().await;
-        let epoch_change_bn = block_state_machine.latest_epoch_change_block_number;
-        if epoch_change_bn > 0 &&
-            block_num > epoch_change_bn &&
+        let cache = block_state_machine.epoch_change_block_info.as_ref()?;
+        if block_num > cache.epoch_block_info.block_number &&
             epoch == block_state_machine.current_epoch
         {
-            block_state_machine.epoch_change_block_info.as_ref().map(|c| c.epoch_block_info.clone())
+            Some(cache.epoch_block_info.clone())
         } else {
             None
         }

--- a/dependencies/aptos-executor-types/src/lib.rs
+++ b/dependencies/aptos-executor-types/src/lib.rs
@@ -135,6 +135,16 @@ impl StateComputeResult {
         StateComputeResult::with_root_hash(*ACCUMULATOR_PLACEHOLDER_HASH)
     }
 
+    /// Like `new_dummy`, but carries an epoch_state so `has_reconfiguration()` returns true.
+    /// Used for suffix blocks after an epoch change: they have no real execution output,
+    /// but must still be tagged as reconfiguration-suffix for the consensus pipeline to
+    /// treat them as part of the epoch transition.
+    pub fn new_dummy_with_epoch_state(epoch_state: EpochState) -> Self {
+        let mut res = Self::new_dummy();
+        res.epoch_state = Some(epoch_state);
+        res
+    }
+
     /// generate a new dummy state compute result with a given root hash.
     /// this function is used in RandomComputeResultStateComputer to assert that the compute
     /// function is really called.
@@ -193,7 +203,20 @@ impl StateComputeResult {
     }
 
     pub fn events(&self) -> Vec<ContractEvent> {
-        self.execution_output.events.iter().map(|event| event.clone().into()).collect()
+        self.execution_output
+            .events
+            .iter()
+            .filter_map(|event| match ContractEvent::try_from(event) {
+                Ok(contract_event) => Some(contract_event),
+                Err(e) => {
+                    eprintln!(
+                        "WARNING: StateComputeResult::events: skipping malformed event: {}",
+                        e
+                    );
+                    None
+                }
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary

Implement non-blocking epoch change in the block buffer manager and fix deprecated `futures_channel` API usage.

### Non-blocking Epoch Change

Previously, when an epoch change block was detected, subsequent blocks in the same epoch ("suffix blocks") were dropped via `release_inflight_blocks()`, causing consensus to block waiting for execution results that would never arrive.

**Changes:**

1. **`block_buffer_manager.rs` — `set_compute_res()`**: When an epoch change is detected, immediately find all subsequent `Ordered` blocks in the same epoch and set `StateComputeResult::new_dummy()` as their compute result. This allows consensus to consume these results instantly without blocking.

2. **`block_buffer_manager.rs` — `get_committed_blocks()`**: Skip suffix blocks past the `latest_epoch_change_block_number` boundary. These blocks have dummy execution results and were never executed by reth, so they must not enter the reth commit path.

### Fix deprecated `try_next()` → `try_recv()`

Replace all deprecated `futures_channel::mpsc::UnboundedReceiver::try_next()` calls with `try_recv()` across the consensus crate.

### Dependency Updates

- Update `gaptos` to branch `feat/add-epoch-block-info` (Galxe/gravity-aptos#57)
- Update `greth` to branch `feat/add-epoch-block-info` (Galxe/gravity-reth#305)

## Related PRs

- Galxe/gravity-aptos#57
- Galxe/gravity-reth#305