### PR TITLE
feat(cli): add localnet command for cluster lifecycle and faucet

### DIFF
--- a/bin/gravity_cli/src/command.rs
+++ b/bin/gravity_cli/src/command.rs
@@ -1,7 +1,7 @@
 use crate::{
     completions::CompletionsCommand, dkg::DKGCommand, epoch::EpochCommand, genesis::GenesisCommand,
-    init::InitCommand, node::NodeCommand, output::OutputFormat, stake::StakeCommand,
-    status::StatusCommand, unwind::UnwindCommand, validator::ValidatorCommand,
+    init::InitCommand, localnet::LocalnetCommand, node::NodeCommand, output::OutputFormat,
+    stake::StakeCommand, status::StatusCommand, unwind::UnwindCommand, validator::ValidatorCommand,
 };
 use build_info::{build_information, BUILD_PKG_VERSION};
 use clap::{Parser, Subcommand};
@@ -68,6 +68,8 @@ pub enum SubCommands {
     Completions(CompletionsCommand),
     /// Initialize configuration interactively
     Init(InitCommand),
+    /// Local cluster lifecycle (start/stop/faucet/reset)
+    Localnet(LocalnetCommand),
 }
 
 pub trait Executable {

--- a/bin/gravity_cli/src/localnet/common.rs
+++ b/bin/gravity_cli/src/localnet/common.rs
@@ -20,10 +20,7 @@ pub fn resolve_cluster_dir(explicit: Option<&str>) -> Result<PathBuf, anyhow::Er
     if let Some(dir) = explicit {
         let p = PathBuf::from(dir);
         if !p.join("start.sh").exists() {
-            return Err(anyhow!(
-                "cluster-dir {} does not contain start.sh",
-                p.display()
-            ));
+            return Err(anyhow!("cluster-dir {} does not contain start.sh", p.display()));
         }
         return Ok(p);
     }
@@ -85,8 +82,9 @@ pub fn load_cluster_toml(path: &Path) -> Result<ClusterToml, anyhow::Error> {
 
 /// Derive the default RPC URL for a cluster (first node's host + port).
 pub fn derive_rpc_url(cfg: &ClusterToml) -> Result<String, anyhow::Error> {
-    let first = cfg.nodes.first().ok_or_else(|| {
-        anyhow!("cluster.toml has no [[nodes]] entries — cannot derive RPC URL")
-    })?;
+    let first = cfg
+        .nodes
+        .first()
+        .ok_or_else(|| anyhow!("cluster.toml has no [[nodes]] entries — cannot derive RPC URL"))?;
     Ok(format!("http://{}:{}", first.host, first.rpc_port))
 }

--- a/bin/gravity_cli/src/localnet/common.rs
+++ b/bin/gravity_cli/src/localnet/common.rs
@@ -1,0 +1,92 @@
+use anyhow::{anyhow, Context};
+use serde::Deserialize;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Default faucet key — the standard anvil/hardhat test account #0. Matches
+/// `cluster/faucet.sh`. Users can override via `--from-key` or the
+/// `GRAVITY_LOCALNET_FAUCET_KEY` env var.
+pub const DEFAULT_ANVIL_FAUCET_KEY: &str =
+    "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+/// Resolve the cluster scripts directory.
+///
+/// Precedence:
+/// 1. Explicit `--cluster-dir` / `GRAVITY_CLUSTER_DIR`
+/// 2. Walk up from CWD looking for `cluster/start.sh` (up to 5 parents)
+pub fn resolve_cluster_dir(explicit: Option<&str>) -> Result<PathBuf, anyhow::Error> {
+    if let Some(dir) = explicit {
+        let p = PathBuf::from(dir);
+        if !p.join("start.sh").exists() {
+            return Err(anyhow!(
+                "cluster-dir {} does not contain start.sh",
+                p.display()
+            ));
+        }
+        return Ok(p);
+    }
+
+    let cwd = std::env::current_dir().context("reading current directory")?;
+    let mut current: &Path = &cwd;
+    for _ in 0..6 {
+        let candidate = current.join("cluster").join("start.sh");
+        if candidate.exists() {
+            return Ok(current.join("cluster"));
+        }
+        match current.parent() {
+            Some(p) => current = p,
+            None => break,
+        }
+    }
+    Err(anyhow!(
+        "Could not locate `cluster/start.sh` from {} (walked up 6 levels). \
+         Pass --cluster-dir or set GRAVITY_CLUSTER_DIR",
+        cwd.display()
+    ))
+}
+
+/// Resolve the cluster config file path. Defaults to `<cluster_dir>/cluster.toml`.
+pub fn resolve_config(cluster_dir: &Path, explicit: Option<&str>) -> PathBuf {
+    match explicit {
+        Some(p) => PathBuf::from(p),
+        None => cluster_dir.join("cluster.toml"),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClusterToml {
+    pub cluster: ClusterSection,
+    #[serde(default)]
+    pub nodes: Vec<NodeEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClusterSection {
+    pub base_dir: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct NodeEntry {
+    pub host: String,
+    pub rpc_port: u16,
+}
+
+/// Parse `cluster.toml` for the fields the CLI needs (base_dir, first node's
+/// host/rpc_port). Other TOML keys are ignored.
+pub fn load_cluster_toml(path: &Path) -> Result<ClusterToml, anyhow::Error> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("reading cluster config {}", path.display()))?;
+    let parsed: ClusterToml = toml::from_str(&content)
+        .with_context(|| format!("parsing cluster config {}", path.display()))?;
+    Ok(parsed)
+}
+
+/// Derive the default RPC URL for a cluster (first node's host + port).
+pub fn derive_rpc_url(cfg: &ClusterToml) -> Result<String, anyhow::Error> {
+    let first = cfg.nodes.first().ok_or_else(|| {
+        anyhow!("cluster.toml has no [[nodes]] entries — cannot derive RPC URL")
+    })?;
+    Ok(format!("http://{}:{}", first.host, first.rpc_port))
+}

--- a/bin/gravity_cli/src/localnet/faucet.rs
+++ b/bin/gravity_cli/src/localnet/faucet.rs
@@ -96,7 +96,8 @@ impl FaucetCommand {
         // Resolve faucet key. The default is hardcoded to the well-known anvil
         // test account so `gravity-cli localnet faucet --to 0x... --amount 1`
         // just works on a fresh cluster. Env override is intentional per design.
-        let key_hex_owned = self.from_key.clone().unwrap_or_else(|| DEFAULT_ANVIL_FAUCET_KEY.to_string());
+        let key_hex_owned =
+            self.from_key.clone().unwrap_or_else(|| DEFAULT_ANVIL_FAUCET_KEY.to_string());
         let key_hex = key_hex_owned.trim().strip_prefix("0x").unwrap_or(key_hex_owned.trim());
         let key_bytes = hex::decode(key_hex)
             .map_err(|e| anyhow::anyhow!("faucet key is not valid hex: {e}"))?;
@@ -107,7 +108,7 @@ impl FaucetCommand {
 
         let is_json = matches!(self.output_format, OutputFormat::Json);
         if !is_json {
-            println!("{} {}", "[localnet faucet]".cyan(), format!("rpc: {rpc_url}"));
+            println!("{} rpc: {rpc_url}", "[localnet faucet]".cyan());
             println!(
                 "{} sending {} ETH from {from:?} → {to:?}",
                 "[localnet faucet]".cyan(),
@@ -115,9 +116,7 @@ impl FaucetCommand {
             );
         }
 
-        let provider = ProviderBuilder::new()
-            .wallet(signer)
-            .connect_http(rpc_url.parse()?);
+        let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url.parse()?);
 
         let balance = provider.get_balance(from).await?;
         if balance < amount_wei {

--- a/bin/gravity_cli/src/localnet/faucet.rs
+++ b/bin/gravity_cli/src/localnet/faucet.rs
@@ -1,0 +1,173 @@
+use alloy_primitives::{Address, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::eth::TransactionRequest;
+use alloy_signer::k256::ecdsa::SigningKey;
+use alloy_signer_local::PrivateKeySigner;
+use clap::Parser;
+use colored::Colorize;
+use serde::Serialize;
+use std::str::FromStr;
+
+use crate::{
+    command::Executable,
+    localnet::common::{
+        derive_rpc_url, load_cluster_toml, resolve_cluster_dir, resolve_config,
+        DEFAULT_ANVIL_FAUCET_KEY,
+    },
+    output::OutputFormat,
+    util::{format_ether, parse_ether},
+};
+
+#[derive(Debug, Parser)]
+pub struct FaucetCommand {
+    /// Destination address (0x-prefixed)
+    #[clap(long)]
+    pub to: String,
+
+    /// Amount to send. Decimal ETH by default; pass --wei to treat as wei.
+    #[clap(long)]
+    pub amount: String,
+
+    /// Treat --amount as a wei-denominated integer instead of decimal ETH
+    #[clap(long)]
+    pub wei: bool,
+
+    /// RPC URL. If unset, derived from cluster.toml (first node).
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Funding private key (hex). Defaults to the anvil test key (matches
+    /// cluster/faucet.sh) unless GRAVITY_LOCALNET_FAUCET_KEY is set or this
+    /// flag is passed.
+    #[clap(long, env = "GRAVITY_LOCALNET_FAUCET_KEY")]
+    pub from_key: Option<String>,
+
+    #[clap(long, env = "GRAVITY_CLUSTER_DIR")]
+    pub cluster_dir: Option<String>,
+
+    #[clap(long)]
+    pub config: Option<String>,
+
+    /// Output format
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+#[derive(Serialize)]
+struct FaucetReceipt {
+    tx_hash: String,
+    from: String,
+    to: String,
+    amount_wei: String,
+    block_number: Option<u64>,
+    status: bool,
+    gas_used: Option<u64>,
+}
+
+impl Executable for FaucetCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl FaucetCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let to = Address::from_str(&self.to)
+            .map_err(|e| anyhow::anyhow!("invalid --to address: {e}"))?;
+        let amount_wei = if self.wei {
+            U256::from_str(&self.amount)
+                .map_err(|e| anyhow::anyhow!("invalid --amount wei: {e}"))?
+        } else {
+            parse_ether(&self.amount)?
+        };
+
+        // Resolve RPC URL: CLI/env first, then cluster.toml fallback.
+        let rpc_url = match self.rpc_url.clone() {
+            Some(u) => u,
+            None => {
+                let cluster_dir = resolve_cluster_dir(self.cluster_dir.as_deref())?;
+                let config = resolve_config(&cluster_dir, self.config.as_deref());
+                let cfg = load_cluster_toml(&config)?;
+                derive_rpc_url(&cfg)?
+            }
+        };
+
+        // Resolve faucet key. The default is hardcoded to the well-known anvil
+        // test account so `gravity-cli localnet faucet --to 0x... --amount 1`
+        // just works on a fresh cluster. Env override is intentional per design.
+        let key_hex_owned = self.from_key.clone().unwrap_or_else(|| DEFAULT_ANVIL_FAUCET_KEY.to_string());
+        let key_hex = key_hex_owned.trim().strip_prefix("0x").unwrap_or(key_hex_owned.trim());
+        let key_bytes = hex::decode(key_hex)
+            .map_err(|e| anyhow::anyhow!("faucet key is not valid hex: {e}"))?;
+        let signing_key = SigningKey::from_slice(&key_bytes)
+            .map_err(|e| anyhow::anyhow!("invalid faucet private key: {e}"))?;
+        let signer = PrivateKeySigner::from(signing_key);
+        let from = signer.address();
+
+        let is_json = matches!(self.output_format, OutputFormat::Json);
+        if !is_json {
+            println!("{} {}", "[localnet faucet]".cyan(), format!("rpc: {rpc_url}"));
+            println!(
+                "{} sending {} ETH from {from:?} → {to:?}",
+                "[localnet faucet]".cyan(),
+                format_ether(amount_wei)
+            );
+        }
+
+        let provider = ProviderBuilder::new()
+            .wallet(signer)
+            .connect_http(rpc_url.parse()?);
+
+        let balance = provider.get_balance(from).await?;
+        if balance < amount_wei {
+            return Err(anyhow::anyhow!(
+                "faucet balance {} ETH is less than requested {} ETH",
+                format_ether(balance),
+                format_ether(amount_wei)
+            ));
+        }
+
+        let tx = TransactionRequest::default().to(to).value(amount_wei);
+        let pending = provider.send_transaction(tx).await?;
+        let tx_hash = *pending.tx_hash();
+
+        if !is_json {
+            println!(
+                "{} tx submitted: {tx_hash:?} — waiting for receipt…",
+                "[localnet faucet]".cyan()
+            );
+        }
+        let receipt = pending.get_receipt().await?;
+        let result = FaucetReceipt {
+            tx_hash: format!("{tx_hash:?}"),
+            from: format!("{from:?}"),
+            to: format!("{to:?}"),
+            amount_wei: amount_wei.to_string(),
+            block_number: receipt.block_number,
+            status: receipt.status(),
+            gas_used: Some(receipt.gas_used),
+        };
+
+        match self.output_format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+            OutputFormat::Plain => {
+                let status = if result.status { "success".green() } else { "FAILED".red() };
+                println!(
+                    "{} {} at block {} (gas_used={})",
+                    "[localnet faucet]".cyan(),
+                    status,
+                    result.block_number.map(|b| b.to_string()).unwrap_or_else(|| "?".into()),
+                    result.gas_used.map(|g| g.to_string()).unwrap_or_else(|| "?".into())
+                );
+            }
+        }
+
+        if !result.status {
+            return Err(anyhow::anyhow!("faucet tx reverted"));
+        }
+        Ok(())
+    }
+}

--- a/bin/gravity_cli/src/localnet/mod.rs
+++ b/bin/gravity_cli/src/localnet/mod.rs
@@ -1,0 +1,30 @@
+mod common;
+mod faucet;
+mod reset;
+mod start;
+mod stop;
+
+use clap::{Parser, Subcommand};
+
+pub use faucet::FaucetCommand;
+pub use reset::ResetCommand;
+pub use start::StartCommand;
+pub use stop::StopCommand;
+
+#[derive(Debug, Parser)]
+pub struct LocalnetCommand {
+    #[command(subcommand)]
+    pub command: SubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SubCommands {
+    /// Start the local cluster (invokes cluster/start.sh)
+    Start(StartCommand),
+    /// Stop the local cluster (invokes cluster/stop.sh)
+    Stop(StopCommand),
+    /// Send a single transfer from the faucet key to an address
+    Faucet(FaucetCommand),
+    /// Stop the cluster and remove its base_dir (destructive)
+    Reset(ResetCommand),
+}

--- a/bin/gravity_cli/src/localnet/reset.rs
+++ b/bin/gravity_cli/src/localnet/reset.rs
@@ -65,9 +65,8 @@ impl Executable for ResetCommand {
 
         if base_dir.exists() {
             println!("{} removing {}", "[localnet reset]".cyan(), base_dir.display());
-            std::fs::remove_dir_all(&base_dir).map_err(|e| {
-                anyhow::anyhow!("failed to remove {}: {e}", base_dir.display())
-            })?;
+            std::fs::remove_dir_all(&base_dir)
+                .map_err(|e| anyhow::anyhow!("failed to remove {}: {e}", base_dir.display()))?;
             println!("{} {}", "[localnet reset]".cyan(), "done".green());
         } else {
             println!(

--- a/bin/gravity_cli/src/localnet/reset.rs
+++ b/bin/gravity_cli/src/localnet/reset.rs
@@ -1,0 +1,81 @@
+use clap::Parser;
+use colored::Colorize;
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+    process::Command,
+};
+
+use crate::{
+    command::Executable,
+    localnet::common::{load_cluster_toml, resolve_cluster_dir, resolve_config},
+};
+
+#[derive(Debug, Parser)]
+pub struct ResetCommand {
+    #[clap(long, env = "GRAVITY_CLUSTER_DIR")]
+    pub cluster_dir: Option<String>,
+
+    #[clap(long)]
+    pub config: Option<String>,
+
+    /// Skip interactive confirmation when base_dir is not under /tmp
+    #[clap(long)]
+    pub force: bool,
+
+    /// Skip the implicit stop.sh call (use when cluster is already stopped)
+    #[clap(long)]
+    pub skip_stop: bool,
+}
+
+impl Executable for ResetCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let cluster_dir = resolve_cluster_dir(self.cluster_dir.as_deref())?;
+        let config = resolve_config(&cluster_dir, self.config.as_deref());
+        let cfg = load_cluster_toml(&config)?;
+        let base_dir = PathBuf::from(&cfg.cluster.base_dir);
+
+        if !base_dir.starts_with("/tmp") && !self.force {
+            print!(
+                "{} base_dir {} is outside /tmp — delete anyway? [y/N] ",
+                "[localnet reset]".yellow(),
+                base_dir.display()
+            );
+            io::stdout().flush()?;
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            if !matches!(input.trim(), "y" | "Y") {
+                println!("{} aborted", "[localnet reset]".cyan());
+                return Ok(());
+            }
+        }
+
+        if !self.skip_stop {
+            let stop_script = cluster_dir.join("stop.sh");
+            if stop_script.exists() {
+                println!("{} stopping cluster first…", "[localnet reset]".cyan());
+                let _ = Command::new("bash")
+                    .arg(&stop_script)
+                    .arg("--config")
+                    .arg(&config)
+                    .current_dir(&cluster_dir)
+                    .status();
+            }
+        }
+
+        if base_dir.exists() {
+            println!("{} removing {}", "[localnet reset]".cyan(), base_dir.display());
+            std::fs::remove_dir_all(&base_dir).map_err(|e| {
+                anyhow::anyhow!("failed to remove {}: {e}", base_dir.display())
+            })?;
+            println!("{} {}", "[localnet reset]".cyan(), "done".green());
+        } else {
+            println!(
+                "{} {} does not exist — nothing to remove",
+                "[localnet reset]".cyan(),
+                base_dir.display()
+            );
+        }
+        Ok(())
+    }
+}

--- a/bin/gravity_cli/src/localnet/start.rs
+++ b/bin/gravity_cli/src/localnet/start.rs
@@ -42,23 +42,21 @@ impl Executable for StartCommand {
         let script = cluster_dir.join("start.sh");
 
         println!(
-            "{} {}",
+            "{} running {} with config {}",
             "[localnet start]".cyan(),
-            format!("running {} with config {}", script.display(), config.display())
+            script.display(),
+            config.display()
         );
 
         let mut cmd = Command::new("bash");
-        cmd.arg(&script)
-            .arg("--config")
-            .arg(&config)
-            .current_dir(&cluster_dir);
+        cmd.arg(&script).arg("--config").arg(&config).current_dir(&cluster_dir);
         if let Some(ref nodes) = self.nodes {
             cmd.arg("--nodes").arg(nodes);
         }
 
-        let status = cmd.status().map_err(|e| {
-            anyhow::anyhow!("failed to execute {}: {e}", script.display())
-        })?;
+        let status = cmd
+            .status()
+            .map_err(|e| anyhow::anyhow!("failed to execute {}: {e}", script.display()))?;
         if !status.success() {
             return Err(anyhow::anyhow!(
                 "start.sh exited with code {}",
@@ -82,28 +80,22 @@ fn wait_for_rpc_ready(rpc_url: &str, timeout: Duration) -> Result<(), anyhow::Er
         let provider = ProviderBuilder::new().connect_http(url);
         let deadline = Instant::now() + timeout;
         println!(
-            "{} {}",
+            "{} waiting for {rpc_url} (timeout {}s)…",
             "[localnet start]".cyan(),
-            format!("waiting for {rpc_url} (timeout {}s)…", timeout.as_secs())
+            timeout.as_secs()
         );
         loop {
             let err: String = match provider.get_block_number().await {
                 Ok(n) if n > 0 => {
-                    println!(
-                        "{} {}",
-                        "[localnet start]".cyan(),
-                        format!("RPC ready — block={n}").green()
-                    );
+                    let ready = format!("RPC ready — block={n}").green();
+                    println!("{} {ready}", "[localnet start]".cyan());
                     return Ok(());
                 }
                 Ok(_) => "block number still 0".into(),
                 Err(e) => e.to_string(),
             };
             if Instant::now() >= deadline {
-                return Err(anyhow::anyhow!(
-                    "RPC not ready after {}s: {err}",
-                    timeout.as_secs()
-                ));
+                return Err(anyhow::anyhow!("RPC not ready after {}s: {err}", timeout.as_secs()));
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/bin/gravity_cli/src/localnet/start.rs
+++ b/bin/gravity_cli/src/localnet/start.rs
@@ -1,0 +1,111 @@
+use alloy_provider::{Provider, ProviderBuilder};
+use clap::Parser;
+use colored::Colorize;
+use std::{
+    process::Command,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    command::Executable,
+    localnet::common::{derive_rpc_url, load_cluster_toml, resolve_cluster_dir, resolve_config},
+};
+
+#[derive(Debug, Parser)]
+pub struct StartCommand {
+    /// Directory containing the cluster scripts. Defaults to walking up from
+    /// CWD looking for `cluster/start.sh`.
+    #[clap(long, env = "GRAVITY_CLUSTER_DIR")]
+    pub cluster_dir: Option<String>,
+
+    /// Path to cluster.toml (defaults to <cluster_dir>/cluster.toml)
+    #[clap(long)]
+    pub config: Option<String>,
+
+    /// Comma-separated list of node IDs to start (defaults to all)
+    #[clap(long)]
+    pub nodes: Option<String>,
+
+    /// Poll eth_blockNumber until it advances past 0 (or timeout)
+    #[clap(long)]
+    pub wait_ready: bool,
+
+    /// Timeout for --wait-ready in seconds
+    #[clap(long, default_value = "60")]
+    pub wait_timeout_secs: u64,
+}
+
+impl Executable for StartCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let cluster_dir = resolve_cluster_dir(self.cluster_dir.as_deref())?;
+        let config = resolve_config(&cluster_dir, self.config.as_deref());
+        let script = cluster_dir.join("start.sh");
+
+        println!(
+            "{} {}",
+            "[localnet start]".cyan(),
+            format!("running {} with config {}", script.display(), config.display())
+        );
+
+        let mut cmd = Command::new("bash");
+        cmd.arg(&script)
+            .arg("--config")
+            .arg(&config)
+            .current_dir(&cluster_dir);
+        if let Some(ref nodes) = self.nodes {
+            cmd.arg("--nodes").arg(nodes);
+        }
+
+        let status = cmd.status().map_err(|e| {
+            anyhow::anyhow!("failed to execute {}: {e}", script.display())
+        })?;
+        if !status.success() {
+            return Err(anyhow::anyhow!(
+                "start.sh exited with code {}",
+                status.code().unwrap_or(-1)
+            ));
+        }
+
+        if self.wait_ready {
+            let cfg = load_cluster_toml(&config)?;
+            let rpc_url = derive_rpc_url(&cfg)?;
+            wait_for_rpc_ready(&rpc_url, Duration::from_secs(self.wait_timeout_secs))?;
+        }
+        Ok(())
+    }
+}
+
+fn wait_for_rpc_ready(rpc_url: &str, timeout: Duration) -> Result<(), anyhow::Error> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let url = rpc_url.parse().map_err(|e| anyhow::anyhow!("invalid rpc url: {e}"))?;
+        let provider = ProviderBuilder::new().connect_http(url);
+        let deadline = Instant::now() + timeout;
+        println!(
+            "{} {}",
+            "[localnet start]".cyan(),
+            format!("waiting for {rpc_url} (timeout {}s)…", timeout.as_secs())
+        );
+        loop {
+            let err: String = match provider.get_block_number().await {
+                Ok(n) if n > 0 => {
+                    println!(
+                        "{} {}",
+                        "[localnet start]".cyan(),
+                        format!("RPC ready — block={n}").green()
+                    );
+                    return Ok(());
+                }
+                Ok(_) => "block number still 0".into(),
+                Err(e) => e.to_string(),
+            };
+            if Instant::now() >= deadline {
+                return Err(anyhow::anyhow!(
+                    "RPC not ready after {}s: {err}",
+                    timeout.as_secs()
+                ));
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+}

--- a/bin/gravity_cli/src/localnet/stop.rs
+++ b/bin/gravity_cli/src/localnet/stop.rs
@@ -29,28 +29,23 @@ impl Executable for StopCommand {
         let script = cluster_dir.join("stop.sh");
 
         println!(
-            "{} {}",
+            "{} running {} with config {}",
             "[localnet stop]".cyan(),
-            format!("running {} with config {}", script.display(), config.display())
+            script.display(),
+            config.display()
         );
 
         let mut cmd = Command::new("bash");
-        cmd.arg(&script)
-            .arg("--config")
-            .arg(&config)
-            .current_dir(&cluster_dir);
+        cmd.arg(&script).arg("--config").arg(&config).current_dir(&cluster_dir);
         if let Some(ref nodes) = self.nodes {
             cmd.arg("--nodes").arg(nodes);
         }
 
-        let status = cmd.status().map_err(|e| {
-            anyhow::anyhow!("failed to execute {}: {e}", script.display())
-        })?;
+        let status = cmd
+            .status()
+            .map_err(|e| anyhow::anyhow!("failed to execute {}: {e}", script.display()))?;
         if !status.success() {
-            return Err(anyhow::anyhow!(
-                "stop.sh exited with code {}",
-                status.code().unwrap_or(-1)
-            ));
+            return Err(anyhow::anyhow!("stop.sh exited with code {}", status.code().unwrap_or(-1)));
         }
         Ok(())
     }

--- a/bin/gravity_cli/src/localnet/stop.rs
+++ b/bin/gravity_cli/src/localnet/stop.rs
@@ -1,0 +1,57 @@
+use clap::Parser;
+use colored::Colorize;
+use std::process::Command;
+
+use crate::{
+    command::Executable,
+    localnet::common::{resolve_cluster_dir, resolve_config},
+};
+
+#[derive(Debug, Parser)]
+pub struct StopCommand {
+    /// Directory containing the cluster scripts
+    #[clap(long, env = "GRAVITY_CLUSTER_DIR")]
+    pub cluster_dir: Option<String>,
+
+    /// Path to cluster.toml (defaults to <cluster_dir>/cluster.toml)
+    #[clap(long)]
+    pub config: Option<String>,
+
+    /// Comma-separated list of node IDs to stop (defaults to all)
+    #[clap(long)]
+    pub nodes: Option<String>,
+}
+
+impl Executable for StopCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let cluster_dir = resolve_cluster_dir(self.cluster_dir.as_deref())?;
+        let config = resolve_config(&cluster_dir, self.config.as_deref());
+        let script = cluster_dir.join("stop.sh");
+
+        println!(
+            "{} {}",
+            "[localnet stop]".cyan(),
+            format!("running {} with config {}", script.display(), config.display())
+        );
+
+        let mut cmd = Command::new("bash");
+        cmd.arg(&script)
+            .arg("--config")
+            .arg(&config)
+            .current_dir(&cluster_dir);
+        if let Some(ref nodes) = self.nodes {
+            cmd.arg("--nodes").arg(nodes);
+        }
+
+        let status = cmd.status().map_err(|e| {
+            anyhow::anyhow!("failed to execute {}: {e}", script.display())
+        })?;
+        if !status.success() {
+            return Err(anyhow::anyhow!(
+                "stop.sh exited with code {}",
+                status.code().unwrap_or(-1)
+            ));
+        }
+        Ok(())
+    }
+}

--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -7,6 +7,7 @@ pub mod epoch;
 pub mod errors;
 pub mod genesis;
 pub mod init;
+pub mod localnet;
 pub mod node;
 pub mod output;
 pub mod stake;
@@ -85,6 +86,15 @@ fn main() {
         }
         command::SubCommands::Completions(completions_cmd) => completions_cmd.execute(),
         command::SubCommands::Init(init_cmd) => init_cmd.execute(),
+        command::SubCommands::Localnet(ln_cmd) => match ln_cmd.command {
+            localnet::SubCommands::Start(c) => c.execute(),
+            localnet::SubCommands::Stop(c) => c.execute(),
+            localnet::SubCommands::Faucet(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
+            localnet::SubCommands::Reset(c) => c.execute(),
+        },
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
## Summary

`gravity-cli localnet` wraps the existing `cluster/*.sh` scripts and adds a one-shot faucet so the common dev-loop is accessible without bash invocations and remembered working directories:

- **`localnet start [--nodes ...] [--wait-ready]`** — shells out to `cluster/start.sh` and (optionally) polls `eth_blockNumber` until the chain produces blocks.
- **`localnet stop [--nodes ...]`** — shells out to `cluster/stop.sh`.
- **`localnet faucet --to <addr> --amount <eth>`** — direct alloy transfer. Default funding key is the well-known anvil test account (matches `cluster/faucet.sh`); overridable via `--from-key` or `GRAVITY_LOCALNET_FAUCET_KEY`. Supports `--wei` for raw amounts and `--output json`.
- **`localnet reset [--force]`** — stops the cluster and removes `base_dir`. Prompts before deleting paths outside `/tmp` unless `--force` is given.

## Design notes

- **Cluster dir auto-discovery**: walks up from CWD looking for `cluster/start.sh` (up to 6 levels). `--cluster-dir` / `GRAVITY_CLUSTER_DIR` override.
- **Config**: defaults to `<cluster_dir>/cluster.toml`. We parse only `cluster.base_dir` and `nodes[0].host/rpc_port` — other keys are ignored.
- **Faucet key default** comes from `DEFAULT_ANVIL_FAUCET_KEY`, the same anvil test account `cluster/faucet.sh` uses. Precedence: `--from-key` > `GRAVITY_LOCALNET_FAUCET_KEY` > default.
- No new node-side endpoints; this is pure tooling.

## Test plan

- [x] `cargo build -p gravity_cli --profile quick-release` clean
- [x] `localnet stop` from `/tmp` → clear "Could not locate cluster/start.sh" error
- [x] `localnet stop` from repo root → invokes stop.sh, reports no PID found
- [x] `localnet faucet --to 0x... --amount 0.5` against running localnet → tx submitted, receipt received, exit 0
- [x] `localnet faucet ... --wei 100` → treats amount as wei
- [x] `GRAVITY_LOCALNET_FAUCET_KEY=<anvil_1>` override → tx sent from anvil account 1
- [x] `--output json localnet faucet` → structured receipt
- [x] `localnet reset --force` with no cluster running → stops (no-op), reports base_dir missing, exits 0
- [x] Invalid `--to` → clear error, no tx submitted