### PR TITLE
feat(cli,genesis): support DNS domain names in validator network addresses

### DIFF
--- a/bin/gravity_cli/src/validator/join.rs
+++ b/bin/gravity_cli/src/validator/join.rs
@@ -53,11 +53,11 @@ pub struct JoinCommand {
     #[clap(long)]
     pub network_public_key: String,
 
-    /// Validator network address in /ip4/{host}/tcp/{port} format
+    /// Validator network address in /ip4/{host}/tcp/{port} or /dns/{domain}/tcp/{port} format
     #[clap(long)]
     pub validator_network_address: String,
 
-    /// Fullnode network address in /ip4/{host}/tcp/{port} format
+    /// Fullnode network address in /ip4/{host}/tcp/{port} or /dns/{domain}/tcp/{port} format
     #[clap(long)]
     pub fullnode_network_address: String,
 }
@@ -222,19 +222,19 @@ impl JoinCommand {
                 ));
             }
 
-            // Validate address format: /ip4/{host}/tcp/{port}
+            // Validate address format: /ip4/{host}/tcp/{port} or /dns/{domain}/tcp/{port}
             fn validate_network_address(addr: &str, label: &str) -> Result<(), anyhow::Error> {
                 let parts: Vec<&str> = addr.split('/').collect();
-                // Expected: ["", "ip4", "{host}", "tcp", "{port}"]
+                // Expected: ["", "ip4"|"dns"|"dns4"|"dns6", "{host}", "tcp", "{port}"]
                 if parts.len() != 5 ||
                     !parts[0].is_empty() ||
-                    parts[1] != "ip4" ||
+                    !matches!(parts[1], "ip4" | "dns" | "dns4" | "dns6") ||
                     parts[2].is_empty() ||
                     parts[3] != "tcp" ||
                     parts[4].parse::<u16>().is_err()
                 {
                     return Err(anyhow::anyhow!(
-                        "Invalid {label} address: expected /ip4/{{host}}/tcp/{{port}} format, got '{addr}'"
+                        "Invalid {label} address: expected /ip4/{{host}}/tcp/{{port}} or /dns/{{domain}}/tcp/{{port}} format, got '{addr}'"
                     ));
                 }
                 Ok(())
@@ -243,7 +243,7 @@ impl JoinCommand {
             validate_network_address(&self.fullnode_network_address, "fullnode network")?;
 
             // Construct full addresses:
-            // /ip4/{host}/tcp/{port}/noise-ik/{network_public_key}/handshake/0
+            // /{ip4|dns}/{host}/tcp/{port}/noise-ik/{network_public_key}/handshake/0
             //
             // The same `network_pk` is intentionally used for both endpoints: in this
             // deployment model a single validator process serves both `validator_network`

--- a/cluster/genesis.toml.example
+++ b/cluster/genesis.toml.example
@@ -85,6 +85,7 @@ balance = "1000000000000000000000000"  # 1M ETH
 # Genesis validators
 # Each validator must specify: id, address, stake_amount, voting_power, host, p2p_port, vfn_port
 # NOTE: voting_power must be >= stake_amount
+# NOTE: host can be an IPv4 address (e.g. "1.2.3.4") or a domain name (e.g. "validator1.example.com")
 
 [[genesis_validators]]
 id = "node1"

--- a/cluster/utils/aggregate_genesis.py
+++ b/cluster/utils/aggregate_genesis.py
@@ -275,10 +275,17 @@ def main():
         host = node['host']
         p2p_port = node['p2p_port']
         vfn_port = node['vfn_port']
-        
-        # Build addresses
-        val_net_addr = f"/ip4/{host}/tcp/{p2p_port}/noise-ik/{network_pk}/handshake/0"
-        vfn_net_addr = f"/ip4/{host}/tcp/{vfn_port}/noise-ik/{network_pk}/handshake/0"
+
+        # Build addresses: use /dns/ for domain names, /ip4/ for IPv4 addresses
+        try:
+            import ipaddress
+            ipaddress.IPv4Address(host)
+            host_proto = "ip4"
+        except ValueError:
+            host_proto = "dns"
+
+        val_net_addr = f"/{host_proto}/{host}/tcp/{p2p_port}/noise-ik/{network_pk}/handshake/0"
+        vfn_net_addr = f"/{host_proto}/{host}/tcp/{vfn_port}/noise-ik/{network_pk}/handshake/0"
         
         # Consensus PoP: use node config value, identity file, or 96-byte dummy
         # ValidatorManagement.sol requires non-empty consensusPop


### PR DESCRIPTION
The validator network address format was hardcoded to /ip4/ only, rejecting domain names. The underlying aptos NetworkAddress type fully supports /dns/ format, so this lifts the restriction in both the CLI and genesis tooling.

- aggregate_genesis.py: auto-detect host as IP vs domain, use /ip4/ or /dns/
- gravity_cli validator join: accept /dns/, /dns4/, /dns6/ in addition to /ip4/
- genesis.toml.example: document that host supports domain names