### PR TITLE
feat(sentinel): add explorer block-advance monitor

### DIFF
--- a/bin/sentinel/sentinel.toml.example
+++ b/bin/sentinel/sentinel.toml.example
@@ -50,3 +50,19 @@ url = "http://localhost:8546"
 tag = "VFN-0 RPC Node"
 # check_interval_seconds defaults to 30
 # failure_threshold defaults to 3
+
+# Explorer block-advance monitor (optional).
+# Polls Blockscout v2 /api/v2/stats and alerts when total_blocks does not
+# advance within the poll window (i.e. any block interval > poll_interval_seconds).
+[explorer_monitor]
+api_base = "https://api.explorer-testnet.gravity.xyz"
+tag = "explorer-testnet"
+# Poll cadence in seconds; doubles as the stall threshold.
+# Default: 1
+poll_interval_seconds = 1
+# Priority for stall alerts (API failures always escalate to P0).
+# Default: "p1"
+priority = "p1"
+# Consecutive API failures before emitting a single P0 degraded alert.
+# Default: 5
+api_failure_threshold = 5

--- a/bin/sentinel/src/config.rs
+++ b/bin/sentinel/src/config.rs
@@ -33,6 +33,8 @@ pub struct Config {
     pub probes: Vec<ProbeConfig>,
     /// Optional chain monitor configuration for on-chain bridge event monitoring.
     pub chain_monitor: Option<crate::chain_monitor::config::ChainMonitorConfig>,
+    /// Optional explorer block-advance monitor (Blockscout v2 API).
+    pub explorer_monitor: Option<ExplorerMonitorConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -51,6 +53,34 @@ fn default_probe_interval() -> u64 {
 
 fn default_probe_threshold() -> u32 {
     3
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ExplorerMonitorConfig {
+    /// Blockscout v2 API base, e.g. "https://api.explorer-testnet.gravity.xyz"
+    pub api_base: String,
+    /// Label shown in alert messages
+    pub tag: Option<String>,
+    #[serde(default = "default_explorer_poll_interval")]
+    pub poll_interval_seconds: u64,
+    #[serde(default = "default_explorer_priority")]
+    pub priority: Priority,
+    /// Consecutive API failures before sending a P0 degraded-API alert.
+    /// Keeps transient network blips from being misreported as chain stalls.
+    #[serde(default = "default_explorer_api_failure_threshold")]
+    pub api_failure_threshold: u32,
+}
+
+fn default_explorer_poll_interval() -> u64 {
+    1
+}
+
+fn default_explorer_priority() -> Priority {
+    Priority::P1
+}
+
+fn default_explorer_api_failure_threshold() -> u32 {
+    5
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/bin/sentinel/src/explorer_monitor.rs
+++ b/bin/sentinel/src/explorer_monitor.rs
@@ -1,0 +1,124 @@
+use crate::{
+    config::{ExplorerMonitorConfig, Priority},
+    notifier::Notifier,
+};
+use anyhow::{anyhow, Result};
+use reqwest::Client;
+use serde::Deserialize;
+use std::time::Duration;
+use tokio::time::{self, MissedTickBehavior};
+
+/// Blockscout v2 `/api/v2/stats` response fragment. `total_blocks` is a
+/// stringified integer in the Blockscout schema.
+#[derive(Deserialize)]
+struct StatsResp {
+    total_blocks: String,
+}
+
+pub struct ExplorerMonitor {
+    config: ExplorerMonitorConfig,
+    client: Client,
+    notifier: Notifier,
+}
+
+impl ExplorerMonitor {
+    pub fn new(config: ExplorerMonitorConfig, notifier: Notifier) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_else(|_| Client::new());
+        Self { config, client, notifier }
+    }
+
+    pub fn tag(&self) -> String {
+        self.config.tag.clone().unwrap_or_else(|| self.config.api_base.clone())
+    }
+
+    async fn fetch_height(&self) -> Result<u64> {
+        let url = format!("{}/api/v2/stats", self.config.api_base.trim_end_matches('/'));
+        let resp: StatsResp =
+            self.client.get(&url).send().await?.error_for_status()?.json().await?;
+        resp.total_blocks
+            .parse::<u64>()
+            .map_err(|e| anyhow!("invalid total_blocks {:?}: {e}", resp.total_blocks))
+    }
+
+    pub async fn run(self) {
+        let tag = self.tag();
+        let mut timer = time::interval(Duration::from_secs(self.config.poll_interval_seconds));
+        timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let mut last_height: Option<u64> = None;
+        // Height for which a stall alert has already been sent; prevents
+        // repeating the same alert every tick while the chain is stuck.
+        let mut last_alerted_stall_height: Option<u64> = None;
+        let mut api_failures: u32 = 0;
+        let mut api_alert_sent = false;
+
+        println!("Starting explorer monitor for {tag}");
+        loop {
+            timer.tick().await;
+            match self.fetch_height().await {
+                Ok(h) => {
+                    if api_alert_sent {
+                        println!("Explorer API recovered for {tag} (height={h})");
+                        api_alert_sent = false;
+                    }
+                    api_failures = 0;
+
+                    match last_height {
+                        None => {
+                            last_height = Some(h);
+                        }
+                        Some(prev) if h > prev => {
+                            last_height = Some(h);
+                            last_alerted_stall_height = None;
+                        }
+                        Some(prev) => {
+                            // h <= prev: height did not advance within the poll window.
+                            if last_alerted_stall_height != Some(prev) {
+                                let msg = format!(
+                                    "Explorer block height stalled on {tag}\n  \
+                                     height: {prev} (no advance in {}s)\n  \
+                                     api: {}",
+                                    self.config.poll_interval_seconds, self.config.api_base,
+                                );
+                                println!("TRIGGERING ALERT: {msg}");
+                                if let Err(e) = self
+                                    .notifier
+                                    .alert(&msg, "EXPLORER", self.config.priority)
+                                    .await
+                                {
+                                    eprintln!("Failed to send explorer alert: {e:?}");
+                                }
+                                last_alerted_stall_height = Some(prev);
+                            }
+                            // Keep last_height unchanged so that when height finally
+                            // advances we reset last_alerted_stall_height above.
+                        }
+                    }
+                }
+                Err(e) => {
+                    api_failures += 1;
+                    eprintln!(
+                        "Explorer API error for {tag} ({api_failures}/{}): {e}",
+                        self.config.api_failure_threshold
+                    );
+                    if !api_alert_sent && api_failures >= self.config.api_failure_threshold {
+                        let msg = format!(
+                            "Explorer API unreachable on {tag} ({} consecutive failures)\n  \
+                             api: {}\n  last error: {e}",
+                            api_failures, self.config.api_base,
+                        );
+                        println!("TRIGGERING ALERT: {msg}");
+                        if let Err(err) = self.notifier.alert(&msg, "EXPLORER", Priority::P0).await
+                        {
+                            eprintln!("Failed to send explorer API alert: {err:?}");
+                        }
+                        api_alert_sent = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bin/sentinel/src/main.rs
+++ b/bin/sentinel/src/main.rs
@@ -1,6 +1,7 @@
 mod analyzer;
 mod chain_monitor;
 mod config;
+mod explorer_monitor;
 mod notifier;
 mod probe;
 mod reader;
@@ -10,6 +11,7 @@ mod whitelist;
 use crate::{
     analyzer::Analyzer,
     config::Config,
+    explorer_monitor::ExplorerMonitor,
     notifier::Notifier,
     probe::Probe,
     reader::Reader,
@@ -138,6 +140,15 @@ async fn main() -> Result<()> {
         chain_monitor::spawn_all(chain_config, notifier.clone())
             .await
             .context("Failed to start chain monitors")?;
+    }
+
+    // Start Explorer Monitor (if configured)
+    if let Some(explorer_cfg) = config.explorer_monitor {
+        let monitor = ExplorerMonitor::new(explorer_cfg, notifier.clone());
+        println!("Starting explorer monitor for {}...", monitor.tag());
+        tokio::spawn(async move {
+            monitor.run().await;
+        });
     }
 
     // Start Log Monitoring (if configured)


### PR DESCRIPTION
## Summary

Adds a new optional `explorer_monitor` to the `sentinel` binary that watches a Blockscout v2 explorer and alerts when the reported block height does not advance within a poll window.

- Polls `<api_base>/api/v2/stats` every `poll_interval_seconds` (default `1`) and reads `total_blocks`.
- Stall → **P1** alert (configurable), de-duplicated per stuck height so the chain being stuck does not produce one alert per tick.
- Consecutive API failures → single **P0** alert (threshold `5`), so a transient network/DNS blip is not misreported as a chain stall; logs a recovery line once the API comes back.
- `MissedTickBehavior::Skip` prevents request latency from backing up the tick loop.

The monitor is a black-box user-visible signal: a stall fires if either the chain is actually slow **or** the explorer indexer is lagging behind the chain. Internal node health is still the job of the existing RPC `probes`.

## Config

```toml
[explorer_monitor]
api_base = "https://api.explorer-testnet.gravity.xyz"
tag = "explorer-testnet"
poll_interval_seconds = 1
priority = "p1"
api_failure_threshold = 5
```

Section is optional; omit it to keep the current sentinel behavior unchanged.

## Test plan

- [x] `cargo build -p sentinel`
- [x] `cargo clippy -p sentinel --all-targets -- -D warnings`
- [x] `cargo fmt -p sentinel --check`
- [ ] Point a local sentinel at `api.explorer-testnet.gravity.xyz`, confirm no false positives over a 30-minute run.
- [ ] Block outbound traffic to the API with `iptables` for ~30s, confirm a single P0 "API unreachable" alert + recovery log line.
- [ ] Verify height-stall alert de-duplicates while a synthetic stall persists and re-arms after height advances.