### PR TITLE
fix(genesis): align cluster deployment with upstream contract changes

### DIFF
--- a/cluster/example/1_node/genesis.toml
+++ b/cluster/example/1_node/genesis.toml
@@ -41,7 +41,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/cluster/example/3_node/genesis.toml
+++ b/cluster/example/3_node/genesis.toml
@@ -61,7 +61,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/cluster/example/3_node_1_vfn/genesis.toml
+++ b/cluster/example/3_node_1_vfn/genesis.toml
@@ -61,7 +61,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/cluster/genesis.sh
+++ b/cluster/genesis.sh
@@ -150,7 +150,15 @@ main() {
     # Generate genesis
     log_info "Generating genesis block..."
     cd "$GENESIS_CONTRACT_DIR"
-    
+
+    # Ensure genesis-tool is a standalone workspace so cargo doesn't pick up
+    # a parent workspace (e.g. when running inside a git worktree)
+    local genesis_tool_cargo="$GENESIS_CONTRACT_DIR/genesis-tool/Cargo.toml"
+    if ! grep -q '^\[workspace\]' "$genesis_tool_cargo" 2>/dev/null; then
+        log_info "Patching genesis-tool Cargo.toml for standalone build..."
+        echo -e '\n[workspace]' >> "$genesis_tool_cargo"
+    fi
+
     ./scripts/generate_genesis.sh --config "$ABS_VAL_GENESIS_PATH"
     
     # Copy artifacts back

--- a/cluster/genesis.toml.example
+++ b/cluster/genesis.toml.example
@@ -31,7 +31,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"
@@ -51,6 +50,7 @@ callbacks = ["0x00000000000000000000000000000001625F4001"]
 [genesis.oracle_config.bridge_config]
 deploy = true
 trusted_bridge = "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
+trusted_source_id = 11155111
 
 [[genesis.oracle_config.tasks]]
 source_type = 0

--- a/cluster/utils/aggregate_genesis.py
+++ b/cluster/utils/aggregate_genesis.py
@@ -30,7 +30,7 @@ def get_genesis_defaults():
         "chainId": 1337,  # Default value, can be overridden in genesis.toml
         "epochIntervalMicros": 7200000000,
         "majorVersion": 1,
-        "consensusConfig": "0x00",
+        "consensusConfig": "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000",
         "executionConfig": "0x00",
         "initialLockedUntilMicros": 1798848000000000,
         "validatorConfig": {
@@ -46,8 +46,7 @@ def get_genesis_defaults():
         "stakingConfig": {
             "minimumStake": "1000000000000000000",
             "lockupDurationMicros": 86400000000,
-            "unbondingDelayMicros": 86400000000,
-            "minimumProposalStake": "10000000000000000000"
+            "unbondingDelayMicros": 86400000000
         },
         "governanceConfig": {
             "minVotingThreshold": "1000000000000000000",
@@ -64,7 +63,7 @@ def get_genesis_defaults():
         },
         "oracleConfig": {
             "sourceTypes": [1],
-            "callbacks": ["0x00000000000000000000000000000001625F2018"],
+            "callbacks": ["0x00000000000000000000000000000001625F4001"],
             "bridgeConfig": None,
             "tasks": []
         },
@@ -117,8 +116,7 @@ def build_genesis_config(config, genesis_cfg):
     result["stakingConfig"] = {
         "minimumStake": sc.get("minimum_stake", defaults["stakingConfig"]["minimumStake"]),
         "lockupDurationMicros": sc.get("lockup_duration_micros", defaults["stakingConfig"]["lockupDurationMicros"]),
-        "unbondingDelayMicros": sc.get("unbonding_delay_micros", defaults["stakingConfig"]["unbondingDelayMicros"]),
-        "minimumProposalStake": sc.get("minimum_proposal_stake", defaults["stakingConfig"]["minimumProposalStake"])
+        "unbondingDelayMicros": sc.get("unbonding_delay_micros", defaults["stakingConfig"]["unbondingDelayMicros"])
     }
     
     # governanceConfig

--- a/gravity_e2e/cluster_test_cases/bridge/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/bridge/genesis.toml
@@ -42,7 +42,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"
@@ -58,7 +57,7 @@ fast_path_secrecy_threshold = 12297829382473033728
 # Oracle config: source_types includes Blockchain (0) for bridge
 [genesis.oracle_config]
 source_types = [1]
-callbacks = ["0x00000000000000000000000000000001625F2018"]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
 
 # Bridge config: deploy GBridgeReceiver at genesis
 [genesis.oracle_config.bridge_config]

--- a/gravity_e2e/cluster_test_cases/four_validator/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/four_validator/genesis.toml
@@ -72,7 +72,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/gravity_e2e/cluster_test_cases/fuzzy_cluster/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/fuzzy_cluster/genesis.toml
@@ -71,7 +71,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/gravity_e2e/cluster_test_cases/long_test/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/long_test/genesis.toml
@@ -72,7 +72,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/gravity_e2e/cluster_test_cases/rolling_upgrade/genesis.toml.tpl
+++ b/gravity_e2e/cluster_test_cases/rolling_upgrade/genesis.toml.tpl
@@ -74,7 +74,6 @@ max_validator_set_size = "100"
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/gravity_e2e/cluster_test_cases/single_node/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/single_node/genesis.toml
@@ -41,7 +41,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"

--- a/gravity_e2e/cluster_test_cases/vfn/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/vfn/genesis.toml
@@ -39,7 +39,6 @@ auto_evict_threshold_pct = 0
 minimum_stake = "1000000000000000000"
 lockup_duration_micros = 86400000000
 unbonding_delay_micros = 86400000000
-minimum_proposal_stake = "10000000000000000000"
 
 [genesis.governance_config]
 min_voting_threshold = "1000000000000000000"
@@ -59,6 +58,7 @@ callbacks = ["0x00000000000000000000000000000001625F4001"]
 [genesis.oracle_config.bridge_config]
 deploy = true
 trusted_bridge = "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
+trusted_source_id = 11155111
 
 [[genesis.oracle_config.tasks]]
 source_type = 0


### PR DESCRIPTION
## Summary

- Sync genesis config schemas with upstream `gravity_chain_core_contracts` (was 15 commits behind)
- `autoEvictThreshold` (uint256) → `autoEvictThresholdPct` (uint64): eviction changed from absolute count to success-rate %
- Remove deprecated `minimumProposalStake` from StakingConfig (kept as storage gap in contracts for hardfork compat)
- Fix stale default `callbacks` address and `consensusConfig` in `aggregate_genesis.py`
- Add missing `trusted_source_id` to `genesis.toml.example` and `vfn` test config
- Support optional `genesisTimestampSecs` field from upstream
- Patch `genesis.sh` for git worktree cargo workspace isolation

## Test plan

- [x] Full `make init → make genesis → deploy → start` cycle verified with upstream contracts
- [x] Node produces blocks, RPC `eth_blockNumber` returns increasing values
- [x] `chainId` and faucet balance match genesis config
- [x] No stale field references (`auto_evict_threshold`, `minimumProposalStake`) remain in repo
- [x] No sensitive information in diff (only well-known Hardhat test keys in existing files)
- [ ] Run full E2E suite (`python3 gravity_e2e/runner.py --force-init`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)