### PR TITLE
refactor(sentinel): make log monitoring optional and run as independent task

### DIFF
--- a/bin/sentinel/sentinel.toml.example
+++ b/bin/sentinel/sentinel.toml.example
@@ -1,6 +1,7 @@
 [general]
 check_interval_ms = 2000
 
+# [monitoring] is optional. Omit the entire section to run in probes-only mode.
 [monitoring]
 # Match all .log files in the logs directory
 file_patterns = ["logs/*.log", "test.log"]

--- a/bin/sentinel/sentinel.toml.example
+++ b/bin/sentinel/sentinel.toml.example
@@ -1,6 +1,3 @@
-[general]
-check_interval_ms = 2000
-
 # [monitoring] is optional. Omit the entire section to run in probes-only mode.
 [monitoring]
 # Match all .log files in the logs directory
@@ -14,6 +11,9 @@ error_pattern = "(?i)error|panic|fatal"
 #   -1 = always ignore
 #   >0 = alert if count >threshold in 5 minutes
 whitelist_path = "whitelist.csv"
+# Periodic interval (ms) to re-scan file_patterns for new log files.
+# If omitted, only the initial set of files is monitored.
+check_interval_ms = 2000
 
 [alerting]
 # Priority assigned to errors that do not match any whitelist rules (default: "p0")

--- a/bin/sentinel/src/config.rs
+++ b/bin/sentinel/src/config.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Priority {
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub general: GeneralConfig,
-    pub monitoring: MonitoringConfig,
+    pub monitoring: Option<MonitoringConfig>,
     pub alerting: AlertingConfig,
     /// Multiple probe endpoints, each with its own URL, interval, and threshold.
     #[serde(default)]

--- a/bin/sentinel/src/config.rs
+++ b/bin/sentinel/src/config.rs
@@ -26,7 +26,6 @@ impl fmt::Display for Priority {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
-    pub general: GeneralConfig,
     pub monitoring: Option<MonitoringConfig>,
     pub alerting: AlertingConfig,
     /// Multiple probe endpoints, each with its own URL, interval, and threshold.
@@ -55,16 +54,14 @@ fn default_probe_threshold() -> u32 {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct GeneralConfig {
-    pub check_interval_ms: u64,
-}
-
-#[derive(Debug, Deserialize, Clone)]
 pub struct MonitoringConfig {
     pub file_patterns: Vec<String>,
     pub recent_file_threshold_seconds: u64,
     pub error_pattern: String,
     pub whitelist_path: Option<String>,
+    /// Periodic interval (ms) to re-scan file_patterns for new log files.
+    /// If omitted, only the initial set of files is monitored (no discovery of new files).
+    pub check_interval_ms: Option<u64>,
 }
 
 /// Per-priority webhook override.

--- a/bin/sentinel/src/main.rs
+++ b/bin/sentinel/src/main.rs
@@ -20,6 +20,86 @@ use anyhow::{Context, Result};
 use std::{env, time::Duration};
 use tokio::time;
 
+/// Spawn log monitoring as an independent task.
+fn spawn_log_monitor(
+    monitoring: config::MonitoringConfig,
+    alerting: config::AlertingConfig,
+    check_interval: Duration,
+    notifier: Notifier,
+) -> Result<()> {
+    let mut whitelist = if let Some(ref path) = monitoring.whitelist_path {
+        println!("Loading whitelist from {path}");
+        Whitelist::load(path).context("Failed to load whitelist")?
+    } else {
+        Whitelist::default()
+    };
+
+    let mut watcher = Watcher::new(monitoring.clone());
+    let analyzer = Analyzer::new(&monitoring.error_pattern)?;
+
+    let files = watcher.discover()?;
+    println!("Found {} files to monitor", files.len());
+
+    tokio::spawn(async move {
+        let mut reader = Reader::new().expect("Failed to create reader");
+        for file in files {
+            println!("Monitoring: {file:?}");
+            if let Err(e) = reader.add_file(&file).await {
+                eprintln!("Failed to add file: {e:?}");
+            }
+        }
+
+        let mut interval = time::interval(check_interval);
+
+        loop {
+            tokio::select! {
+                Some(line_event) = reader.next_line() => {
+                    let line = line_event.line();
+                    let path = line_event.source();
+
+                    if !analyzer.is_error(line) {
+                        continue;
+                    }
+
+                    let file_str = path.to_str().unwrap_or("unknown");
+
+                    match whitelist.check(line, path) {
+                        CheckResult::Skip => continue,
+                        CheckResult::Alert { count, priority } => {
+                            let msg = format!("{line} [Frequency Alert: >{count}/5min]");
+                            println!("Frequency Alert in {path:?}: {msg}");
+                            if let Err(e) = notifier.alert(&msg, file_str, priority).await {
+                                eprintln!("Failed to send alert: {e:?}");
+                            }
+                        }
+                        CheckResult::AlwaysAlert => {
+                            println!("Alert in {path:?}: {line}");
+                            if let Err(e) = notifier.alert(line, file_str, alerting.default_priority).await {
+                                eprintln!("Failed to send alert: {e:?}");
+                            }
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    match watcher.discover() {
+                        Ok(new_files) => {
+                            for file in new_files {
+                                println!("New file discovered: {file:?}");
+                                if let Err(e) = reader.add_file(&file).await {
+                                    eprintln!("Failed to add file: {e:?}");
+                                }
+                            }
+                        }
+                        Err(e) => eprintln!("Discovery error: {e:?}"),
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
@@ -35,17 +115,6 @@ async fn main() -> Result<()> {
     println!("Loading config from {config_path}");
     let config = Config::load(config_path).context("Failed to load config")?;
 
-    // Load whitelist if configured
-    let mut whitelist = if let Some(ref path) = config.monitoring.whitelist_path {
-        println!("Loading whitelist from {path}");
-        Whitelist::load(path).context("Failed to load whitelist")?
-    } else {
-        Whitelist::default()
-    };
-
-    let mut watcher = Watcher::new(config.monitoring.clone());
-    let mut reader = Reader::new()?;
-    let analyzer = Analyzer::new(&config.monitoring.error_pattern)?;
     let notifier = Notifier::new(config.alerting.clone());
 
     // Verify webhook connectivity on startup
@@ -68,71 +137,17 @@ async fn main() -> Result<()> {
             .context("Failed to start chain monitors")?;
     }
 
-    // Initial file discovery
-    let files = watcher.discover()?;
-    println!("Found {} files to monitor", files.len());
-    for file in files {
-        println!("Monitoring: {file:?}");
-        reader.add_file(&file).await?;
+    // Start Log Monitoring (if configured)
+    if let Some(monitoring) = config.monitoring {
+        println!("Starting log monitoring...");
+        let check_interval = Duration::from_millis(config.general.check_interval_ms);
+        spawn_log_monitor(monitoring, config.alerting, check_interval, notifier)?;
     }
-
-    let check_interval = Duration::from_millis(config.general.check_interval_ms);
-    let mut interval = time::interval(check_interval);
 
     println!("Sentinel started...");
 
-    loop {
-        tokio::select! {
-            // Event-driven: new log line from linemux
-            Some(line_event) = reader.next_line() => {
-                let line = line_event.line();
-                let path = line_event.source();
+    tokio::signal::ctrl_c().await?;
+    println!("Shutting down...");
 
-                if !analyzer.is_error(line) {
-                    continue;
-                }
-
-                let file_str = path.to_str().unwrap_or("unknown");
-
-                match whitelist.check(line, path) {
-                    CheckResult::Skip => {
-                        // Matched whitelist rule but below threshold, skip
-                        continue;
-                    }
-                    CheckResult::Alert { count, priority } => {
-                        // Matched whitelist rule and above threshold
-                        let msg = format!("{line} [Frequency Alert: >{count}/5min]");
-                        println!("Frequency Alert in {path:?}: {msg}");
-                        if let Err(e) = notifier.alert(&msg, file_str, priority).await {
-                            eprintln!("Failed to send alert: {e:?}");
-                        }
-                    }
-                    CheckResult::AlwaysAlert => {
-                        // Design Intent: Provide a fallback priority (e.g. P2) for unknown
-                        // error patterns to avoid P0 spamming, while still ensuring they are
-                        // reported.
-                        // No whitelist rule matched, always alert with default_priority
-                        println!("Alert in {path:?}: {line}");
-                        if let Err(e) = notifier.alert(line, file_str, config.alerting.default_priority).await {
-                            eprintln!("Failed to send alert: {e:?}");
-                        }
-                    }
-                }
-            }
-            // Periodic: discover new files via glob
-            _ = interval.tick() => {
-                match watcher.discover() {
-                    Ok(new_files) => {
-                        for file in new_files {
-                            println!("New file discovered: {file:?}");
-                            if let Err(e) = reader.add_file(&file).await {
-                                eprintln!("Failed to add file: {e:?}");
-                            }
-                        }
-                    }
-                    Err(e) => eprintln!("Discovery error: {e:?}"),
-                }
-            }
-        }
-    }
+    Ok(())
 }

--- a/bin/sentinel/src/main.rs
+++ b/bin/sentinel/src/main.rs
@@ -24,7 +24,6 @@ use tokio::time;
 fn spawn_log_monitor(
     monitoring: config::MonitoringConfig,
     alerting: config::AlertingConfig,
-    check_interval: Duration,
     notifier: Notifier,
 ) -> Result<()> {
     let mut whitelist = if let Some(ref path) = monitoring.whitelist_path {
@@ -40,6 +39,8 @@ fn spawn_log_monitor(
     let files = watcher.discover()?;
     println!("Found {} files to monitor", files.len());
 
+    let check_interval_ms = monitoring.check_interval_ms;
+
     tokio::spawn(async move {
         let mut reader = Reader::new().expect("Failed to create reader");
         for file in files {
@@ -49,7 +50,9 @@ fn spawn_log_monitor(
             }
         }
 
-        let mut interval = time::interval(check_interval);
+        // Periodic file discovery only if check_interval_ms is configured
+        let mut discovery_interval =
+            check_interval_ms.map(|ms| time::interval(Duration::from_millis(ms)));
 
         loop {
             tokio::select! {
@@ -80,7 +83,7 @@ fn spawn_log_monitor(
                         }
                     }
                 }
-                _ = interval.tick() => {
+                _ = async { discovery_interval.as_mut().unwrap().tick().await }, if discovery_interval.is_some() => {
                     match watcher.discover() {
                         Ok(new_files) => {
                             for file in new_files {
@@ -140,8 +143,7 @@ async fn main() -> Result<()> {
     // Start Log Monitoring (if configured)
     if let Some(monitoring) = config.monitoring {
         println!("Starting log monitoring...");
-        let check_interval = Duration::from_millis(config.general.check_interval_ms);
-        spawn_log_monitor(monitoring, config.alerting, check_interval, notifier)?;
+        spawn_log_monitor(monitoring, config.alerting, notifier)?;
     }
 
     println!("Sentinel started...");

--- a/bin/sentinel/src/notifier.rs
+++ b/bin/sentinel/src/notifier.rs
@@ -74,10 +74,10 @@ impl Notifier {
             let payload = match *kind {
                 "feishu" => json!({
                     "msg_type": "text",
-                    "content": { "text": "✅ Log Sentinel started and webhook is connected." }
+                    "content": { "text": "✅ Sentinel started and webhook is connected." }
                 }),
                 _ => json!({
-                    "text": "✅ Log Sentinel started and webhook is connected.",
+                    "text": "✅ Sentinel started and webhook is connected.",
                     "channel": "#alerts-devops",
                     "username": "System-Monitor"
                 }),


### PR DESCRIPTION
## Summary

- Make the `[monitoring]` config section optional — sentinel can now run in probes-only mode (no log monitoring) by omitting the section entirely.
- Refactor log monitoring from running inline in `main` into a spawned tokio task, consistent with `probe` and `chain_monitor`. `main` now only orchestrates startup and waits for `ctrl_c` to shut down cleanly.
- Move `check_interval_ms` from `[general]` into `[monitoring]` as an optional field. When omitted, periodic glob re-scan is skipped and only the initial set of files is monitored. The now-empty `[general]` section is removed.

## Motivation

Some deployments only want probe-based failure alerts (e.g. health checks on RPC endpoints) without log monitoring. The previous config required a fully-populated `[monitoring]` section, and `main` would deadlock on log events even if `file_patterns` were empty. With these changes, a minimal probes-only config looks like:

```toml
[alerting]
feishu_webhook = "..."

[[probes]]
url = "http://127.0.0.1:8545"
tag = "node1"
```

## Test plan

- [x] `cargo check -p sentinel` passes
- [x] Run sentinel with probes-only config and verify probe alerts fire on RPC failure
- [x] Run sentinel with full `[monitoring]` + probes config and verify both log alerts and probe alerts work as before
- [x] Run sentinel with `[monitoring]` but no `check_interval_ms` and verify initial files are monitored but no new files get picked up