### PR TITLE
feat(sentinel): add bridge chain monitor for on-chain event surveillance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16950,6 +16950,12 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 name = "sentinel"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-sol-macro",
+ "alloy-sol-types",
+ "alloy-transport-http",
  "anyhow",
  "chrono",
  "csv",
@@ -16959,7 +16965,7 @@ dependencies = [
  "linemux",
  "log",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/bin/sentinel/Cargo.toml
+++ b/bin/sentinel/Cargo.toml
@@ -12,10 +12,18 @@ regex = "1.10"
 glob = "0.3"
 sha2 = "0.10"
 hex = "0.4"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 linemux = "0.3"
 anyhow = "1.0"
 chrono = "0.4"
 log = "0.4"
 env_logger = "0.10"
 csv.workspace = true
+
+# Chain monitor dependencies (alloy for Ethereum JSON-RPC)
+alloy-primitives = { version = "1.3.1", default-features = false, features = ["map-foldhash"] }
+alloy-provider = { version = "1.0.37", features = ["reqwest"], default-features = false }
+alloy-sol-types = { version = "1.3.1", default-features = false }
+alloy-sol-macro = "1.3.1"
+alloy-transport-http = { version = "1.0.37", features = ["reqwest-rustls-tls"], default-features = false }
+alloy-rpc-types = { version = "1.0.37", features = ["eth"], default-features = false }

--- a/bin/sentinel/src/chain_monitor/abi.rs
+++ b/bin/sentinel/src/chain_monitor/abi.rs
@@ -1,0 +1,46 @@
+//! ABI definitions for bridge contract events using alloy sol! macro.
+
+alloy_sol_macro::sol! {
+    // ========================================================================
+    // GBridgeSender events (Ethereum side)
+    // ========================================================================
+
+    event TokensLocked(address indexed from, address indexed recipient, uint256 amount, uint128 indexed nonce);
+    event EmergencyWithdraw(address indexed recipient, uint256 amount);
+    event ERC20Recovered(address indexed token, address indexed recipient, uint256 amount);
+
+    // ========================================================================
+    // GravityPortal events (Ethereum side)
+    // ========================================================================
+
+    event MessageSent(uint128 indexed nonce, uint256 indexed block_number, bytes payload);
+    event FeeConfigUpdated(uint256 baseFee, uint256 feePerByte);
+    event FeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+    event FeesWithdrawn(address indexed recipient, uint256 amount);
+
+    // ========================================================================
+    // GBridgeReceiver events (Gravity side)
+    // ========================================================================
+
+    event NativeMinted(address indexed recipient, uint256 amount, uint128 indexed nonce);
+
+    // ========================================================================
+    // NativeOracle events (Gravity side)
+    // ========================================================================
+
+    event CallbackFailed(uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, address callback, bytes reason);
+    event DataRecorded(uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, uint256 dataLength);
+
+    // ========================================================================
+    // OpenZeppelin Ownable2Step events
+    // ========================================================================
+
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    // ========================================================================
+    // ERC20 balanceOf for vault balance monitoring
+    // ========================================================================
+
+    function balanceOf(address account) external view returns (uint256);
+}

--- a/bin/sentinel/src/chain_monitor/bridge_timeout.rs
+++ b/bin/sentinel/src/chain_monitor/bridge_timeout.rs
@@ -154,8 +154,7 @@ impl BridgeTimeoutMonitor {
                 let mut ckpt = self.checkpoint.lock().unwrap();
                 ckpt.pending_nonces.insert(nonce, timestamp);
                 println!(
-                    "Bridge timeout: Tracking nonce {} (block {}, timestamp {})",
-                    nonce, block_number, timestamp
+                    "Bridge timeout: Tracking nonce {nonce} (block {block_number}, timestamp {timestamp})"
                 );
             }
         }
@@ -199,7 +198,7 @@ impl BridgeTimeoutMonitor {
                 let nonce = event.nonce;
                 let mut ckpt = self.checkpoint.lock().unwrap();
                 if ckpt.pending_nonces.remove(&nonce).is_some() {
-                    println!("Bridge timeout: Nonce {} confirmed on Gravity", nonce);
+                    println!("Bridge timeout: Nonce {nonce} confirmed on Gravity");
                 }
             }
         }

--- a/bin/sentinel/src/chain_monitor/bridge_timeout.rs
+++ b/bin/sentinel/src/chain_monitor/bridge_timeout.rs
@@ -1,0 +1,271 @@
+use crate::{
+    chain_monitor::{
+        abi::{NativeMinted, TokensLocked},
+        checkpoint::SharedCheckpoint,
+        config::BridgeTimeoutConfig,
+        provider::{self, HttpProvider},
+    },
+    config::Priority,
+    notifier::Notifier,
+};
+use alloy_primitives::Address;
+use alloy_provider::Provider;
+use alloy_rpc_types::Filter;
+use alloy_sol_types::SolEvent;
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+pub struct BridgeTimeoutMonitor {
+    config: BridgeTimeoutConfig,
+    gbridge_sender: Address,
+    gbridge_receiver: Address,
+    eth_provider: HttpProvider,
+    gravity_provider: HttpProvider,
+    notifier: Notifier,
+    checkpoint: SharedCheckpoint,
+    eth_poll_interval: Duration,
+    gravity_poll_interval: Duration,
+    confirmation_blocks: u64,
+    max_consecutive_failures: u32,
+}
+
+impl BridgeTimeoutMonitor {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        config: BridgeTimeoutConfig,
+        gbridge_sender: Address,
+        gbridge_receiver: Address,
+        eth_provider: HttpProvider,
+        gravity_provider: HttpProvider,
+        notifier: Notifier,
+        checkpoint: SharedCheckpoint,
+        eth_poll_interval: Duration,
+        confirmation_blocks: u64,
+        max_consecutive_failures: u32,
+    ) -> Self {
+        let gravity_poll_interval = Duration::from_secs(config.check_interval_seconds);
+        Self {
+            config,
+            gbridge_sender,
+            gbridge_receiver,
+            eth_provider,
+            gravity_provider,
+            notifier,
+            checkpoint,
+            eth_poll_interval,
+            gravity_poll_interval,
+            confirmation_blocks,
+            max_consecutive_failures,
+        }
+    }
+
+    pub async fn run(self) {
+        let mut eth_interval = tokio::time::interval(self.eth_poll_interval);
+        let mut gravity_interval = tokio::time::interval(self.gravity_poll_interval);
+        let mut timeout_interval =
+            tokio::time::interval(Duration::from_secs(self.config.check_interval_seconds));
+
+        let mut eth_failures: u32 = 0;
+        let mut gravity_failures: u32 = 0;
+
+        // Local cache of block timestamps to avoid repeated RPC calls
+        let mut block_timestamps: HashMap<u64, u64> = HashMap::new();
+
+        loop {
+            tokio::select! {
+                _ = eth_interval.tick() => {
+                    match self.poll_ethereum(&mut block_timestamps).await {
+                        Ok(()) => { eth_failures = 0; }
+                        Err(e) => {
+                            eth_failures += 1;
+                            eprintln!("Bridge timeout: Ethereum poll error ({eth_failures}): {e:?}");
+                            if eth_failures >= self.max_consecutive_failures {
+                                let msg = format!("Bridge timeout monitor lost Ethereum RPC ({eth_failures} failures)");
+                                let _ = self.notifier.alert(&msg, "CHAIN_MONITOR", Priority::P0).await;
+                                eth_failures = 0;
+                            }
+                        }
+                    }
+                }
+                _ = gravity_interval.tick() => {
+                    match self.poll_gravity().await {
+                        Ok(()) => { gravity_failures = 0; }
+                        Err(e) => {
+                            gravity_failures += 1;
+                            eprintln!("Bridge timeout: Gravity poll error ({gravity_failures}): {e:?}");
+                            if gravity_failures >= self.max_consecutive_failures {
+                                let msg = format!("Bridge timeout monitor lost Gravity RPC ({gravity_failures} failures)");
+                                let _ = self.notifier.alert(&msg, "CHAIN_MONITOR", Priority::P0).await;
+                                gravity_failures = 0;
+                            }
+                        }
+                    }
+                }
+                _ = timeout_interval.tick() => {
+                    self.check_timeouts().await;
+                }
+            }
+        }
+    }
+
+    /// Poll Ethereum for new TokensLocked events and record them as pending.
+    async fn poll_ethereum(
+        &self,
+        block_timestamps: &mut HashMap<u64, u64>,
+    ) -> anyhow::Result<()> {
+        let safe_block =
+            provider::get_safe_block_number(&self.eth_provider, self.confirmation_blocks).await?;
+        let from_block = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            if ckpt.ethereum_block == 0 {
+                safe_block
+            } else {
+                ckpt.ethereum_block + 1
+            }
+        };
+
+        if from_block > safe_block {
+            return Ok(());
+        }
+
+        let filter = Filter::new()
+            .address(self.gbridge_sender)
+            .event_signature(TokensLocked::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(safe_block);
+
+        let logs = provider::get_logs(&self.eth_provider, filter).await?;
+
+        for log in &logs {
+            if let Ok(event) = TokensLocked::decode_log_data(log.data()) {
+                let block_number = log.block_number.unwrap_or(0);
+
+                // Get block timestamp
+                let timestamp = if let Some(&ts) = block_timestamps.get(&block_number) {
+                    ts
+                } else {
+                    let ts = self.get_block_timestamp(block_number).await.unwrap_or_else(|_| {
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs()
+                    });
+                    block_timestamps.insert(block_number, ts);
+                    ts
+                };
+
+                let nonce = event.nonce;
+                let mut ckpt = self.checkpoint.lock().unwrap();
+                ckpt.pending_nonces.insert(nonce, timestamp);
+                println!(
+                    "Bridge timeout: Tracking nonce {} (block {}, timestamp {})",
+                    nonce, block_number, timestamp
+                );
+            }
+        }
+
+        // Update ethereum block cursor
+        {
+            let mut ckpt = self.checkpoint.lock().unwrap();
+            ckpt.ethereum_block = ckpt.ethereum_block.max(safe_block);
+        }
+
+        Ok(())
+    }
+
+    /// Poll Gravity for NativeMinted events and remove matched nonces from pending.
+    async fn poll_gravity(&self) -> anyhow::Result<()> {
+        // Gravity has finality, no confirmation blocks needed
+        let latest_block = self.gravity_provider.get_block_number().await?;
+        let from_block = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            if ckpt.gravity_block == 0 {
+                latest_block
+            } else {
+                ckpt.gravity_block + 1
+            }
+        };
+
+        if from_block > latest_block {
+            return Ok(());
+        }
+
+        let filter = Filter::new()
+            .address(self.gbridge_receiver)
+            .event_signature(NativeMinted::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(latest_block);
+
+        let logs = provider::get_logs(&self.gravity_provider, filter).await?;
+
+        for log in &logs {
+            if let Ok(event) = NativeMinted::decode_log_data(log.data()) {
+                let nonce = event.nonce;
+                let mut ckpt = self.checkpoint.lock().unwrap();
+                if ckpt.pending_nonces.remove(&nonce).is_some() {
+                    println!("Bridge timeout: Nonce {} confirmed on Gravity", nonce);
+                }
+            }
+        }
+
+        // Update gravity block cursor
+        {
+            let mut ckpt = self.checkpoint.lock().unwrap();
+            ckpt.gravity_block = ckpt.gravity_block.max(latest_block);
+        }
+
+        Ok(())
+    }
+
+    /// Check for timed-out nonces and alert.
+    async fn check_timeouts(&self) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let timed_out: Vec<(u128, u64)> = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            ckpt.pending_nonces
+                .iter()
+                .filter(|(_, &ts)| now.saturating_sub(ts) > self.config.timeout_seconds)
+                .map(|(&nonce, &ts)| (nonce, ts))
+                .collect()
+        };
+
+        for (nonce, timestamp) in &timed_out {
+            let elapsed = now.saturating_sub(*timestamp);
+            let msg = format!(
+                "Bridge transaction TIMEOUT!\nNonce: {nonce}\nLocked on Ethereum at: {} ({}s ago)\nNot yet confirmed on Gravity after {} seconds threshold\nInvestigate relay pipeline!",
+                *timestamp, elapsed, self.config.timeout_seconds
+            );
+            if let Err(e) = self
+                .notifier
+                .alert(&msg, "BRIDGE_TIMEOUT", self.config.priority)
+                .await
+            {
+                eprintln!("Failed to send bridge timeout alert: {e:?}");
+            }
+        }
+
+        // Remove alerted nonces to avoid repeated alerts
+        // (they'll re-alert if still pending after another timeout_seconds)
+        if !timed_out.is_empty() {
+            let mut ckpt = self.checkpoint.lock().unwrap();
+            for (nonce, _) in &timed_out {
+                ckpt.pending_nonces.remove(nonce);
+            }
+        }
+    }
+
+    async fn get_block_timestamp(&self, block_number: u64) -> anyhow::Result<u64> {
+        let block = self
+            .eth_provider
+            .get_block_by_number(block_number.into())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Block {block_number} not found"))?;
+        Ok(block.header.timestamp)
+    }
+}

--- a/bin/sentinel/src/chain_monitor/bridge_timeout.rs
+++ b/bin/sentinel/src/chain_monitor/bridge_timeout.rs
@@ -111,10 +111,7 @@ impl BridgeTimeoutMonitor {
     }
 
     /// Poll Ethereum for new TokensLocked events and record them as pending.
-    async fn poll_ethereum(
-        &self,
-        block_timestamps: &mut HashMap<u64, u64>,
-    ) -> anyhow::Result<()> {
+    async fn poll_ethereum(&self, block_timestamps: &mut HashMap<u64, u64>) -> anyhow::Result<()> {
         let safe_block =
             provider::get_safe_block_number(&self.eth_provider, self.confirmation_blocks).await?;
         let from_block = {
@@ -147,10 +144,7 @@ impl BridgeTimeoutMonitor {
                     ts
                 } else {
                     let ts = self.get_block_timestamp(block_number).await.unwrap_or_else(|_| {
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs()
+                        SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
                     });
                     block_timestamps.insert(block_number, ts);
                     ts
@@ -221,10 +215,7 @@ impl BridgeTimeoutMonitor {
 
     /// Check for timed-out nonces and alert.
     async fn check_timeouts(&self) {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
 
         let timed_out: Vec<(u128, u64)> = {
             let ckpt = self.checkpoint.lock().unwrap();
@@ -241,10 +232,7 @@ impl BridgeTimeoutMonitor {
                 "Bridge transaction TIMEOUT!\nNonce: {nonce}\nLocked on Ethereum at: {} ({}s ago)\nNot yet confirmed on Gravity after {} seconds threshold\nInvestigate relay pipeline!",
                 *timestamp, elapsed, self.config.timeout_seconds
             );
-            if let Err(e) = self
-                .notifier
-                .alert(&msg, "BRIDGE_TIMEOUT", self.config.priority)
-                .await
+            if let Err(e) = self.notifier.alert(&msg, "BRIDGE_TIMEOUT", self.config.priority).await
             {
                 eprintln!("Failed to send bridge timeout alert: {e:?}");
             }

--- a/bin/sentinel/src/chain_monitor/checkpoint.rs
+++ b/bin/sentinel/src/chain_monitor/checkpoint.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fs,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+/// Persistent state for chain monitors, saved as JSON.
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct Checkpoint {
+    /// Last scanned Ethereum block number
+    pub ethereum_block: u64,
+    /// Last scanned Gravity block number
+    pub gravity_block: u64,
+    /// Pending bridge nonces: nonce -> ethereum block timestamp (unix seconds)
+    pub pending_nonces: HashMap<u128, u64>,
+    /// Last known vault balance (decimal string for U256 precision)
+    pub last_vault_balance: Option<String>,
+}
+
+pub type SharedCheckpoint = Arc<Mutex<Checkpoint>>;
+
+impl Checkpoint {
+    /// Load checkpoint from file, or return default if file doesn't exist or is malformed.
+    pub fn load_or_default(path: Option<&str>) -> Result<Self> {
+        let Some(path) = path else {
+            return Ok(Self::default());
+        };
+
+        if !Path::new(path).exists() {
+            return Ok(Self::default());
+        }
+
+        match fs::read_to_string(path) {
+            Ok(content) => match serde_json::from_str(&content) {
+                Ok(ckpt) => {
+                    println!("Loaded checkpoint from {path}");
+                    Ok(ckpt)
+                }
+                Err(e) => {
+                    eprintln!("Warning: Failed to parse checkpoint file {path}: {e}, starting fresh");
+                    Ok(Self::default())
+                }
+            },
+            Err(e) => {
+                eprintln!("Warning: Failed to read checkpoint file {path}: {e}, starting fresh");
+                Ok(Self::default())
+            }
+        }
+    }
+
+    /// Save checkpoint to file using atomic write (temp file + rename).
+    pub fn save(&self, path: &str) -> Result<()> {
+        let tmp_path = format!("{path}.tmp");
+        let content = serde_json::to_string_pretty(self)?;
+        fs::write(&tmp_path, &content)?;
+        fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+}
+
+/// Background task that periodically flushes the checkpoint to disk.
+pub async fn flush_loop(checkpoint: SharedCheckpoint, path: String) {
+    let mut interval = tokio::time::interval(Duration::from_secs(10));
+    loop {
+        interval.tick().await;
+        let ckpt = checkpoint.lock().unwrap().clone();
+        if let Err(e) = ckpt.save(&path) {
+            eprintln!("Failed to save checkpoint: {e:?}");
+        }
+    }
+}

--- a/bin/sentinel/src/chain_monitor/checkpoint.rs
+++ b/bin/sentinel/src/chain_monitor/checkpoint.rs
@@ -41,7 +41,9 @@ impl Checkpoint {
                     Ok(ckpt)
                 }
                 Err(e) => {
-                    eprintln!("Warning: Failed to parse checkpoint file {path}: {e}, starting fresh");
+                    eprintln!(
+                        "Warning: Failed to parse checkpoint file {path}: {e}, starting fresh"
+                    );
                     Ok(Self::default())
                 }
             },

--- a/bin/sentinel/src/chain_monitor/config.rs
+++ b/bin/sentinel/src/chain_monitor/config.rs
@@ -189,6 +189,6 @@ impl ChainMonitorConfig {
     /// Parse an address string into an alloy Address.
     pub fn parse_address(s: &str) -> Result<alloy_primitives::Address> {
         s.parse::<alloy_primitives::Address>()
-            .map_err(|e| anyhow::anyhow!("Invalid address '{}': {}", s, e))
+            .map_err(|e| anyhow::anyhow!("Invalid address '{s}': {e}"))
     }
 }

--- a/bin/sentinel/src/chain_monitor/config.rs
+++ b/bin/sentinel/src/chain_monitor/config.rs
@@ -1,0 +1,201 @@
+use crate::config::Priority;
+use anyhow::Result;
+use serde::Deserialize;
+
+fn default_poll_interval() -> u64 {
+    12
+}
+
+fn default_confirmation_blocks() -> u64 {
+    2
+}
+
+fn default_max_consecutive_failures() -> u32 {
+    10
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_timeout_seconds() -> u64 {
+    1800
+}
+
+fn default_timeout_check_interval() -> u64 {
+    60
+}
+
+fn default_drop_percentage() -> f64 {
+    10.0
+}
+
+/// Top-level chain monitor configuration, added as optional field to sentinel Config.
+#[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
+pub struct ChainMonitorConfig {
+    /// Ethereum L1 RPC URL (where GBridgeSender + GravityPortal live)
+    pub ethereum_rpc_url: String,
+    /// Gravity chain RPC URL (where GBridgeReceiver + NativeOracle live)
+    pub gravity_rpc_url: String,
+
+    /// Contract addresses
+    pub gbridge_sender_address: String,
+    pub gravity_portal_address: String,
+    pub gbridge_receiver_address: String,
+    pub native_oracle_address: String,
+
+    /// Owner address to watch (Ownable2Step owner of bridge contracts)
+    pub owner_address: String,
+
+    /// ERC20 G token address on Ethereum (for vault balance tracking)
+    pub gtoken_address: String,
+
+    /// Polling interval for eth_getLogs (seconds)
+    #[serde(default = "default_poll_interval")]
+    pub poll_interval_seconds: u64,
+
+    /// Number of confirmation blocks for reorg safety on Ethereum
+    #[serde(default = "default_confirmation_blocks")]
+    pub confirmation_blocks: u64,
+
+    /// Fire a connectivity alert after this many consecutive RPC failures
+    #[serde(default = "default_max_consecutive_failures")]
+    pub max_consecutive_failures: u32,
+
+    /// Optional checkpoint file path for persisting block cursors across restarts
+    pub checkpoint_path: Option<String>,
+
+    // Per-rule configs
+    #[serde(default)]
+    pub large_withdrawal: LargeWithdrawalConfig,
+    #[serde(default)]
+    pub vault_balance: VaultBalanceConfig,
+    #[serde(default)]
+    pub bridge_timeout: BridgeTimeoutConfig,
+    #[serde(default)]
+    pub owner_activity: OwnerActivityConfig,
+    #[serde(default)]
+    pub timelock: TimelockConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct LargeWithdrawalConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Threshold in wei as a decimal string (e.g., "50000000000000000000" for 50 tokens)
+    #[serde(default = "default_large_withdrawal_threshold")]
+    pub threshold_wei: String,
+    #[serde(default)]
+    pub priority: Priority,
+}
+
+fn default_large_withdrawal_threshold() -> String {
+    "50000000000000000000".to_string() // 50 * 10^18
+}
+
+impl Default for LargeWithdrawalConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            threshold_wei: default_large_withdrawal_threshold(),
+            priority: Priority::P0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct VaultBalanceConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Alert if balance drops by more than this percentage in one poll cycle
+    #[serde(default = "default_drop_percentage")]
+    pub drop_percentage_threshold: f64,
+    /// Or absolute drop threshold in wei
+    #[serde(default = "default_large_withdrawal_threshold")]
+    pub drop_absolute_threshold_wei: String,
+    #[serde(default)]
+    pub priority: Priority,
+}
+
+impl Default for VaultBalanceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            drop_percentage_threshold: default_drop_percentage(),
+            drop_absolute_threshold_wei: default_large_withdrawal_threshold(),
+            priority: Priority::P0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BridgeTimeoutConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Max time (seconds) between TokensLocked on Ethereum and NativeMinted on Gravity
+    #[serde(default = "default_timeout_seconds")]
+    pub timeout_seconds: u64,
+    /// How often to scan for timed-out nonces (seconds)
+    #[serde(default = "default_timeout_check_interval")]
+    pub check_interval_seconds: u64,
+    #[serde(default)]
+    pub priority: Priority,
+}
+
+impl Default for BridgeTimeoutConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            timeout_seconds: default_timeout_seconds(),
+            check_interval_seconds: default_timeout_check_interval(),
+            priority: Priority::P0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct OwnerActivityConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub priority: Priority,
+}
+
+impl Default for OwnerActivityConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            priority: Priority::P0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TimelockConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub priority: Priority,
+    /// Expected governance/multisig address. If owner calls privileged functions
+    /// from a different address, trigger a GOVERNANCE BYPASS alert.
+    pub expected_governance_address: Option<String>,
+}
+
+impl Default for TimelockConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            priority: Priority::P0,
+            expected_governance_address: None,
+        }
+    }
+}
+
+impl ChainMonitorConfig {
+    /// Parse an address string into an alloy Address.
+    pub fn parse_address(s: &str) -> Result<alloy_primitives::Address> {
+        s.parse::<alloy_primitives::Address>()
+            .map_err(|e| anyhow::anyhow!("Invalid address '{}': {}", s, e))
+    }
+}

--- a/bin/sentinel/src/chain_monitor/config.rs
+++ b/bin/sentinel/src/chain_monitor/config.rs
@@ -164,10 +164,7 @@ pub struct OwnerActivityConfig {
 
 impl Default for OwnerActivityConfig {
     fn default() -> Self {
-        Self {
-            enabled: true,
-            priority: Priority::P0,
-        }
+        Self { enabled: true, priority: Priority::P0 }
     }
 }
 
@@ -184,11 +181,7 @@ pub struct TimelockConfig {
 
 impl Default for TimelockConfig {
     fn default() -> Self {
-        Self {
-            enabled: true,
-            priority: Priority::P0,
-            expected_governance_address: None,
-        }
+        Self { enabled: true, priority: Priority::P0, expected_governance_address: None }
     }
 }
 

--- a/bin/sentinel/src/chain_monitor/large_withdrawal.rs
+++ b/bin/sentinel/src/chain_monitor/large_withdrawal.rs
@@ -152,10 +152,8 @@ impl LargeWithdrawalMonitor {
                     "CRITICAL: EmergencyWithdraw called on GBridgeSender!\nRecipient: {}\nAmount: {} tokens ({} wei)\nThis drains the vault - investigate immediately!",
                     event.recipient, amount_eth, event.amount
                 );
-                if let Err(e) = self
-                    .notifier
-                    .alert(&msg, "BRIDGE_EMERGENCY_WITHDRAW", Priority::P0)
-                    .await
+                if let Err(e) =
+                    self.notifier.alert(&msg, "BRIDGE_EMERGENCY_WITHDRAW", Priority::P0).await
                 {
                     eprintln!("Failed to send emergency withdraw alert: {e:?}");
                 }

--- a/bin/sentinel/src/chain_monitor/large_withdrawal.rs
+++ b/bin/sentinel/src/chain_monitor/large_withdrawal.rs
@@ -1,0 +1,181 @@
+use crate::{
+    chain_monitor::{
+        abi::{EmergencyWithdraw, TokensLocked},
+        checkpoint::SharedCheckpoint,
+        config::LargeWithdrawalConfig,
+        provider::{self, HttpProvider},
+    },
+    config::Priority,
+    notifier::Notifier,
+};
+use alloy_primitives::{Address, U256};
+use alloy_rpc_types::Filter;
+use alloy_sol_types::SolEvent;
+use std::time::Duration;
+
+pub struct LargeWithdrawalMonitor {
+    config: LargeWithdrawalConfig,
+    gbridge_sender: Address,
+    threshold: U256,
+    provider: HttpProvider,
+    notifier: Notifier,
+    checkpoint: SharedCheckpoint,
+    poll_interval: Duration,
+    confirmation_blocks: u64,
+    max_consecutive_failures: u32,
+}
+
+impl LargeWithdrawalMonitor {
+    pub fn new(
+        config: LargeWithdrawalConfig,
+        gbridge_sender: Address,
+        provider: HttpProvider,
+        notifier: Notifier,
+        checkpoint: SharedCheckpoint,
+        poll_interval: Duration,
+        confirmation_blocks: u64,
+        max_consecutive_failures: u32,
+    ) -> anyhow::Result<Self> {
+        let threshold = config
+            .threshold_wei
+            .parse::<U256>()
+            .map_err(|e| anyhow::anyhow!("Invalid threshold_wei: {e}"))?;
+
+        Ok(Self {
+            config,
+            gbridge_sender,
+            threshold,
+            provider,
+            notifier,
+            checkpoint,
+            poll_interval,
+            confirmation_blocks,
+            max_consecutive_failures,
+        })
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(self.poll_interval);
+        let mut consecutive_failures: u32 = 0;
+        let mut backoff = Duration::from_secs(1);
+
+        loop {
+            interval.tick().await;
+
+            match self.poll_once().await {
+                Ok(()) => {
+                    consecutive_failures = 0;
+                    backoff = Duration::from_secs(1);
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    eprintln!(
+                        "Large withdrawal monitor error (failures: {consecutive_failures}): {e:?}"
+                    );
+
+                    if consecutive_failures >= self.max_consecutive_failures {
+                        let msg = format!(
+                            "Chain monitor lost connectivity to Ethereum RPC ({consecutive_failures} consecutive failures). Last error: {e}"
+                        );
+                        if let Err(alert_err) =
+                            self.notifier.alert(&msg, "CHAIN_MONITOR", Priority::P0).await
+                        {
+                            eprintln!("Failed to send connectivity alert: {alert_err:?}");
+                        }
+                        consecutive_failures = 0;
+                    }
+
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    async fn poll_once(&self) -> anyhow::Result<()> {
+        let safe_block =
+            provider::get_safe_block_number(&self.provider, self.confirmation_blocks).await?;
+        let from_block = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            if ckpt.ethereum_block == 0 {
+                safe_block // Start from current block on first run
+            } else {
+                ckpt.ethereum_block + 1
+            }
+        };
+
+        if from_block > safe_block {
+            return Ok(()); // No new blocks
+        }
+
+        // Fetch TokensLocked events
+        let tokens_locked_filter = Filter::new()
+            .address(self.gbridge_sender)
+            .event_signature(TokensLocked::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(safe_block);
+
+        let locked_logs = provider::get_logs(&self.provider, tokens_locked_filter).await?;
+
+        for log in &locked_logs {
+            if let Ok(event) = TokensLocked::decode_log_data(log.data()) {
+                if event.amount >= self.threshold {
+                    let amount_eth = format_wei_to_eth(event.amount);
+                    let msg = format!(
+                        "Large withdrawal detected!\nFrom: {}\nRecipient: {}\nAmount: {} tokens ({} wei)\nNonce: {}",
+                        event.from, event.recipient, amount_eth, event.amount, event.nonce
+                    );
+                    if let Err(e) = self
+                        .notifier
+                        .alert(&msg, "BRIDGE_LARGE_WITHDRAWAL", self.config.priority)
+                        .await
+                    {
+                        eprintln!("Failed to send large withdrawal alert: {e:?}");
+                    }
+                }
+            }
+        }
+
+        // Fetch EmergencyWithdraw events - ALWAYS P0 regardless of amount
+        let emergency_filter = Filter::new()
+            .address(self.gbridge_sender)
+            .event_signature(EmergencyWithdraw::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(safe_block);
+
+        let emergency_logs = provider::get_logs(&self.provider, emergency_filter).await?;
+
+        for log in &emergency_logs {
+            if let Ok(event) = EmergencyWithdraw::decode_log_data(log.data()) {
+                let amount_eth = format_wei_to_eth(event.amount);
+                let msg = format!(
+                    "CRITICAL: EmergencyWithdraw called on GBridgeSender!\nRecipient: {}\nAmount: {} tokens ({} wei)\nThis drains the vault - investigate immediately!",
+                    event.recipient, amount_eth, event.amount
+                );
+                if let Err(e) = self
+                    .notifier
+                    .alert(&msg, "BRIDGE_EMERGENCY_WITHDRAW", Priority::P0)
+                    .await
+                {
+                    eprintln!("Failed to send emergency withdraw alert: {e:?}");
+                }
+            }
+        }
+
+        // Update checkpoint
+        {
+            let mut ckpt = self.checkpoint.lock().unwrap();
+            ckpt.ethereum_block = ckpt.ethereum_block.max(safe_block);
+        }
+
+        Ok(())
+    }
+}
+
+/// Format a U256 wei value to a human-readable ETH-like string.
+fn format_wei_to_eth(wei: U256) -> String {
+    let divisor = U256::from(10u64.pow(18));
+    let whole = wei / divisor;
+    let remainder = wei % divisor;
+    format!("{}.{:0>18}", whole, remainder).trim_end_matches('0').trim_end_matches('.').to_string()
+}

--- a/bin/sentinel/src/chain_monitor/large_withdrawal.rs
+++ b/bin/sentinel/src/chain_monitor/large_withdrawal.rs
@@ -26,6 +26,7 @@ pub struct LargeWithdrawalMonitor {
 }
 
 impl LargeWithdrawalMonitor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: LargeWithdrawalConfig,
         gbridge_sender: Address,
@@ -175,5 +176,5 @@ fn format_wei_to_eth(wei: U256) -> String {
     let divisor = U256::from(10u64.pow(18));
     let whole = wei / divisor;
     let remainder = wei % divisor;
-    format!("{}.{:0>18}", whole, remainder).trim_end_matches('0').trim_end_matches('.').to_string()
+    format!("{whole}.{remainder:0>18}").trim_end_matches('0').trim_end_matches('.').to_string()
 }

--- a/bin/sentinel/src/chain_monitor/mod.rs
+++ b/bin/sentinel/src/chain_monitor/mod.rs
@@ -1,0 +1,153 @@
+//! Chain monitor module for monitoring bridge contract events on-chain.
+//!
+//! Each monitor runs as an independent tokio task, following the same pattern
+//! as the existing Probe module.
+
+pub mod abi;
+pub mod bridge_timeout;
+pub mod checkpoint;
+pub mod config;
+pub mod large_withdrawal;
+pub mod owner_activity;
+pub mod provider;
+pub mod timelock;
+pub mod vault_balance;
+
+use crate::notifier::Notifier;
+use anyhow::{Context, Result};
+use checkpoint::{Checkpoint, SharedCheckpoint};
+use config::ChainMonitorConfig;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Spawn all enabled chain monitor tasks.
+pub async fn spawn_all(config: ChainMonitorConfig, notifier: Notifier) -> Result<()> {
+    // Build providers
+    let eth_provider = provider::build_provider(&config.ethereum_rpc_url)
+        .context("Failed to build Ethereum provider")?;
+    let gravity_provider = provider::build_provider(&config.gravity_rpc_url)
+        .context("Failed to build Gravity provider")?;
+
+    // Parse addresses
+    let gbridge_sender = ChainMonitorConfig::parse_address(&config.gbridge_sender_address)?;
+    let gravity_portal = ChainMonitorConfig::parse_address(&config.gravity_portal_address)?;
+    let gbridge_receiver = ChainMonitorConfig::parse_address(&config.gbridge_receiver_address)?;
+    let gtoken_address = ChainMonitorConfig::parse_address(&config.gtoken_address)?;
+
+    // Load or create checkpoint
+    let checkpoint: SharedCheckpoint = Arc::new(Mutex::new(
+        Checkpoint::load_or_default(config.checkpoint_path.as_deref())?,
+    ));
+
+    let poll_interval = Duration::from_secs(config.poll_interval_seconds);
+    let confirmation_blocks = config.confirmation_blocks;
+    let max_failures = config.max_consecutive_failures;
+
+    // Spawn checkpoint flusher if path is configured
+    if let Some(ref path) = config.checkpoint_path {
+        let ckpt = checkpoint.clone();
+        let path = path.clone();
+        tokio::spawn(async move {
+            checkpoint::flush_loop(ckpt, path).await;
+        });
+    }
+
+    // Rule 1: Large Withdrawal
+    if config.large_withdrawal.enabled {
+        let monitor = large_withdrawal::LargeWithdrawalMonitor::new(
+            config.large_withdrawal.clone(),
+            gbridge_sender,
+            eth_provider.clone(),
+            notifier.clone(),
+            checkpoint.clone(),
+            poll_interval,
+            confirmation_blocks,
+            max_failures,
+        )?;
+        println!("Starting chain monitor: large withdrawal (threshold: {} wei)", config.large_withdrawal.threshold_wei);
+        tokio::spawn(async move { monitor.run().await });
+    }
+
+    // Rule 2: Vault Balance
+    if config.vault_balance.enabled {
+        let monitor = vault_balance::VaultBalanceMonitor::new(
+            config.vault_balance.clone(),
+            gtoken_address,
+            gbridge_sender,
+            eth_provider.clone(),
+            notifier.clone(),
+            checkpoint.clone(),
+            poll_interval,
+            max_failures,
+        )?;
+        println!("Starting chain monitor: vault balance");
+        tokio::spawn(async move { monitor.run().await });
+    }
+
+    // Rule 3: Bridge Timeout
+    if config.bridge_timeout.enabled {
+        let monitor = bridge_timeout::BridgeTimeoutMonitor::new(
+            config.bridge_timeout.clone(),
+            gbridge_sender,
+            gbridge_receiver,
+            eth_provider.clone(),
+            gravity_provider.clone(),
+            notifier.clone(),
+            checkpoint.clone(),
+            poll_interval,
+            confirmation_blocks,
+            max_failures,
+        );
+        println!(
+            "Starting chain monitor: bridge timeout ({}s threshold)",
+            config.bridge_timeout.timeout_seconds
+        );
+        tokio::spawn(async move { monitor.run().await });
+    }
+
+    // Rule 4: Owner Activity
+    if config.owner_activity.enabled {
+        let monitor = owner_activity::OwnerActivityMonitor::new(
+            config.owner_activity.clone(),
+            gbridge_sender,
+            gravity_portal,
+            eth_provider.clone(),
+            notifier.clone(),
+            checkpoint.clone(),
+            poll_interval,
+            confirmation_blocks,
+            max_failures,
+        );
+        println!("Starting chain monitor: owner activity");
+        tokio::spawn(async move { monitor.run().await });
+    }
+
+    // Rule 5: Timelock / Ownership
+    if config.timelock.enabled {
+        let expected_governance = config
+            .timelock
+            .expected_governance_address
+            .as_ref()
+            .map(|addr| ChainMonitorConfig::parse_address(addr))
+            .transpose()?;
+
+        let watched_contracts = vec![gbridge_sender, gravity_portal];
+
+        let monitor = timelock::TimelockMonitor::new(
+            config.timelock.clone(),
+            watched_contracts,
+            gbridge_sender,
+            expected_governance,
+            eth_provider.clone(),
+            notifier.clone(),
+            checkpoint.clone(),
+            poll_interval,
+            confirmation_blocks,
+            max_failures,
+        );
+        println!("Starting chain monitor: timelock/ownership");
+        tokio::spawn(async move { monitor.run().await });
+    }
+
+    Ok(())
+}

--- a/bin/sentinel/src/chain_monitor/mod.rs
+++ b/bin/sentinel/src/chain_monitor/mod.rs
@@ -17,8 +17,10 @@ use crate::notifier::Notifier;
 use anyhow::{Context, Result};
 use checkpoint::{Checkpoint, SharedCheckpoint};
 use config::ChainMonitorConfig;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 /// Spawn all enabled chain monitor tasks.
 pub async fn spawn_all(config: ChainMonitorConfig, notifier: Notifier) -> Result<()> {
@@ -35,9 +37,8 @@ pub async fn spawn_all(config: ChainMonitorConfig, notifier: Notifier) -> Result
     let gtoken_address = ChainMonitorConfig::parse_address(&config.gtoken_address)?;
 
     // Load or create checkpoint
-    let checkpoint: SharedCheckpoint = Arc::new(Mutex::new(
-        Checkpoint::load_or_default(config.checkpoint_path.as_deref())?,
-    ));
+    let checkpoint: SharedCheckpoint =
+        Arc::new(Mutex::new(Checkpoint::load_or_default(config.checkpoint_path.as_deref())?));
 
     let poll_interval = Duration::from_secs(config.poll_interval_seconds);
     let confirmation_blocks = config.confirmation_blocks;
@@ -64,7 +65,10 @@ pub async fn spawn_all(config: ChainMonitorConfig, notifier: Notifier) -> Result
             confirmation_blocks,
             max_failures,
         )?;
-        println!("Starting chain monitor: large withdrawal (threshold: {} wei)", config.large_withdrawal.threshold_wei);
+        println!(
+            "Starting chain monitor: large withdrawal (threshold: {} wei)",
+            config.large_withdrawal.threshold_wei
+        );
         tokio::spawn(async move { monitor.run().await });
     }
 

--- a/bin/sentinel/src/chain_monitor/owner_activity.rs
+++ b/bin/sentinel/src/chain_monitor/owner_activity.rs
@@ -1,8 +1,7 @@
 use crate::{
     chain_monitor::{
         abi::{
-            ERC20Recovered, EmergencyWithdraw, FeeConfigUpdated, FeeRecipientUpdated,
-            FeesWithdrawn,
+            ERC20Recovered, EmergencyWithdraw, FeeConfigUpdated, FeeRecipientUpdated, FeesWithdrawn,
         },
         checkpoint::SharedCheckpoint,
         config::OwnerActivityConfig,
@@ -77,10 +76,7 @@ impl OwnerActivityMonitor {
                         let msg = format!(
                             "Owner activity monitor lost RPC connectivity ({consecutive_failures} failures)"
                         );
-                        let _ = self
-                            .notifier
-                            .alert(&msg, "CHAIN_MONITOR", Priority::P0)
-                            .await;
+                        let _ = self.notifier.alert(&msg, "CHAIN_MONITOR", Priority::P0).await;
                         consecutive_failures = 0;
                     }
 
@@ -119,11 +115,7 @@ impl OwnerActivityMonitor {
         Ok(())
     }
 
-    async fn check_emergency_withdraw(
-        &self,
-        from_block: u64,
-        to_block: u64,
-    ) -> anyhow::Result<()> {
+    async fn check_emergency_withdraw(&self, from_block: u64, to_block: u64) -> anyhow::Result<()> {
         let filter = Filter::new()
             .address(self.gbridge_sender)
             .event_signature(EmergencyWithdraw::SIGNATURE_HASH)
@@ -137,20 +129,13 @@ impl OwnerActivityMonitor {
                     "OWNER ACTIVITY: EmergencyWithdraw called!\nRecipient: {}\nAmount: {} wei\nContract: GBridgeSender ({})",
                     event.recipient, event.amount, self.gbridge_sender
                 );
-                let _ = self
-                    .notifier
-                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
-                    .await;
+                let _ = self.notifier.alert(&msg, "OWNER_ACTIVITY", self.config.priority).await;
             }
         }
         Ok(())
     }
 
-    async fn check_erc20_recovered(
-        &self,
-        from_block: u64,
-        to_block: u64,
-    ) -> anyhow::Result<()> {
+    async fn check_erc20_recovered(&self, from_block: u64, to_block: u64) -> anyhow::Result<()> {
         let filter = Filter::new()
             .address(self.gbridge_sender)
             .event_signature(ERC20Recovered::SIGNATURE_HASH)
@@ -164,20 +149,13 @@ impl OwnerActivityMonitor {
                     "OWNER ACTIVITY: ERC20Recovered called!\nToken: {}\nRecipient: {}\nAmount: {} wei\nContract: GBridgeSender ({})",
                     event.token, event.recipient, event.amount, self.gbridge_sender
                 );
-                let _ = self
-                    .notifier
-                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
-                    .await;
+                let _ = self.notifier.alert(&msg, "OWNER_ACTIVITY", self.config.priority).await;
             }
         }
         Ok(())
     }
 
-    async fn check_fee_config_updated(
-        &self,
-        from_block: u64,
-        to_block: u64,
-    ) -> anyhow::Result<()> {
+    async fn check_fee_config_updated(&self, from_block: u64, to_block: u64) -> anyhow::Result<()> {
         let filter = Filter::new()
             .address(self.gravity_portal)
             .event_signature(FeeConfigUpdated::SIGNATURE_HASH)
@@ -191,10 +169,7 @@ impl OwnerActivityMonitor {
                     "OWNER ACTIVITY: FeeConfigUpdated!\nBaseFee: {} wei\nFeePerByte: {} wei\nContract: GravityPortal ({})",
                     event.baseFee, event.feePerByte, self.gravity_portal
                 );
-                let _ = self
-                    .notifier
-                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
-                    .await;
+                let _ = self.notifier.alert(&msg, "OWNER_ACTIVITY", self.config.priority).await;
             }
         }
         Ok(())
@@ -218,20 +193,13 @@ impl OwnerActivityMonitor {
                     "OWNER ACTIVITY: FeeRecipientUpdated!\nOld: {}\nNew: {}\nContract: GravityPortal ({})",
                     event.oldRecipient, event.newRecipient, self.gravity_portal
                 );
-                let _ = self
-                    .notifier
-                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
-                    .await;
+                let _ = self.notifier.alert(&msg, "OWNER_ACTIVITY", self.config.priority).await;
             }
         }
         Ok(())
     }
 
-    async fn check_fees_withdrawn(
-        &self,
-        from_block: u64,
-        to_block: u64,
-    ) -> anyhow::Result<()> {
+    async fn check_fees_withdrawn(&self, from_block: u64, to_block: u64) -> anyhow::Result<()> {
         let filter = Filter::new()
             .address(self.gravity_portal)
             .event_signature(FeesWithdrawn::SIGNATURE_HASH)
@@ -245,10 +213,7 @@ impl OwnerActivityMonitor {
                     "OWNER ACTIVITY: FeesWithdrawn!\nRecipient: {}\nAmount: {} wei\nContract: GravityPortal ({})",
                     event.recipient, event.amount, self.gravity_portal
                 );
-                let _ = self
-                    .notifier
-                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
-                    .await;
+                let _ = self.notifier.alert(&msg, "OWNER_ACTIVITY", self.config.priority).await;
             }
         }
         Ok(())

--- a/bin/sentinel/src/chain_monitor/owner_activity.rs
+++ b/bin/sentinel/src/chain_monitor/owner_activity.rs
@@ -1,0 +1,256 @@
+use crate::{
+    chain_monitor::{
+        abi::{
+            ERC20Recovered, EmergencyWithdraw, FeeConfigUpdated, FeeRecipientUpdated,
+            FeesWithdrawn,
+        },
+        checkpoint::SharedCheckpoint,
+        config::OwnerActivityConfig,
+        provider::{self, HttpProvider},
+    },
+    config::Priority,
+    notifier::Notifier,
+};
+use alloy_primitives::Address;
+use alloy_rpc_types::Filter;
+use alloy_sol_types::SolEvent;
+use std::time::Duration;
+
+pub struct OwnerActivityMonitor {
+    config: OwnerActivityConfig,
+    gbridge_sender: Address,
+    gravity_portal: Address,
+    provider: HttpProvider,
+    notifier: Notifier,
+    checkpoint: SharedCheckpoint,
+    poll_interval: Duration,
+    confirmation_blocks: u64,
+    max_consecutive_failures: u32,
+}
+
+impl OwnerActivityMonitor {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        config: OwnerActivityConfig,
+        gbridge_sender: Address,
+        gravity_portal: Address,
+        provider: HttpProvider,
+        notifier: Notifier,
+        checkpoint: SharedCheckpoint,
+        poll_interval: Duration,
+        confirmation_blocks: u64,
+        max_consecutive_failures: u32,
+    ) -> Self {
+        Self {
+            config,
+            gbridge_sender,
+            gravity_portal,
+            provider,
+            notifier,
+            checkpoint,
+            poll_interval,
+            confirmation_blocks,
+            max_consecutive_failures,
+        }
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(self.poll_interval);
+        let mut consecutive_failures: u32 = 0;
+        let mut backoff = Duration::from_secs(1);
+
+        loop {
+            interval.tick().await;
+
+            match self.poll_once().await {
+                Ok(()) => {
+                    consecutive_failures = 0;
+                    backoff = Duration::from_secs(1);
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    eprintln!(
+                        "Owner activity monitor error (failures: {consecutive_failures}): {e:?}"
+                    );
+
+                    if consecutive_failures >= self.max_consecutive_failures {
+                        let msg = format!(
+                            "Owner activity monitor lost RPC connectivity ({consecutive_failures} failures)"
+                        );
+                        let _ = self
+                            .notifier
+                            .alert(&msg, "CHAIN_MONITOR", Priority::P0)
+                            .await;
+                        consecutive_failures = 0;
+                    }
+
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    async fn poll_once(&self) -> anyhow::Result<()> {
+        let safe_block =
+            provider::get_safe_block_number(&self.provider, self.confirmation_blocks).await?;
+        let from_block = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            if ckpt.ethereum_block == 0 {
+                safe_block
+            } else {
+                ckpt.ethereum_block + 1
+            }
+        };
+
+        if from_block > safe_block {
+            return Ok(());
+        }
+
+        // Monitor GBridgeSender privileged events
+        self.check_emergency_withdraw(from_block, safe_block).await?;
+        self.check_erc20_recovered(from_block, safe_block).await?;
+
+        // Monitor GravityPortal privileged events
+        self.check_fee_config_updated(from_block, safe_block).await?;
+        self.check_fee_recipient_updated(from_block, safe_block).await?;
+        self.check_fees_withdrawn(from_block, safe_block).await?;
+
+        Ok(())
+    }
+
+    async fn check_emergency_withdraw(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        let filter = Filter::new()
+            .address(self.gbridge_sender)
+            .event_signature(EmergencyWithdraw::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = provider::get_logs(&self.provider, filter).await?;
+        for log in &logs {
+            if let Ok(event) = EmergencyWithdraw::decode_log_data(log.data()) {
+                let msg = format!(
+                    "OWNER ACTIVITY: EmergencyWithdraw called!\nRecipient: {}\nAmount: {} wei\nContract: GBridgeSender ({})",
+                    event.recipient, event.amount, self.gbridge_sender
+                );
+                let _ = self
+                    .notifier
+                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_erc20_recovered(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        let filter = Filter::new()
+            .address(self.gbridge_sender)
+            .event_signature(ERC20Recovered::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = provider::get_logs(&self.provider, filter).await?;
+        for log in &logs {
+            if let Ok(event) = ERC20Recovered::decode_log_data(log.data()) {
+                let msg = format!(
+                    "OWNER ACTIVITY: ERC20Recovered called!\nToken: {}\nRecipient: {}\nAmount: {} wei\nContract: GBridgeSender ({})",
+                    event.token, event.recipient, event.amount, self.gbridge_sender
+                );
+                let _ = self
+                    .notifier
+                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_fee_config_updated(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        let filter = Filter::new()
+            .address(self.gravity_portal)
+            .event_signature(FeeConfigUpdated::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = provider::get_logs(&self.provider, filter).await?;
+        for log in &logs {
+            if let Ok(event) = FeeConfigUpdated::decode_log_data(log.data()) {
+                let msg = format!(
+                    "OWNER ACTIVITY: FeeConfigUpdated!\nBaseFee: {} wei\nFeePerByte: {} wei\nContract: GravityPortal ({})",
+                    event.baseFee, event.feePerByte, self.gravity_portal
+                );
+                let _ = self
+                    .notifier
+                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_fee_recipient_updated(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        let filter = Filter::new()
+            .address(self.gravity_portal)
+            .event_signature(FeeRecipientUpdated::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = provider::get_logs(&self.provider, filter).await?;
+        for log in &logs {
+            if let Ok(event) = FeeRecipientUpdated::decode_log_data(log.data()) {
+                let msg = format!(
+                    "OWNER ACTIVITY: FeeRecipientUpdated!\nOld: {}\nNew: {}\nContract: GravityPortal ({})",
+                    event.oldRecipient, event.newRecipient, self.gravity_portal
+                );
+                let _ = self
+                    .notifier
+                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_fees_withdrawn(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        let filter = Filter::new()
+            .address(self.gravity_portal)
+            .event_signature(FeesWithdrawn::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = provider::get_logs(&self.provider, filter).await?;
+        for log in &logs {
+            if let Ok(event) = FeesWithdrawn::decode_log_data(log.data()) {
+                let msg = format!(
+                    "OWNER ACTIVITY: FeesWithdrawn!\nRecipient: {}\nAmount: {} wei\nContract: GravityPortal ({})",
+                    event.recipient, event.amount, self.gravity_portal
+                );
+                let _ = self
+                    .notifier
+                    .alert(&msg, "OWNER_ACTIVITY", self.config.priority)
+                    .await;
+            }
+        }
+        Ok(())
+    }
+}

--- a/bin/sentinel/src/chain_monitor/provider.rs
+++ b/bin/sentinel/src/chain_monitor/provider.rs
@@ -1,0 +1,48 @@
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::Filter;
+use anyhow::Result;
+
+// Use the full filler type returned by `connect_http`.
+pub type HttpProvider = alloy_provider::fillers::FillProvider<
+    alloy_provider::fillers::JoinFill<
+        alloy_provider::Identity,
+        alloy_provider::fillers::JoinFill<
+            alloy_provider::fillers::GasFiller,
+            alloy_provider::fillers::JoinFill<
+                alloy_provider::fillers::BlobGasFiller,
+                alloy_provider::fillers::JoinFill<
+                    alloy_provider::fillers::NonceFiller,
+                    alloy_provider::fillers::ChainIdFiller,
+                >,
+            >,
+        >,
+    >,
+    alloy_provider::RootProvider,
+>;
+
+/// Build an alloy HTTP provider for the given RPC URL.
+pub fn build_provider(rpc_url: &str) -> Result<HttpProvider> {
+    let url = rpc_url
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid RPC URL '{}': {}", rpc_url, e))?;
+    let provider = ProviderBuilder::new().connect_http(url);
+    Ok(provider)
+}
+
+/// Get the latest block number, with optional confirmation offset for reorg safety.
+pub async fn get_safe_block_number(
+    provider: &HttpProvider,
+    confirmation_blocks: u64,
+) -> Result<u64> {
+    let latest = provider.get_block_number().await?;
+    Ok(latest.saturating_sub(confirmation_blocks))
+}
+
+/// Fetch logs matching the given filter.
+pub async fn get_logs(
+    provider: &HttpProvider,
+    filter: Filter,
+) -> Result<Vec<alloy_rpc_types::Log>> {
+    let logs = provider.get_logs(&filter).await?;
+    Ok(logs)
+}

--- a/bin/sentinel/src/chain_monitor/provider.rs
+++ b/bin/sentinel/src/chain_monitor/provider.rs
@@ -23,7 +23,7 @@ pub type HttpProvider = alloy_provider::fillers::FillProvider<
 /// Build an alloy HTTP provider for the given RPC URL.
 pub fn build_provider(rpc_url: &str) -> Result<HttpProvider> {
     let url =
-        rpc_url.parse().map_err(|e| anyhow::anyhow!("Invalid RPC URL '{}': {}", rpc_url, e))?;
+        rpc_url.parse().map_err(|e| anyhow::anyhow!("Invalid RPC URL '{rpc_url}': {e}"))?;
     let provider = ProviderBuilder::new().connect_http(url);
     Ok(provider)
 }

--- a/bin/sentinel/src/chain_monitor/provider.rs
+++ b/bin/sentinel/src/chain_monitor/provider.rs
@@ -22,8 +22,7 @@ pub type HttpProvider = alloy_provider::fillers::FillProvider<
 
 /// Build an alloy HTTP provider for the given RPC URL.
 pub fn build_provider(rpc_url: &str) -> Result<HttpProvider> {
-    let url =
-        rpc_url.parse().map_err(|e| anyhow::anyhow!("Invalid RPC URL '{rpc_url}': {e}"))?;
+    let url = rpc_url.parse().map_err(|e| anyhow::anyhow!("Invalid RPC URL '{rpc_url}': {e}"))?;
     let provider = ProviderBuilder::new().connect_http(url);
     Ok(provider)
 }

--- a/bin/sentinel/src/chain_monitor/provider.rs
+++ b/bin/sentinel/src/chain_monitor/provider.rs
@@ -22,9 +22,8 @@ pub type HttpProvider = alloy_provider::fillers::FillProvider<
 
 /// Build an alloy HTTP provider for the given RPC URL.
 pub fn build_provider(rpc_url: &str) -> Result<HttpProvider> {
-    let url = rpc_url
-        .parse()
-        .map_err(|e| anyhow::anyhow!("Invalid RPC URL '{}': {}", rpc_url, e))?;
+    let url =
+        rpc_url.parse().map_err(|e| anyhow::anyhow!("Invalid RPC URL '{}': {}", rpc_url, e))?;
     let provider = ProviderBuilder::new().connect_http(url);
     Ok(provider)
 }

--- a/bin/sentinel/src/chain_monitor/timelock.rs
+++ b/bin/sentinel/src/chain_monitor/timelock.rs
@@ -188,8 +188,7 @@ impl TimelockMonitor {
                         let sender = tx.inner.signer();
                         if sender != expected_gov {
                             let msg = format!(
-                                "GOVERNANCE BYPASS DETECTED!\nEmergencyWithdraw called by {} instead of expected governance address {}\nTransaction: {:#x}\nThis may indicate a compromised owner key!",
-                                sender, expected_gov, tx_hash
+                                "GOVERNANCE BYPASS DETECTED!\nEmergencyWithdraw called by {sender} instead of expected governance address {expected_gov}\nTransaction: {tx_hash:#x}\nThis may indicate a compromised owner key!"
                             );
                             let _ =
                                 self.notifier.alert(&msg, "GOVERNANCE_BYPASS", Priority::P0).await;

--- a/bin/sentinel/src/chain_monitor/timelock.rs
+++ b/bin/sentinel/src/chain_monitor/timelock.rs
@@ -1,0 +1,223 @@
+use crate::{
+    chain_monitor::{
+        abi::{EmergencyWithdraw, OwnershipTransferStarted, OwnershipTransferred},
+        checkpoint::SharedCheckpoint,
+        config::TimelockConfig,
+        provider::{self, HttpProvider},
+    },
+    config::Priority,
+    notifier::Notifier,
+};
+use alloy_primitives::Address;
+use alloy_provider::Provider;
+use alloy_rpc_types::Filter;
+use alloy_sol_types::SolEvent;
+use std::time::Duration;
+
+pub struct TimelockMonitor {
+    config: TimelockConfig,
+    /// All bridge contract addresses to monitor for ownership events
+    watched_contracts: Vec<Address>,
+    gbridge_sender: Address,
+    expected_governance: Option<Address>,
+    provider: HttpProvider,
+    notifier: Notifier,
+    checkpoint: SharedCheckpoint,
+    poll_interval: Duration,
+    confirmation_blocks: u64,
+    max_consecutive_failures: u32,
+}
+
+impl TimelockMonitor {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        config: TimelockConfig,
+        watched_contracts: Vec<Address>,
+        gbridge_sender: Address,
+        expected_governance: Option<Address>,
+        provider: HttpProvider,
+        notifier: Notifier,
+        checkpoint: SharedCheckpoint,
+        poll_interval: Duration,
+        confirmation_blocks: u64,
+        max_consecutive_failures: u32,
+    ) -> Self {
+        Self {
+            config,
+            watched_contracts,
+            gbridge_sender,
+            expected_governance,
+            provider,
+            notifier,
+            checkpoint,
+            poll_interval,
+            confirmation_blocks,
+            max_consecutive_failures,
+        }
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(self.poll_interval);
+        let mut consecutive_failures: u32 = 0;
+        let mut backoff = Duration::from_secs(1);
+
+        loop {
+            interval.tick().await;
+
+            match self.poll_once().await {
+                Ok(()) => {
+                    consecutive_failures = 0;
+                    backoff = Duration::from_secs(1);
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    eprintln!(
+                        "Timelock monitor error (failures: {consecutive_failures}): {e:?}"
+                    );
+
+                    if consecutive_failures >= self.max_consecutive_failures {
+                        let msg = format!(
+                            "Timelock monitor lost RPC connectivity ({consecutive_failures} failures)"
+                        );
+                        let _ = self
+                            .notifier
+                            .alert(&msg, "CHAIN_MONITOR", Priority::P0)
+                            .await;
+                        consecutive_failures = 0;
+                    }
+
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    async fn poll_once(&self) -> anyhow::Result<()> {
+        let safe_block =
+            provider::get_safe_block_number(&self.provider, self.confirmation_blocks).await?;
+        let from_block = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            if ckpt.ethereum_block == 0 {
+                safe_block
+            } else {
+                ckpt.ethereum_block + 1
+            }
+        };
+
+        if from_block > safe_block {
+            return Ok(());
+        }
+
+        self.check_ownership_transfer_started(from_block, safe_block)
+            .await?;
+        self.check_ownership_transferred(from_block, safe_block)
+            .await?;
+        self.check_governance_bypass(from_block, safe_block).await?;
+
+        Ok(())
+    }
+
+    /// Monitor OwnershipTransferStarted events on all watched contracts.
+    async fn check_ownership_transfer_started(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        for &contract in &self.watched_contracts {
+            let filter = Filter::new()
+                .address(contract)
+                .event_signature(OwnershipTransferStarted::SIGNATURE_HASH)
+                .from_block(from_block)
+                .to_block(to_block);
+
+            let logs = provider::get_logs(&self.provider, filter).await?;
+            for log in &logs {
+                if let Ok(event) = OwnershipTransferStarted::decode_log_data(log.data()) {
+                    let msg = format!(
+                        "OWNERSHIP ALERT: Transfer initiated!\nContract: {contract}\nPrevious Owner: {}\nNew Owner: {}\nThis is step 1 of Ownable2Step - pending acceptance.",
+                        event.previousOwner, event.newOwner
+                    );
+                    let _ = self
+                        .notifier
+                        .alert(&msg, "TIMELOCK", self.config.priority)
+                        .await;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Monitor OwnershipTransferred events on all watched contracts.
+    async fn check_ownership_transferred(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        for &contract in &self.watched_contracts {
+            let filter = Filter::new()
+                .address(contract)
+                .event_signature(OwnershipTransferred::SIGNATURE_HASH)
+                .from_block(from_block)
+                .to_block(to_block);
+
+            let logs = provider::get_logs(&self.provider, filter).await?;
+            for log in &logs {
+                if let Ok(event) = OwnershipTransferred::decode_log_data(log.data()) {
+                    let msg = format!(
+                        "CRITICAL OWNERSHIP CHANGE: Transfer completed!\nContract: {contract}\nPrevious Owner: {}\nNew Owner: {}\nOwnership has been transferred - verify this was authorized!",
+                        event.previousOwner, event.newOwner
+                    );
+                    let _ = self
+                        .notifier
+                        .alert(&msg, "TIMELOCK", Priority::P0)
+                        .await;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// If expected_governance_address is set, check if EmergencyWithdraw was called
+    /// by a transaction sender that is NOT the expected governance address.
+    async fn check_governance_bypass(
+        &self,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<()> {
+        let Some(expected_gov) = self.expected_governance else {
+            return Ok(());
+        };
+
+        let filter = Filter::new()
+            .address(self.gbridge_sender)
+            .event_signature(EmergencyWithdraw::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let logs = provider::get_logs(&self.provider, filter).await?;
+
+        for log in &logs {
+            if EmergencyWithdraw::decode_log_data(log.data()).is_ok() {
+                // Get the transaction to check who sent it
+                if let Some(tx_hash) = log.transaction_hash {
+                    if let Ok(Some(tx)) = self.provider.get_transaction_by_hash(tx_hash).await {
+                        let sender = tx.inner.signer();
+                        if sender != expected_gov {
+                            let msg = format!(
+                                "GOVERNANCE BYPASS DETECTED!\nEmergencyWithdraw called by {} instead of expected governance address {}\nTransaction: {:#x}\nThis may indicate a compromised owner key!",
+                                sender, expected_gov, tx_hash
+                            );
+                            let _ = self
+                                .notifier
+                                .alert(&msg, "GOVERNANCE_BYPASS", Priority::P0)
+                                .await;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bin/sentinel/src/chain_monitor/timelock.rs
+++ b/bin/sentinel/src/chain_monitor/timelock.rs
@@ -71,18 +71,13 @@ impl TimelockMonitor {
                 }
                 Err(e) => {
                     consecutive_failures += 1;
-                    eprintln!(
-                        "Timelock monitor error (failures: {consecutive_failures}): {e:?}"
-                    );
+                    eprintln!("Timelock monitor error (failures: {consecutive_failures}): {e:?}");
 
                     if consecutive_failures >= self.max_consecutive_failures {
                         let msg = format!(
                             "Timelock monitor lost RPC connectivity ({consecutive_failures} failures)"
                         );
-                        let _ = self
-                            .notifier
-                            .alert(&msg, "CHAIN_MONITOR", Priority::P0)
-                            .await;
+                        let _ = self.notifier.alert(&msg, "CHAIN_MONITOR", Priority::P0).await;
                         consecutive_failures = 0;
                     }
 
@@ -109,10 +104,8 @@ impl TimelockMonitor {
             return Ok(());
         }
 
-        self.check_ownership_transfer_started(from_block, safe_block)
-            .await?;
-        self.check_ownership_transferred(from_block, safe_block)
-            .await?;
+        self.check_ownership_transfer_started(from_block, safe_block).await?;
+        self.check_ownership_transferred(from_block, safe_block).await?;
         self.check_governance_bypass(from_block, safe_block).await?;
 
         Ok(())
@@ -138,10 +131,7 @@ impl TimelockMonitor {
                         "OWNERSHIP ALERT: Transfer initiated!\nContract: {contract}\nPrevious Owner: {}\nNew Owner: {}\nThis is step 1 of Ownable2Step - pending acceptance.",
                         event.previousOwner, event.newOwner
                     );
-                    let _ = self
-                        .notifier
-                        .alert(&msg, "TIMELOCK", self.config.priority)
-                        .await;
+                    let _ = self.notifier.alert(&msg, "TIMELOCK", self.config.priority).await;
                 }
             }
         }
@@ -168,10 +158,7 @@ impl TimelockMonitor {
                         "CRITICAL OWNERSHIP CHANGE: Transfer completed!\nContract: {contract}\nPrevious Owner: {}\nNew Owner: {}\nOwnership has been transferred - verify this was authorized!",
                         event.previousOwner, event.newOwner
                     );
-                    let _ = self
-                        .notifier
-                        .alert(&msg, "TIMELOCK", Priority::P0)
-                        .await;
+                    let _ = self.notifier.alert(&msg, "TIMELOCK", Priority::P0).await;
                 }
             }
         }
@@ -180,11 +167,7 @@ impl TimelockMonitor {
 
     /// If expected_governance_address is set, check if EmergencyWithdraw was called
     /// by a transaction sender that is NOT the expected governance address.
-    async fn check_governance_bypass(
-        &self,
-        from_block: u64,
-        to_block: u64,
-    ) -> anyhow::Result<()> {
+    async fn check_governance_bypass(&self, from_block: u64, to_block: u64) -> anyhow::Result<()> {
         let Some(expected_gov) = self.expected_governance else {
             return Ok(());
         };
@@ -208,10 +191,8 @@ impl TimelockMonitor {
                                 "GOVERNANCE BYPASS DETECTED!\nEmergencyWithdraw called by {} instead of expected governance address {}\nTransaction: {:#x}\nThis may indicate a compromised owner key!",
                                 sender, expected_gov, tx_hash
                             );
-                            let _ = self
-                                .notifier
-                                .alert(&msg, "GOVERNANCE_BYPASS", Priority::P0)
-                                .await;
+                            let _ =
+                                self.notifier.alert(&msg, "GOVERNANCE_BYPASS", Priority::P0).await;
                         }
                     }
                 }

--- a/bin/sentinel/src/chain_monitor/vault_balance.rs
+++ b/bin/sentinel/src/chain_monitor/vault_balance.rs
@@ -1,0 +1,180 @@
+use crate::{
+    chain_monitor::{
+        abi::balanceOfCall,
+        checkpoint::SharedCheckpoint,
+        config::VaultBalanceConfig,
+        provider::HttpProvider,
+    },
+    config::Priority,
+    notifier::Notifier,
+};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_provider::Provider;
+use alloy_rpc_types::{TransactionInput, TransactionRequest};
+use alloy_sol_types::SolCall;
+use std::time::Duration;
+
+pub struct VaultBalanceMonitor {
+    config: VaultBalanceConfig,
+    gtoken_address: Address,
+    gbridge_sender: Address,
+    drop_absolute_threshold: U256,
+    provider: HttpProvider,
+    notifier: Notifier,
+    checkpoint: SharedCheckpoint,
+    poll_interval: Duration,
+    max_consecutive_failures: u32,
+}
+
+impl VaultBalanceMonitor {
+    pub fn new(
+        config: VaultBalanceConfig,
+        gtoken_address: Address,
+        gbridge_sender: Address,
+        provider: HttpProvider,
+        notifier: Notifier,
+        checkpoint: SharedCheckpoint,
+        poll_interval: Duration,
+        max_consecutive_failures: u32,
+    ) -> anyhow::Result<Self> {
+        let drop_absolute_threshold = config
+            .drop_absolute_threshold_wei
+            .parse::<U256>()
+            .map_err(|e| anyhow::anyhow!("Invalid drop_absolute_threshold_wei: {e}"))?;
+
+        Ok(Self {
+            config,
+            gtoken_address,
+            gbridge_sender,
+            drop_absolute_threshold,
+            provider,
+            notifier,
+            checkpoint,
+            poll_interval,
+            max_consecutive_failures,
+        })
+    }
+
+    pub async fn run(self) {
+        let mut interval = tokio::time::interval(self.poll_interval);
+        let mut consecutive_failures: u32 = 0;
+        let mut backoff = Duration::from_secs(1);
+
+        loop {
+            interval.tick().await;
+
+            match self.poll_once().await {
+                Ok(()) => {
+                    consecutive_failures = 0;
+                    backoff = Duration::from_secs(1);
+                }
+                Err(e) => {
+                    consecutive_failures += 1;
+                    eprintln!(
+                        "Vault balance monitor error (failures: {consecutive_failures}): {e:?}"
+                    );
+
+                    if consecutive_failures >= self.max_consecutive_failures {
+                        let msg = format!(
+                            "Vault balance monitor lost RPC connectivity ({consecutive_failures} failures). Last error: {e}"
+                        );
+                        if let Err(alert_err) =
+                            self.notifier.alert(&msg, "CHAIN_MONITOR", Priority::P0).await
+                        {
+                            eprintln!("Failed to send connectivity alert: {alert_err:?}");
+                        }
+                        consecutive_failures = 0;
+                    }
+
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(60));
+                }
+            }
+        }
+    }
+
+    async fn poll_once(&self) -> anyhow::Result<()> {
+        // Call balanceOf(gbridge_sender) on gtoken contract
+        let call = balanceOfCall {
+            account: self.gbridge_sender,
+        };
+        let input: Bytes = call.abi_encode().into();
+
+        let tx = TransactionRequest {
+            to: Some(TxKind::Call(self.gtoken_address)),
+            input: TransactionInput::new(input),
+            ..Default::default()
+        };
+
+        let result = self.provider.call(tx).await?;
+        let current_balance =
+            balanceOfCall::abi_decode_returns(&result)
+                .map_err(|e| anyhow::anyhow!("Failed to decode balanceOf: {e}"))?;
+
+        // Get previous balance from checkpoint
+        let previous_balance = {
+            let ckpt = self.checkpoint.lock().unwrap();
+            ckpt.last_vault_balance
+                .as_ref()
+                .and_then(|s| s.parse::<U256>().ok())
+        };
+
+        // Update checkpoint with current balance
+        {
+            let mut ckpt = self.checkpoint.lock().unwrap();
+            ckpt.last_vault_balance = Some(current_balance.to_string());
+        }
+
+        // First run — no previous balance to compare against
+        let Some(prev) = previous_balance else {
+            println!(
+                "Vault balance baseline recorded: {} wei",
+                current_balance
+            );
+            return Ok(());
+        };
+
+        // Only alert on decreases
+        if current_balance >= prev {
+            return Ok(());
+        }
+
+        let drop = prev - current_balance;
+
+        // Check absolute threshold
+        let absolute_triggered = drop >= self.drop_absolute_threshold;
+
+        // Check percentage threshold
+        let percentage_triggered = if !prev.is_zero() {
+            // Calculate percentage: (drop * 10000) / prev gives basis points
+            let basis_points = (drop * U256::from(10000)) / prev;
+            let threshold_bp = (self.config.drop_percentage_threshold * 100.0) as u64;
+            basis_points >= U256::from(threshold_bp)
+        } else {
+            false
+        };
+
+        if absolute_triggered || percentage_triggered {
+            let drop_pct = if !prev.is_zero() {
+                let bp = (drop * U256::from(10000)) / prev;
+                format!("{:.2}%", bp.to::<u64>() as f64 / 100.0)
+            } else {
+                "N/A".to_string()
+            };
+
+            let msg = format!(
+                "Vault balance alert!\nPrevious: {} wei\nCurrent: {} wei\nDrop: {} wei ({drop_pct})\nContract: {}",
+                prev, current_balance, drop, self.gbridge_sender
+            );
+            if let Err(e) = self
+                .notifier
+                .alert(&msg, "BRIDGE_VAULT_BALANCE", self.config.priority)
+                .await
+            {
+                eprintln!("Failed to send vault balance alert: {e:?}");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/bin/sentinel/src/chain_monitor/vault_balance.rs
+++ b/bin/sentinel/src/chain_monitor/vault_balance.rs
@@ -25,6 +25,7 @@ pub struct VaultBalanceMonitor {
 }
 
 impl VaultBalanceMonitor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: VaultBalanceConfig,
         gtoken_address: Address,
@@ -120,7 +121,7 @@ impl VaultBalanceMonitor {
 
         // First run — no previous balance to compare against
         let Some(prev) = previous_balance else {
-            println!("Vault balance baseline recorded: {} wei", current_balance);
+            println!("Vault balance baseline recorded: {current_balance} wei");
             return Ok(());
         };
 

--- a/bin/sentinel/src/chain_monitor/vault_balance.rs
+++ b/bin/sentinel/src/chain_monitor/vault_balance.rs
@@ -1,8 +1,6 @@
 use crate::{
     chain_monitor::{
-        abi::balanceOfCall,
-        checkpoint::SharedCheckpoint,
-        config::VaultBalanceConfig,
+        abi::balanceOfCall, checkpoint::SharedCheckpoint, config::VaultBalanceConfig,
         provider::HttpProvider,
     },
     config::Priority,
@@ -95,9 +93,7 @@ impl VaultBalanceMonitor {
 
     async fn poll_once(&self) -> anyhow::Result<()> {
         // Call balanceOf(gbridge_sender) on gtoken contract
-        let call = balanceOfCall {
-            account: self.gbridge_sender,
-        };
+        let call = balanceOfCall { account: self.gbridge_sender };
         let input: Bytes = call.abi_encode().into();
 
         let tx = TransactionRequest {
@@ -107,16 +103,13 @@ impl VaultBalanceMonitor {
         };
 
         let result = self.provider.call(tx).await?;
-        let current_balance =
-            balanceOfCall::abi_decode_returns(&result)
-                .map_err(|e| anyhow::anyhow!("Failed to decode balanceOf: {e}"))?;
+        let current_balance = balanceOfCall::abi_decode_returns(&result)
+            .map_err(|e| anyhow::anyhow!("Failed to decode balanceOf: {e}"))?;
 
         // Get previous balance from checkpoint
         let previous_balance = {
             let ckpt = self.checkpoint.lock().unwrap();
-            ckpt.last_vault_balance
-                .as_ref()
-                .and_then(|s| s.parse::<U256>().ok())
+            ckpt.last_vault_balance.as_ref().and_then(|s| s.parse::<U256>().ok())
         };
 
         // Update checkpoint with current balance
@@ -127,10 +120,7 @@ impl VaultBalanceMonitor {
 
         // First run — no previous balance to compare against
         let Some(prev) = previous_balance else {
-            println!(
-                "Vault balance baseline recorded: {} wei",
-                current_balance
-            );
+            println!("Vault balance baseline recorded: {} wei", current_balance);
             return Ok(());
         };
 
@@ -166,10 +156,8 @@ impl VaultBalanceMonitor {
                 "Vault balance alert!\nPrevious: {} wei\nCurrent: {} wei\nDrop: {} wei ({drop_pct})\nContract: {}",
                 prev, current_balance, drop, self.gbridge_sender
             );
-            if let Err(e) = self
-                .notifier
-                .alert(&msg, "BRIDGE_VAULT_BALANCE", self.config.priority)
-                .await
+            if let Err(e) =
+                self.notifier.alert(&msg, "BRIDGE_VAULT_BALANCE", self.config.priority).await
             {
                 eprintln!("Failed to send vault balance alert: {e:?}");
             }

--- a/bin/sentinel/src/config.rs
+++ b/bin/sentinel/src/config.rs
@@ -37,6 +37,8 @@ pub struct Config {
     /// Multiple probe endpoints, each with its own URL, interval, and threshold.
     #[serde(default)]
     pub probes: Vec<ProbeConfig>,
+    /// Optional chain monitor configuration for on-chain bridge event monitoring.
+    pub chain_monitor: Option<crate::chain_monitor::config::ChainMonitorConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/bin/sentinel/src/main.rs
+++ b/bin/sentinel/src/main.rs
@@ -1,4 +1,5 @@
 mod analyzer;
+mod chain_monitor;
 mod config;
 mod notifier;
 mod probe;
@@ -57,6 +58,14 @@ async fn main() -> Result<()> {
         tokio::spawn(async move {
             probe.run().await;
         });
+    }
+
+    // Start Chain Monitors (if configured)
+    if let Some(chain_config) = config.chain_monitor {
+        println!("Starting chain monitors...");
+        chain_monitor::spawn_all(chain_config, notifier.clone())
+            .await
+            .context("Failed to start chain monitors")?;
     }
 
     // Initial file discovery


### PR DESCRIPTION
## Summary

Add a new `chain_monitor` module to Sentinel that monitors bridge contract events via Ethereum JSON-RPC (`eth_getLogs` polling). Implements 5 security monitoring rules:

1. **Large Withdrawal**: Alert when `TokensLocked` exceeds configurable threshold
2. **Vault Balance**: Monitor ERC20 vault balance for abnormal drops
3. **Bridge Timeout**: Track cross-chain nonce correlation (ETH→Gravity), alert if not confirmed within timeout
4. **Owner Activity**: Alert on privileged function calls (`EmergencyWithdraw`, `ERC20Recovered`, `FeeConfigUpdated`, etc.)
5. **Timelock/Ownership**: Monitor `Ownable2Step` ownership transfers and governance bypass detection

## Architecture

```
bin/sentinel/src/chain_monitor/
  mod.rs              — spawn_all() entry, launches monitors as independent tokio tasks
  config.rs           — TOML config structs for [chain_monitor] section
  abi.rs              — alloy sol! macro for all bridge contract event ABIs
  provider.rs         — alloy HTTP provider factory (connect_http)
  checkpoint.rs       — JSON checkpoint persistence (block cursors + pending nonces)
  large_withdrawal.rs — Rule 1: TokensLocked amount > threshold + EmergencyWithdraw
  vault_balance.rs    — Rule 2: ERC20 balanceOf polling with drop detection
  bridge_timeout.rs   — Rule 3: cross-chain nonce tracking with tokio::select! loop
  owner_activity.rs   — Rule 4: privileged event scanning on GBridgeSender + GravityPortal
  timelock.rs         — Rule 5: OwnershipTransferStarted/Transferred + governance bypass
```

### Key Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Ethereum library | alloy v1.0.37 | Consistent with `gravity_cli`, ethers-rs is in maintenance mode |
| Polling strategy | `eth_getLogs` | Idempotent, checkpoint-friendly; WebSocket is fragile in prod |
| Module granularity | One file per rule | Each rule has distinct polling strategy, clear separation |
| State persistence | JSON checkpoint file | Simple, atomic write (tmp+rename), survives restarts |
| Integration pattern | Independent tokio tasks | Same as existing `Probe` module, no changes to main event loop |

### Minimal Integration Points

- `config.rs`: Added `chain_monitor: Option<ChainMonitorConfig>` (fully backward-compatible)
- `main.rs`: Added `mod chain_monitor` + 4-line spawn block after probe startup
- `Cargo.toml`: Added alloy dependencies, upgraded reqwest 0.11→0.12

## How Has This Been Tested

### End-to-End Test with Mock RPC Server

Tested using a lightweight Python mock JSON-RPC server that simulates both Ethereum and Gravity chains, returning pre-crafted event logs at specific block numbers. No real contracts or EVM needed.

**Test scenario:**

| Block | Chain | Event | Expected Alert |
|-------|-------|-------|----------------|
| 5 | Ethereum | `TokensLocked` (100 tokens, nonce=1) | Large withdrawal P0 |
| 6 | Ethereum | `TokensLocked` (100 tokens, nonce=2) | Large withdrawal P0 |
| 8 | Gravity | `NativeMinted` (nonce=1 only) | — (nonce 1 confirmed) |
| 10 | Ethereum | `EmergencyWithdraw` | Owner activity P0 |
| 15 | Ethereum | `OwnershipTransferred` | Timelock P0 |
| — | — | nonce=2 never minted | Bridge timeout P0 (after 15s) |

**Sentinel stdout output:**
```
Loading config from sentinel_bridge_test.toml
Starting chain monitors...
Starting chain monitor: large withdrawal (threshold: 500000000000000000 wei)
Starting chain monitor: bridge timeout (15s threshold)
Starting chain monitor: owner activity
Starting chain monitor: timelock/ownership
Sentinel started...
Bridge timeout: Tracking nonce 1 (block 5, timestamp ...)
Bridge timeout: Tracking nonce 2 (block 6, timestamp ...)
Bridge timeout: Nonce 1 confirmed on Gravity
```

**Webhook alerts received (Feishu):**

```
🚨 Log Sentinel Alert [P0] 🚨
File: BRIDGE_TIMEOUT
Error: Bridge transaction TIMEOUT!
  Nonce: 2
  Locked on Ethereum at: ... (17s ago)
  Not yet confirmed on Gravity after 15 seconds threshold
  Investigate relay pipeline!

🚨 Log Sentinel Alert [P0] 🚨
File: TIMELOCK
Error: CRITICAL OWNERSHIP CHANGE: Transfer completed!
  Contract: 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
  Previous Owner: 0xf39F...2266
  New Owner: 0xDeaD...beef
  Ownership has been transferred - verify this was authorized!

🚨 Log Sentinel Alert [P0] 🚨
File: OWNER_ACTIVITY
Error: OWNER ACTIVITY: EmergencyWithdraw called!
  Recipient: 0x6954...765C
  Amount: 100000000000000000000 wei
  Contract: GBridgeSender (0x9fE4...fa6e0)
```

**Verified behaviors:**
- ✅ Event decoding (alloy `sol!` macro + `decode_log_data`)
- ✅ Cross-chain nonce correlation (nonce 1 tracked → confirmed → cleared)
- ✅ Timeout detection (nonce 2 never confirmed → P0 alert after threshold)
- ✅ Privileged operation detection (EmergencyWithdraw → P0)
- ✅ Ownership change detection (OwnershipTransferred → P0)
- ✅ Webhook delivery (Feishu)
- ✅ Checkpoint persistence (block cursors saved to JSON, resume on restart)
- ✅ Graceful handling when no events found (no crashes, no false positives)

### Bridge E2E Cluster Integration

Also validated against the live bridge E2E cluster (`python3 gravity_e2e/runner.py bridge`):
- Sentinel successfully connected to Gravity chain RPC (port 8545)
- Scanned from block 0 to ~2996, made 107 network calls in 15 seconds
- Checkpoint correctly persisted and resumed across runs
- No false positives when scanning real chain data with no matching events

## TOML Configuration Example

```toml
[chain_monitor]
ethereum_rpc_url = "https://eth-mainnet.example.com"
gravity_rpc_url = "http://localhost:8545"
gbridge_sender_address = "0x..."
gravity_portal_address = "0x..."
gbridge_receiver_address = "0x..."
native_oracle_address = "0x..."
owner_address = "0x..."
gtoken_address = "0x..."
poll_interval_seconds = 12
confirmation_blocks = 2
checkpoint_path = "chain_monitor_checkpoint.json"

[chain_monitor.large_withdrawal]
enabled = true
threshold_wei = "50000000000000000000"
priority = "p0"

[chain_monitor.bridge_timeout]
enabled = true
timeout_seconds = 1800
check_interval_seconds = 60
priority = "p0"

[chain_monitor.owner_activity]
enabled = true
priority = "p0"

[chain_monitor.timelock]
enabled = true
priority = "p0"
expected_governance_address = "0x..."
```

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] CLI Tools
- [x] Other (Sentinel monitoring daemon)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works