### PR TITLE
feat(genesis): passthrough genesisTimestampSecs from TOML to genesis-tool

### DIFF
--- a/cluster/genesis.toml.example
+++ b/cluster/genesis.toml.example
@@ -15,6 +15,7 @@ major_version = 1
 consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
 execution_config = "0x00"
 initial_locked_until_micros = 1798848000000000
+# genesis_timestamp_secs = 1750000000  # Genesis block timestamp (Unix seconds). Required for non-dev chains; omit for dev/e2e to use template default.
 
 [genesis.validator_config]
 minimum_bond = "1000000000000000000"

--- a/cluster/utils/aggregate_genesis.py
+++ b/cluster/utils/aggregate_genesis.py
@@ -94,7 +94,11 @@ def build_genesis_config(config, genesis_cfg):
     result["consensusConfig"] = genesis_cfg.get("consensus_config", defaults["consensusConfig"])
     result["executionConfig"] = genesis_cfg.get("execution_config", defaults["executionConfig"])
     result["initialLockedUntilMicros"] = genesis_cfg.get("initial_locked_until_micros", defaults["initialLockedUntilMicros"])
-    
+
+    # Optional: genesis block timestamp (passthrough only if explicitly set)
+    if "genesis_timestamp_secs" in genesis_cfg:
+        result["genesisTimestampSecs"] = genesis_cfg["genesis_timestamp_secs"]
+
     # validatorConfig
     vc = genesis_cfg.get("validator_config", {})
     result["validatorConfig"] = {


### PR DESCRIPTION
Wire the new genesis_timestamp_secs field through aggregate_genesis.py so it reaches the genesis-tool JSON config, and add a commented-out example in genesis.toml.example. Dev/e2e configs are unaffected (field is optional).
