### PR TITLE
fix(consensus): improve error handling and remove unreachable panics

### DIFF
--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -866,7 +866,11 @@ impl BlockStore {
                 .consensus_db()
                 .ledger_db
                 .metadata_db()
-                .get_ledger_infos_by_range((lower, upper));
+                .get_ledger_infos_by_range((lower, upper))
+                .unwrap_or_else(|e| {
+                    error!("Failed to get ledger infos by range ({}, {}): {}", lower, upper, e);
+                    vec![]
+                });
             // Filter ledger infos by retrieval_epoch
             ledger_infos.retain(|ledger_info| ledger_info.ledger_info().epoch() == retrieval_epoch);
             // Reverse to get them in ascending order

--- a/aptos-core/consensus/src/consensusdb/ledger_db/ledger_metadata_db.rs
+++ b/aptos-core/consensus/src/consensusdb/ledger_db/ledger_metadata_db.rs
@@ -121,10 +121,10 @@ impl LedgerMetadataDb {
         self.latest_ledger_info.store(Arc::new(Some(ledger_info_with_sigs)));
     }
 
-    pub(crate) fn update_latest_ledger_info(&self) {
-        let latest_ledger_info =
-            get_latest_ledger_info_in_db_impl(&self.db).expect("DB read failed.");
+    pub(crate) fn update_latest_ledger_info(&self) -> Result<()> {
+        let latest_ledger_info = get_latest_ledger_info_in_db_impl(&self.db)?;
         self.latest_ledger_info.store(Arc::new(latest_ledger_info));
+        Ok(())
     }
 
     pub(crate) fn get_latest_ledger_info(&self) -> Option<LedgerInfoWithSignatures> {
@@ -149,8 +149,8 @@ impl LedgerMetadataDb {
         batch.put::<LedgerInfoSchema>(&ledger_info.block_number(), ledger_info_with_sigs)
     }
 
-    pub(crate) fn get_latest_ledger_infos(&self) -> Vec<LedgerInfoWithSignatures> {
-        get_latest_ledger_infos_in_db_impl(&self.db).expect("DB read failed.")
+    pub(crate) fn get_latest_ledger_infos(&self) -> Result<Vec<LedgerInfoWithSignatures>> {
+        get_latest_ledger_infos_in_db_impl(&self.db)
     }
 
     pub(crate) fn get_block_hash(&self, block_number: u64) -> Option<HashValue> {
@@ -163,8 +163,8 @@ impl LedgerMetadataDb {
     pub(crate) fn get_ledger_infos_by_range(
         &self,
         range: (u64, u64),
-    ) -> Vec<LedgerInfoWithSignatures> {
-        get_ledger_infos_by_range_in_db_impl(&self.db, range).expect("DB read failed.")
+    ) -> Result<Vec<LedgerInfoWithSignatures>> {
+        get_ledger_infos_by_range_in_db_impl(&self.db, range)
     }
 }
 
@@ -209,7 +209,7 @@ mod tests {
 
         {
             let ledger_metadata_db = LedgerMetadataDb::new(init_db());
-            let res = ledger_metadata_db.get_ledger_infos_by_range((0, 0));
+            let res = ledger_metadata_db.get_ledger_infos_by_range((0, 0)).unwrap();
             println!("res len {} ", res.len());
             for li in res {
                 println!("{}", li);

--- a/aptos-core/consensus/src/consensusdb/mod.rs
+++ b/aptos-core/consensus/src/consensusdb/mod.rs
@@ -583,8 +583,9 @@ impl ConsensusDB {
         }
 
         // Step 5: Update the in-memory latest_ledger_info cache.
-        self.ledger_db.metadata_db().update_latest_ledger_info()
-            .map_err(|e| DbError::from(anyhow::anyhow!("Failed to update latest ledger info: {}", e)))?;
+        self.ledger_db.metadata_db().update_latest_ledger_info().map_err(|e| {
+            DbError::from(anyhow::anyhow!("Failed to update latest ledger info: {}", e))
+        })?;
 
         info!(
             "ConsensusDB::unwind_to_block complete: deleted {} blocks, \

--- a/aptos-core/consensus/src/consensusdb/mod.rs
+++ b/aptos-core/consensus/src/consensusdb/mod.rs
@@ -583,7 +583,8 @@ impl ConsensusDB {
         }
 
         // Step 5: Update the in-memory latest_ledger_info cache.
-        self.ledger_db.metadata_db().update_latest_ledger_info();
+        self.ledger_db.metadata_db().update_latest_ledger_info()
+            .map_err(|e| DbError::from(anyhow::anyhow!("Failed to update latest ledger info: {}", e)))?;
 
         info!(
             "ConsensusDB::unwind_to_block complete: deleted {} blocks, \

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -531,7 +531,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             // We request proof to join higher epoch
             Ordering::Greater => {
                 let epoch = self.epoch();
-                let sender = self.round_manager_tx.as_ref().unwrap();
+                let Some(sender) = self.round_manager_tx.as_ref() else {
+                    warn!("Received epoch change request from {} but Round Manager is not initialized", peer_id);
+                    return Ok(());
+                };
 
                 let event = VerifiedEvent::EpochChange(epoch);
                 if let Err(e) = sender.push((peer_id, discriminant(&event)), (peer_id, event)) {
@@ -1854,14 +1857,20 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         let self_epoch = self.epoch();
         match sync_info.epoch().cmp(&self_epoch) {
             Ordering::Greater => {
-                let sender = self.round_manager_tx.as_ref().unwrap();
+                let Some(sender) = self.round_manager_tx.as_ref() else {
+                    warn!("Received block sync epoch change from {} but Round Manager is not initialized", peer_id);
+                    return;
+                };
                 let event = VerifiedEvent::EpochChange(self_epoch);
                 if let Err(e) = sender.push((peer_id, discriminant(&event)), (peer_id, event)) {
                     error!("Failed to send event to round manager {:?}", e);
                 }
             }
             Ordering::Equal => {
-                let sender = self.round_manager_tx.as_ref().unwrap();
+                let Some(sender) = self.round_manager_tx.as_ref() else {
+                    warn!("Received block sync info from {} but Round Manager is not initialized", peer_id);
+                    return;
+                };
                 let event = VerifiedEvent::UnverifiedSyncInfo(sync_info);
                 if let Err(e) = sender.push((peer_id, discriminant(&event)), (peer_id, event)) {
                     error!("Failed to send event to round manager {:?}", e);

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -1868,7 +1868,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             }
             Ordering::Equal => {
                 let Some(sender) = self.round_manager_tx.as_ref() else {
-                    warn!("Received block sync info from {} but Round Manager is not initialized", peer_id);
+                    warn!(
+                        "Received block sync info from {} but Round Manager is not initialized",
+                        peer_id
+                    );
                     return;
                 };
                 let event = VerifiedEvent::UnverifiedSyncInfo(sync_info);

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -624,8 +624,8 @@ impl BufferManager {
                 if commit_info.round() >= self.latest_round {
                     // Limit the cache size to prevent OOM from unverified future votes
                     const MAX_COMMIT_VOTE_CACHE_ENTRIES: usize = 1000;
-                    if self.commit_vote_cache.len() < MAX_COMMIT_VOTE_CACHE_ENTRIES
-                        || self.commit_vote_cache.contains_key(&commit_info.id())
+                    if self.commit_vote_cache.len() < MAX_COMMIT_VOTE_CACHE_ENTRIES ||
+                        self.commit_vote_cache.contains_key(&commit_info.id())
                     {
                         self.commit_vote_cache
                             .entry(commit_info.id())

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -622,13 +622,21 @@ impl BufferManager {
                 let commit_info = vote.commit_info().clone();
                 info!("Receive commit vote {} from {}", commit_info, author);
                 if commit_info.round() >= self.latest_round {
-                    if !self.commit_vote_cache.contains_key(&commit_info.id()) {
-                        self.commit_vote_cache.insert(commit_info.id(), HashMap::new());
+                    // Limit the cache size to prevent OOM from unverified future votes
+                    const MAX_COMMIT_VOTE_CACHE_ENTRIES: usize = 1000;
+                    if self.commit_vote_cache.len() < MAX_COMMIT_VOTE_CACHE_ENTRIES
+                        || self.commit_vote_cache.contains_key(&commit_info.id())
+                    {
+                        self.commit_vote_cache
+                            .entry(commit_info.id())
+                            .or_default()
+                            .insert(HashValue::new(*author), vote.clone());
+                    } else {
+                        warn!(
+                            "Commit vote cache is full ({}), dropping vote from {}",
+                            MAX_COMMIT_VOTE_CACHE_ENTRIES, author
+                        );
                     }
-                    self.commit_vote_cache
-                        .get_mut(&commit_info.id())
-                        .unwrap()
-                        .insert(HashValue::new(*author), vote.clone());
                 }
                 let target_block_id = vote.commit_info().id();
                 let current_cursor =

--- a/crates/api/src/bootstrap.rs
+++ b/crates/api/src/bootstrap.rs
@@ -279,7 +279,7 @@ pub async fn init_block_buffer_manager(consensus_db: &Arc<ConsensusDB>, latest_b
     for epoch_i in (1..=max_epoch).rev() {
         let start_key = (epoch_i, HashValue::zero());
         let end_key = (epoch_i, HashValue::new([u8::MAX; HashValue::LENGTH]));
-        consensus_db
+        let results = consensus_db
             .get_range_with_filter::<BlockNumberSchema, _>(
                 &start_key,
                 &end_key,
@@ -287,22 +287,12 @@ pub async fn init_block_buffer_manager(consensus_db: &Arc<ConsensusDB>, latest_b
                     *block_number >= start_block_number && *block_number <= latest_block_number
                 },
             )
-            .unwrap()
-            .into_iter()
-            .for_each(|((epoch, block_id), block_number)| {
-                if !block_number_to_block_id.contains_key(&block_number) {
-                    block_number_to_block_id
-                        .insert(block_number, (epoch, BlockId::from_bytes(block_id.as_slice())));
-                } else {
-                    let (cur_epoch, _) = block_number_to_block_id.get(&block_number).unwrap();
-                    if *cur_epoch < epoch {
-                        block_number_to_block_id.insert(
-                            block_number,
-                            (epoch, BlockId::from_bytes(block_id.as_slice())),
-                        );
-                    }
-                }
-            });
+            .unwrap();
+        for ((epoch, block_id), block_number) in results {
+            block_number_to_block_id
+                .entry(block_number)
+                .or_insert_with(|| (epoch, BlockId::from_bytes(block_id.as_slice())));
+        }
         if block_number_to_block_id.len() >= (latest_block_number - start_block_number + 1) as usize
         {
             break;

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -289,13 +289,14 @@ impl BlockBufferManager {
         block_state_machine.current_epoch = initial_epoch;
         if !block_number_to_block_id_with_epoch.is_empty() {
             let Some(&(commit_block_epoch, commit_block_id)) =
-                block_number_to_block_id_with_epoch.get(&latest_commit_block_number) else {
-                    error!(
+                block_number_to_block_id_with_epoch.get(&latest_commit_block_number)
+            else {
+                error!(
                         "BlockBufferManager::init: latest_commit_block_number {} not found in block_number_to_block_id_with_epoch map",
                         latest_commit_block_number
                     );
-                    return;
-                };
+                return;
+            };
             block_state_machine.blocks.insert(
                 BlockKey::new(commit_block_epoch, latest_commit_block_number),
                 BlockState::Historical { id: commit_block_id },

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -20,7 +20,7 @@ use tokio::{
     time::Instant,
 };
 
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use gaptos::api_types::{
     compute_res::{ComputeRes, TxnStatus},
@@ -288,8 +288,14 @@ impl BlockBufferManager {
         // Initialize current_epoch from the parameter
         block_state_machine.current_epoch = initial_epoch;
         if !block_number_to_block_id_with_epoch.is_empty() {
-            let (commit_block_epoch, commit_block_id) =
-                *block_number_to_block_id_with_epoch.get(&latest_commit_block_number).unwrap();
+            let Some(&(commit_block_epoch, commit_block_id)) =
+                block_number_to_block_id_with_epoch.get(&latest_commit_block_number) else {
+                    error!(
+                        "BlockBufferManager::init: latest_commit_block_number {} not found in block_number_to_block_id_with_epoch map",
+                        latest_commit_block_number
+                    );
+                    return;
+                };
             block_state_machine.blocks.insert(
                 BlockKey::new(commit_block_epoch, latest_commit_block_number),
                 BlockState::Historical { id: commit_block_id },


### PR DESCRIPTION
Replace unwrap/unreachable panics with proper error handling across consensus modules to improve node resilience. Key changes:
- epoch_manager: guard round_manager_tx access during epoch transitions
- payload_manager: replace unreachable!() with error logging and graceful return
- buffer_manager: add commit vote cache size limit (1000) to prevent OOM
- ledger_metadata_db: propagate Result instead of expect/unwrap on DB reads
- block_buffer_manager: handle missing block_number gracefully in init
- bootstrap: simplify block_number_to_block_id population with entry API
- sync_manager: handle ledger info range query errors gracefully
