### PR TITLE
feat(cli): add --output json support to stake commands and update E2E parsing

### DIFF
--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -52,8 +52,14 @@ fn main() {
             }
         },
         command::SubCommands::Stake(stake_cmd) => match stake_cmd.command {
-            stake::SubCommands::Create(create_cmd) => create_cmd.execute(),
-            stake::SubCommands::Get(get_cmd) => get_cmd.execute(),
+            stake::SubCommands::Create(mut create_cmd) => {
+                create_cmd.output_format = output_format;
+                create_cmd.execute()
+            }
+            stake::SubCommands::Get(mut get_cmd) => {
+                get_cmd.output_format = output_format;
+                get_cmd.execute()
+            }
         },
         command::SubCommands::Node(node_cmd) => match node_cmd.command {
             node::SubCommands::Start(start_cmd) => start_cmd.execute(),

--- a/bin/gravity_cli/src/stake/create.rs
+++ b/bin/gravity_cli/src/stake/create.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use crate::{
     command::Executable,
     contract::{Staking, STAKING_ADDRESS},
+    output::OutputFormat,
     util::{format_ether, parse_ether},
 };
 
@@ -33,6 +34,10 @@ pub struct CreateCommand {
     /// Lockup duration in seconds (default 30 days)
     #[clap(long, default_value = "2592000")]
     pub lockup_duration: u64,
+
+    /// Output format (injected from global flag)
+    #[clap(skip)]
+    pub output_format: OutputFormat,
 }
 
 impl Executable for CreateCommand {
@@ -44,9 +49,13 @@ impl Executable for CreateCommand {
 
 impl CreateCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let is_json = matches!(self.output_format, OutputFormat::Json);
+
         // 1. Initialize Provider and Wallet
-        println!("Creating new StakePool...\n");
-        println!("1. Initializing connection...");
+        if !is_json {
+            println!("Creating new StakePool...\n");
+            println!("1. Initializing connection...");
+        }
 
         let rpc_url = self.rpc_url.ok_or_else(|| {
             anyhow::anyhow!(
@@ -56,7 +65,9 @@ impl CreateCommand {
         let gas_limit = self.gas_limit.unwrap_or(2_000_000);
         let gas_price = self.gas_price.unwrap_or(20);
 
-        println!("   RPC URL: {rpc_url}");
+        if !is_json {
+            println!("   RPC URL: {rpc_url}");
+        }
         let private_key_input = rpassword::prompt_password_stdout(
             "Enter private key (hex, with or without 0x prefix): ",
         )
@@ -68,21 +79,31 @@ impl CreateCommand {
             .map_err(|e| anyhow::anyhow!("Invalid private key: {e}"))?;
         let signer = PrivateKeySigner::from(private_key);
         let wallet_address = signer.address();
-        println!("   Wallet address: {wallet_address:?}");
-        println!("   Staking contract: {STAKING_ADDRESS:?}");
+        if !is_json {
+            println!("   Wallet address: {wallet_address:?}");
+            println!("   Staking contract: {STAKING_ADDRESS:?}");
+        }
 
         // Create provider
         let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url.parse()?);
 
         let chain_id = provider.get_chain_id().await?;
-        println!("   Chain ID: {chain_id}");
+        if !is_json {
+            println!("   Chain ID: {chain_id}");
+        }
         let balance = provider.get_balance(wallet_address).await?;
-        println!("   Wallet balance: {} ETH\n", format_ether(balance));
+        if !is_json {
+            println!("   Wallet balance: {} ETH\n", format_ether(balance));
+        }
 
         // 2. Create StakePool
-        println!("2. Creating StakePool...");
+        if !is_json {
+            println!("2. Creating StakePool...");
+        }
         let stake_wei = parse_ether(&self.stake_amount)?;
-        println!("   Stake amount: {} ETH", self.stake_amount);
+        if !is_json {
+            println!("   Stake amount: {} ETH", self.stake_amount);
+        }
 
         // Calculate lockup expiration timestamp.
         //
@@ -100,8 +121,10 @@ impl CreateCommand {
             .await?
             .ok_or(anyhow::anyhow!("Failed to get latest block"))?;
         let current_timestamp = block.header.timestamp;
-        println!("   Current timestamp: {current_timestamp} (seconds)");
-        println!("   Lockup duration: {} seconds", self.lockup_duration);
+        if !is_json {
+            println!("   Current timestamp: {current_timestamp} (seconds)");
+            println!("   Lockup duration: {} seconds", self.lockup_duration);
+        }
         let locked_until = (current_timestamp + self.lockup_duration) * 1_000_000;
 
         let call = Staking::createPoolCall {
@@ -124,7 +147,9 @@ impl CreateCommand {
             })
             .await?;
         let tx_hash = *pending_tx.tx_hash();
-        println!("   Transaction hash: {tx_hash}");
+        if !is_json {
+            println!("   Transaction hash: {tx_hash}");
+        }
         let _ = pending_tx
             .with_required_confirmations(2)
             .with_timeout(Some(std::time::Duration::from_secs(60)))
@@ -135,32 +160,48 @@ impl CreateCommand {
             .get_transaction_receipt(tx_hash)
             .await?
             .ok_or(anyhow::anyhow!("Failed to get transaction receipt"))?;
-        println!(
-            "   Transaction confirmed, block number: {}",
-            receipt.block_number.ok_or(anyhow::anyhow!("Failed to get block number"))?
-        );
-        println!("   Gas used: {}", receipt.gas_used);
-        println!(
-            "   Transaction cost: {} ETH",
-            format_ether(U256::from(receipt.effective_gas_price) * U256::from(receipt.gas_used))
-        );
+        let block_number =
+            receipt.block_number.ok_or(anyhow::anyhow!("Failed to get block number"))?;
+        if !is_json {
+            println!("   Transaction confirmed, block number: {block_number}");
+            println!("   Gas used: {}", receipt.gas_used);
+            println!(
+                "   Transaction cost: {} ETH",
+                format_ether(
+                    U256::from(receipt.effective_gas_price) * U256::from(receipt.gas_used)
+                )
+            );
+        }
 
         // Parse PoolCreated event to get the new pool address
         let mut found_pool = None;
         for log in receipt.logs() {
             if let Ok(event) = Staking::PoolCreated::decode_log(&log.inner) {
-                println!("\n✓ StakePool created successfully!");
-                println!("   Pool address: {}", event.pool);
-                println!("   Owner: {}", event.owner);
-                println!("   Pool index: {}", event.poolIndex);
-                found_pool = Some(event.pool);
+                found_pool = Some((event.pool, event.owner, event.poolIndex));
                 break;
             }
         }
-        let stake_pool = found_pool.ok_or(anyhow::anyhow!("Failed to find PoolCreated event"))?;
+        let (stake_pool, owner, pool_index) =
+            found_pool.ok_or(anyhow::anyhow!("Failed to find PoolCreated event"))?;
 
-        println!("\nUse this address with validator join:");
-        println!("  --stake-pool {stake_pool}");
+        if is_json {
+            let result = serde_json::json!({
+                "pool_address": format!("{stake_pool}"),
+                "owner": format!("{owner}"),
+                "pool_index": pool_index,
+                "tx_hash": format!("{tx_hash}"),
+                "block_number": block_number,
+                "gas_used": receipt.gas_used,
+            });
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        } else {
+            println!("\n✓ StakePool created successfully!");
+            println!("   Pool address: {stake_pool}");
+            println!("   Owner: {owner}");
+            println!("   Pool index: {pool_index}");
+            println!("\nUse this address with validator join:");
+            println!("  --stake-pool {stake_pool}");
+        }
 
         Ok(())
     }

--- a/bin/gravity_cli/src/stake/get.rs
+++ b/bin/gravity_cli/src/stake/get.rs
@@ -3,11 +3,13 @@ use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::eth::{BlockNumberOrTag, Filter, TransactionInput, TransactionRequest};
 use alloy_sol_types::{SolCall, SolValue};
 use clap::Parser;
+use serde::Serialize;
 use std::str::FromStr;
 
 use crate::{
     command::Executable,
     contract::{Staking, STAKING_ADDRESS},
+    output::OutputFormat,
     util::format_ether,
 };
 
@@ -39,6 +41,17 @@ pub struct GetCommand {
     /// Query voting power for each pool
     #[clap(long, default_value = "true")]
     pub show_voting_power: bool,
+
+    /// Output format (injected from global flag)
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+#[derive(Debug, Serialize)]
+struct PoolInfo {
+    pool_address: String,
+    voting_power: Option<String>,
+    block_number: u64,
 }
 
 /// Reth's default max block range for log queries
@@ -53,7 +66,11 @@ impl Executable for GetCommand {
 
 impl GetCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
-        println!("Querying StakePools for owner: {}\n", self.owner);
+        let is_json = matches!(self.output_format, OutputFormat::Json);
+
+        if !is_json {
+            println!("Querying StakePools for owner: {}\n", self.owner);
+        }
 
         // Parse owner address and pad to 32 bytes for topic filtering
         let owner_addr = Address::from_str(&self.owner)?;
@@ -100,30 +117,27 @@ impl GetCommand {
             .event_signature(POOL_CREATED_EVENT_SIGNATURE.parse::<B256>()?)
             .topic3(owner_topic.parse::<B256>()?);
 
-        println!("Searching for PoolCreated events...");
-        println!("   Contract: {STAKING_ADDRESS:?}");
-        println!("   Owner: {owner_addr:?}");
-        println!("   Block range: {from_block} to {to_block}\n");
+        if !is_json {
+            println!("Searching for PoolCreated events...");
+            println!("   Contract: {STAKING_ADDRESS:?}");
+            println!("   Owner: {owner_addr:?}");
+            println!("   Block range: {from_block} to {to_block}\n");
+        }
 
         let logs = provider.get_logs(&filter).await?;
 
         if logs.is_empty() {
-            println!("No StakePools found for this owner.");
+            if is_json {
+                println!("{}", serde_json::to_string_pretty(&serde_json::json!({"pools": []}))?);
+            } else {
+                println!("No StakePools found for this owner.");
+            }
             return Ok(());
         }
 
-        println!("Found {} StakePool(s):\n", logs.len());
+        let mut pools = Vec::new();
 
-        // Print header
-        if self.show_voting_power {
-            println!("{:<44} {:<16} {:<12}", "Pool Address", "Voting Power", "Block Number");
-            println!("{}", "-".repeat(76));
-        } else {
-            println!("{:<44} {:<12}", "Pool Address", "Block Number");
-            println!("{}", "-".repeat(58));
-        }
-
-        for log in logs {
+        for log in &logs {
             // Extract pool address from topics[2]
             let pool_topic = log.topics().get(2).ok_or(anyhow::anyhow!("Missing pool topic"))?;
             // Pool address is the last 20 bytes of the 32-byte topic
@@ -132,8 +146,7 @@ impl GetCommand {
 
             let block_number = log.block_number.ok_or(anyhow::anyhow!("Missing block number"))?;
 
-            if self.show_voting_power {
-                // Query voting power
+            let voting_power = if self.show_voting_power {
                 let call = Staking::getPoolVotingPowerNowCall { pool: pool_address };
                 let input: Bytes = call.abi_encode().into();
                 let result = provider
@@ -144,27 +157,52 @@ impl GetCommand {
                     })
                     .await;
 
-                let voting_power = match result {
+                match result {
                     Ok(data) => {
                         let power = U256::abi_decode(&data)
                             .map_err(|e| anyhow::anyhow!("Failed to decode voting power: {e}"))?;
-                        format!("{} ETH", format_ether(power))
+                        Some(format!("{} ETH", format_ether(power)))
                     }
-                    Err(_) => "N/A".to_string(),
-                };
-
-                println!(
-                    "{:<44} {:<16} {:<12}",
-                    format!("{pool_address:?}"),
-                    voting_power,
-                    block_number
-                );
+                    Err(_) => Some("N/A".to_string()),
+                }
             } else {
-                println!("{:<44} {:<12}", format!("{pool_address:?}"), block_number);
-            }
+                None
+            };
+
+            pools.push(PoolInfo {
+                pool_address: format!("{pool_address:?}"),
+                voting_power,
+                block_number,
+            });
         }
 
-        println!();
+        if is_json {
+            let result = serde_json::json!({ "pools": pools });
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        } else {
+            println!("Found {} StakePool(s):\n", pools.len());
+
+            if self.show_voting_power {
+                println!("{:<44} {:<16} {:<12}", "Pool Address", "Voting Power", "Block Number");
+                println!("{}", "-".repeat(76));
+                for p in &pools {
+                    println!(
+                        "{:<44} {:<16} {:<12}",
+                        p.pool_address,
+                        p.voting_power.as_deref().unwrap_or(""),
+                        p.block_number
+                    );
+                }
+            } else {
+                println!("{:<44} {:<12}", "Pool Address", "Block Number");
+                println!("{}", "-".repeat(58));
+                for p in &pools {
+                    println!("{:<44} {:<12}", p.pool_address, p.block_number);
+                }
+            }
+            println!();
+        }
+
         Ok(())
     }
 }

--- a/gravity_e2e/gravity_e2e/cluster/manager.py
+++ b/gravity_e2e/gravity_e2e/cluster/manager.py
@@ -648,6 +648,8 @@ class Cluster:
         rpc_url = self._get_first_rpc_url()
         list_cmd = [
             str(self.gravity_cli_path),
+            "--output",
+            "json",
             "validator",
             "list",
             "--rpc-url",
@@ -743,6 +745,8 @@ class Cluster:
 
         get_cmd = [
             str(self.gravity_cli_path),
+            "--output",
+            "json",
             "stake",
             "get",
             "--rpc-url",
@@ -770,25 +774,10 @@ class Cluster:
             LOG.warning(f"Failed to query stakes for {node_id}: {stderr_str}")
             return None
 
-        # Parse pool addresses from table rows after the header:
-        #   Pool Address                                 Voting Power     Block Number
-        #   --------------------------------------------------------------------------
-        #   0x2f3eaf272bf50acd32fe9c4c4c7c8f3f9cb6bde4   1. ETH           136
-        import re
-
-        pool_address = None
-        in_table = False
-        for line in stdout_str.splitlines():
-            if line.startswith("Pool Address"):
-                in_table = True
-                continue
-            if in_table and line.startswith("---"):
-                continue  # skip separator
-            if in_table:
-                match = re.match(r"^(0x[0-9a-fA-F]{40})\s+", line)
-                if match:
-                    pool_address = match.group(1)
-                    # Don't break — we want the LAST pool address
+        # Parse JSON output: {"pools": [{"pool_address": "0x...", ...}, ...]}
+        stake_data = json.loads(stdout_str)
+        pools = stake_data.get("pools", [])
+        pool_address = pools[-1]["pool_address"] if pools else None
 
         if pool_address:
             node.stake_pool = pool_address
@@ -829,6 +818,8 @@ class Cluster:
 
         create_cmd = [
             str(self.gravity_cli_path),
+            "--output",
+            "json",
             "stake",
             "create",
             "--rpc-url",
@@ -859,18 +850,14 @@ class Cluster:
             LOG.error(f"Failed to create stake for {node_id}: {stderr_str}")
             raise RuntimeError(f"Failed to create stake for {node_id}: {stderr_str}")
 
-        # Parse pool address from output line like:
-        #    Pool address: 0x2F3Eaf272bf50aCd32fe9C4C4c7C8F3f9CB6bde4
-        import re
-
-        match = re.search(r"Pool address:\s*(0x[0-9a-fA-F]{40})", stdout_str)
-        if not match:
-            LOG.error(f"Could not parse pool address from stake create output")
+        # Parse JSON output: {"pool_address": "0x...", ...}
+        create_data = json.loads(stdout_str)
+        pool_address = create_data.get("pool_address")
+        if not pool_address:
+            LOG.error("Could not parse pool address from stake create output")
             raise RuntimeError(
                 f"Failed to parse pool address from stake create output: {stdout_str}"
             )
-
-        pool_address = match.group(1)
         node.stake_pool = pool_address
         LOG.info(f"Created stake pool for node {node_id}: {pool_address}")
         return pool_address

--- a/gravity_e2e/gravity_e2e/utils/validator_utils.py
+++ b/gravity_e2e/gravity_e2e/utils/validator_utils.py
@@ -409,6 +409,7 @@ async def execute_validator_list(
     """
     list_cmd = [
         str(gravity_cli_path),
+        "--output", "json",
         "validator", "list",
         "--rpc-url", rpc_url,
     ]

--- a/gravity_e2e/runner.py
+++ b/gravity_e2e/runner.py
@@ -481,6 +481,7 @@ def main():
                     resume=args.resume,
                 )
             except Exception:
+                logger.exception(f"Suite {test_dir.name} failed with exception:")
                 failed_suites.append(test_dir.name)
 
         if failed_suites:


### PR DESCRIPTION
Extend the global --output flag to `stake create` and `stake get` commands (previously only validator list, dkg/epoch status had it). Update all E2E test CLI invocations to use --output json and replace fragile regex/table parsing with structured JSON parsing, ensuring compatibility with PR #647's default-to-plain output change.
