### PR TITLE
feat(cli): add tx simulate and trace subcommands

### DIFF
--- a/bin/gravity_cli/src/command.rs
+++ b/bin/gravity_cli/src/command.rs
@@ -1,7 +1,7 @@
 use crate::{
     completions::CompletionsCommand, dkg::DKGCommand, epoch::EpochCommand, genesis::GenesisCommand,
     init::InitCommand, node::NodeCommand, output::OutputFormat, stake::StakeCommand,
-    status::StatusCommand, unwind::UnwindCommand, validator::ValidatorCommand,
+    status::StatusCommand, tx::TxCommand, unwind::UnwindCommand, validator::ValidatorCommand,
 };
 use build_info::{build_information, BUILD_PKG_VERSION};
 use clap::{Parser, Subcommand};
@@ -68,6 +68,8 @@ pub enum SubCommands {
     Completions(CompletionsCommand),
     /// Initialize configuration interactively
     Init(InitCommand),
+    /// Transaction simulation and tracing helpers
+    Tx(TxCommand),
 }
 
 pub trait Executable {

--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -11,6 +11,7 @@ pub mod node;
 pub mod output;
 pub mod stake;
 pub mod status;
+pub mod tx;
 pub mod unwind;
 pub mod util;
 pub mod validator;
@@ -85,6 +86,20 @@ fn main() {
         }
         command::SubCommands::Completions(completions_cmd) => completions_cmd.execute(),
         command::SubCommands::Init(init_cmd) => init_cmd.execute(),
+        command::SubCommands::Tx(tx_cmd) => match tx_cmd.command {
+            tx::SubCommands::Simulate(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
+            tx::SubCommands::Trace(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
+            tx::SubCommands::TraceCall(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
+        },
     };
 
     if let Err(e) = result {

--- a/bin/gravity_cli/src/tx/common.rs
+++ b/bin/gravity_cli/src/tx/common.rs
@@ -1,0 +1,118 @@
+use alloy_primitives::{Bytes, U256};
+
+/// Standard Solidity revert selectors.
+const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0]; // Error(string)
+const PANIC_UINT_SELECTOR: [u8; 4] = [0x4e, 0x48, 0x7b, 0x71]; // Panic(uint256)
+
+/// Human-readable decoding of revert bytes returned by eth_call / debug_traceCall.
+/// Handles the two standard selectors and falls back to hex for unknown formats.
+pub fn decode_revert(data: &[u8]) -> String {
+    if data.is_empty() {
+        return "reverted (no data)".to_string();
+    }
+    if data.len() < 4 {
+        return format!("raw: 0x{}", hex::encode(data));
+    }
+
+    let selector: [u8; 4] = data[0..4].try_into().unwrap();
+    let payload = &data[4..];
+
+    if selector == ERROR_STRING_SELECTOR {
+        if let Some(msg) = decode_error_string(payload) {
+            return format!("Error(\"{msg}\")");
+        }
+    } else if selector == PANIC_UINT_SELECTOR {
+        if payload.len() >= 32 {
+            let code = U256::from_be_slice(&payload[0..32]);
+            return format!("Panic(0x{code:x})");
+        }
+    }
+
+    format!("raw: 0x{}", hex::encode(data))
+}
+
+/// ABI-decode `Error(string)` payload: [offset:32][length:32][utf8 bytes padded to 32].
+fn decode_error_string(payload: &[u8]) -> Option<String> {
+    if payload.len() < 64 {
+        return None;
+    }
+    // payload[0..32] is the offset — for a single string arg it's always 0x20,
+    // but we don't need to validate it since we use length directly.
+    let len = U256::from_be_slice(&payload[32..64]).try_into().ok()?;
+    let len: usize = len;
+    if payload.len() < 64 + len {
+        return None;
+    }
+    std::str::from_utf8(&payload[64..64 + len]).ok().map(|s| s.to_string())
+}
+
+/// Parse a 0x-prefixed hex string returned in JSON-RPC error `data` fields.
+pub fn parse_hex_data(raw: &str) -> Option<Bytes> {
+    let trimmed = raw.trim().trim_matches('"');
+    let no_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    if no_prefix.is_empty() {
+        return Some(Bytes::new());
+    }
+    hex::decode(no_prefix).ok().map(Bytes::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_error_string_standard() {
+        // keccak("Error(string)")[0..4] = 0x08c379a0
+        // Encoded revert for Error("bad stuff"):
+        //   08c379a0                                          (selector)
+        //   0000...0020                                       (offset = 32)
+        //   0000...0009                                       (length = 9)
+        //   6261642073747566660000000000000000000000000000000000000000000000 (padded "bad stuff")
+        let mut data = hex::decode("08c379a0").unwrap();
+        data.extend_from_slice(&[0u8; 31]);
+        data.push(0x20);
+        data.extend_from_slice(&[0u8; 31]);
+        data.push(0x09);
+        let mut tail = b"bad stuff".to_vec();
+        tail.resize(32, 0);
+        data.extend_from_slice(&tail);
+
+        assert_eq!(decode_revert(&data), r#"Error("bad stuff")"#);
+    }
+
+    #[test]
+    fn decode_panic_arithmetic_overflow() {
+        // Panic(uint256) with code 0x11 (arithmetic overflow)
+        let mut data = hex::decode("4e487b71").unwrap();
+        let mut payload = [0u8; 32];
+        payload[31] = 0x11;
+        data.extend_from_slice(&payload);
+
+        assert_eq!(decode_revert(&data), "Panic(0x11)");
+    }
+
+    #[test]
+    fn decode_empty_reverts_to_no_data() {
+        assert_eq!(decode_revert(&[]), "reverted (no data)");
+    }
+
+    #[test]
+    fn decode_unknown_selector_falls_back_to_hex() {
+        let data = hex::decode("deadbeef1234").unwrap();
+        assert_eq!(decode_revert(&data), "raw: 0xdeadbeef1234");
+    }
+
+    #[test]
+    fn decode_short_payload_falls_back() {
+        let data = hex::decode("ab").unwrap();
+        assert_eq!(decode_revert(&data), "raw: 0xab");
+    }
+
+    #[test]
+    fn parse_hex_handles_quoted_and_unquoted() {
+        assert_eq!(parse_hex_data("\"0xdead\"").unwrap().as_ref(), &[0xde, 0xad]);
+        assert_eq!(parse_hex_data("0xdead").unwrap().as_ref(), &[0xde, 0xad]);
+        assert_eq!(parse_hex_data("dead").unwrap().as_ref(), &[0xde, 0xad]);
+        assert_eq!(parse_hex_data("0x").unwrap().as_ref(), &[] as &[u8]);
+    }
+}

--- a/bin/gravity_cli/src/tx/common.rs
+++ b/bin/gravity_cli/src/tx/common.rs
@@ -21,11 +21,9 @@ pub fn decode_revert(data: &[u8]) -> String {
         if let Some(msg) = decode_error_string(payload) {
             return format!("Error(\"{msg}\")");
         }
-    } else if selector == PANIC_UINT_SELECTOR {
-        if payload.len() >= 32 {
-            let code = U256::from_be_slice(&payload[0..32]);
-            return format!("Panic(0x{code:x})");
-        }
+    } else if selector == PANIC_UINT_SELECTOR && payload.len() >= 32 {
+        let code = U256::from_be_slice(&payload[0..32]);
+        return format!("Panic(0x{code:x})");
     }
 
     format!("raw: 0x{}", hex::encode(data))

--- a/bin/gravity_cli/src/tx/mod.rs
+++ b/bin/gravity_cli/src/tx/mod.rs
@@ -1,0 +1,26 @@
+mod common;
+mod simulate;
+mod trace;
+mod trace_call;
+
+use clap::{Parser, Subcommand};
+
+pub use simulate::SimulateCommand;
+pub use trace::TraceCommand;
+pub use trace_call::TraceCallCommand;
+
+#[derive(Debug, Parser)]
+pub struct TxCommand {
+    #[command(subcommand)]
+    pub command: SubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SubCommands {
+    /// Simulate a call via eth_call + eth_estimateGas (no signing, no submission)
+    Simulate(SimulateCommand),
+    /// Trace an already-mined transaction via debug_traceTransaction
+    Trace(TraceCommand),
+    /// Trace a hypothetical call via debug_traceCall (no submission)
+    TraceCall(TraceCallCommand),
+}

--- a/bin/gravity_cli/src/tx/simulate.rs
+++ b/bin/gravity_cli/src/tx/simulate.rs
@@ -1,11 +1,15 @@
-use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_primitives::{Address, TxKind, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::eth::{BlockNumberOrTag, TransactionInput, TransactionRequest};
 use clap::Parser;
 use serde::Serialize;
 use std::str::FromStr;
 
-use crate::{command::Executable, output::OutputFormat, tx::common::{decode_revert, parse_hex_data}};
+use crate::{
+    command::Executable,
+    output::OutputFormat,
+    tx::common::{decode_revert, parse_hex_data},
+};
 
 #[derive(Debug, Parser)]
 pub struct SimulateCommand {
@@ -114,14 +118,14 @@ fn build_tx_request(cmd: &SimulateCommand) -> Result<TransactionRequest, anyhow:
         }
         None => TxKind::Create,
     };
-    let data = parse_hex_data(&cmd.data)
-        .ok_or_else(|| anyhow::anyhow!("--data is not valid hex"))?;
+    let data =
+        parse_hex_data(&cmd.data).ok_or_else(|| anyhow::anyhow!("--data is not valid hex"))?;
     let value = U256::from_str(&cmd.value).map_err(|e| anyhow::anyhow!("invalid --value: {e}"))?;
 
     Ok(TransactionRequest {
         from,
         to: Some(to_kind),
-        input: TransactionInput::new(Bytes::from(data)),
+        input: TransactionInput::new(data),
         value: Some(value),
         ..Default::default()
     })
@@ -140,7 +144,7 @@ fn extract_revert_reason<E: std::error::Error + 'static>(err: &E) -> Option<Stri
     // Look for the common `data: 0x…` or `data: "0x…"` pattern that alloy emits.
     if let Some(idx) = msg.find("data: ") {
         let tail = &msg[idx + "data: ".len()..];
-        let end = tail.find(|c: char| c == ',' || c == '}' || c == ')').unwrap_or(tail.len());
+        let end = tail.find([',', '}', ')']).unwrap_or(tail.len());
         let raw = &tail[..end];
         if let Some(bytes) = parse_hex_data(raw) {
             return Some(decode_revert(&bytes));

--- a/bin/gravity_cli/src/tx/simulate.rs
+++ b/bin/gravity_cli/src/tx/simulate.rs
@@ -1,0 +1,183 @@
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::eth::{BlockNumberOrTag, TransactionInput, TransactionRequest};
+use clap::Parser;
+use serde::Serialize;
+use std::str::FromStr;
+
+use crate::{command::Executable, output::OutputFormat, tx::common::{decode_revert, parse_hex_data}};
+
+#[derive(Debug, Parser)]
+pub struct SimulateCommand {
+    /// RPC URL for gravity node
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Sender address (msg.sender for the simulated call)
+    #[clap(long)]
+    pub from: Option<String>,
+
+    /// Destination address (None = contract creation)
+    #[clap(long)]
+    pub to: Option<String>,
+
+    /// Hex-encoded calldata (empty for plain transfer)
+    #[clap(long, default_value = "0x")]
+    pub data: String,
+
+    /// Value in wei (not ETH)
+    #[clap(long, default_value = "0")]
+    pub value: String,
+
+    /// Block tag or number (latest, pending, earliest, finalized, safe, or a decimal/hex number)
+    #[clap(long, default_value = "latest")]
+    pub block: String,
+
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+#[derive(Serialize)]
+struct SimulateResult {
+    success: bool,
+    return_data: Option<String>,
+    gas_estimate: Option<u64>,
+    revert_reason: Option<String>,
+    error: Option<String>,
+}
+
+impl Executable for SimulateCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl SimulateCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "--rpc-url is required. Set via CLI flag, GRAVITY_RPC_URL env var, or ~/.gravity/config.toml"
+            )
+        })?;
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+
+        let tx = build_tx_request(&self)?;
+        let block = parse_block_tag(&self.block)?;
+
+        // Attempt eth_call first — this gives us return data or revert reason.
+        let call_res = provider.call(tx.clone()).block(block.into()).await;
+        // Then estimate gas — only meaningful if the call succeeded, but we try
+        // regardless so the user sees the estimate when possible.
+        let gas_res = provider.estimate_gas(tx).block(block.into()).await;
+
+        let result = match call_res {
+            Ok(bytes) => SimulateResult {
+                success: true,
+                return_data: Some(format!("0x{}", hex::encode(&bytes))),
+                gas_estimate: gas_res.ok(),
+                revert_reason: None,
+                error: None,
+            },
+            Err(e) => {
+                let revert = extract_revert_reason(&e);
+                SimulateResult {
+                    success: false,
+                    return_data: None,
+                    gas_estimate: None,
+                    revert_reason: revert,
+                    error: Some(e.to_string()),
+                }
+            }
+        };
+
+        emit_result(&result, self.output_format);
+        if !result.success {
+            std::process::exit(1);
+        }
+        Ok(())
+    }
+}
+
+fn build_tx_request(cmd: &SimulateCommand) -> Result<TransactionRequest, anyhow::Error> {
+    let from = cmd
+        .from
+        .as_deref()
+        .map(Address::from_str)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid --from: {e}"))?;
+    let to_kind = match cmd.to.as_deref() {
+        Some(addr) => {
+            let parsed =
+                Address::from_str(addr).map_err(|e| anyhow::anyhow!("invalid --to: {e}"))?;
+            TxKind::Call(parsed)
+        }
+        None => TxKind::Create,
+    };
+    let data = parse_hex_data(&cmd.data)
+        .ok_or_else(|| anyhow::anyhow!("--data is not valid hex"))?;
+    let value = U256::from_str(&cmd.value).map_err(|e| anyhow::anyhow!("invalid --value: {e}"))?;
+
+    Ok(TransactionRequest {
+        from,
+        to: Some(to_kind),
+        input: TransactionInput::new(Bytes::from(data)),
+        value: Some(value),
+        ..Default::default()
+    })
+}
+
+fn parse_block_tag(s: &str) -> Result<BlockNumberOrTag, anyhow::Error> {
+    BlockNumberOrTag::from_str(s).map_err(|e| anyhow::anyhow!("invalid --block: {e}"))
+}
+
+/// Try to pull revert bytes out of a transport error and decode them.
+fn extract_revert_reason<E: std::error::Error + 'static>(err: &E) -> Option<String> {
+    // Walk the error chain looking for a serde representation that contains
+    // JSON-RPC error payload with a `data` field — most alloy transport errors
+    // serialize this way in Display. As a fallback, scan the Display string.
+    let msg = err.to_string();
+    // Look for the common `data: 0x…` or `data: "0x…"` pattern that alloy emits.
+    if let Some(idx) = msg.find("data: ") {
+        let tail = &msg[idx + "data: ".len()..];
+        let end = tail.find(|c: char| c == ',' || c == '}' || c == ')').unwrap_or(tail.len());
+        let raw = &tail[..end];
+        if let Some(bytes) = parse_hex_data(raw) {
+            return Some(decode_revert(&bytes));
+        }
+    }
+    // Fallback: many reverts surface as `execution reverted: <reason>` in the message.
+    if let Some(idx) = msg.find("execution reverted") {
+        let tail = &msg[idx..];
+        let line_end = tail.find('\n').unwrap_or(tail.len());
+        return Some(tail[..line_end].trim().to_string());
+    }
+    None
+}
+
+fn emit_result(r: &SimulateResult, fmt: OutputFormat) {
+    match fmt {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(r).unwrap());
+        }
+        OutputFormat::Plain => {
+            if r.success {
+                println!("success");
+                if let Some(ref data) = r.return_data {
+                    println!("return: {data}");
+                }
+                if let Some(gas) = r.gas_estimate {
+                    println!("gas:    {gas}");
+                }
+            } else {
+                println!("reverted");
+                if let Some(ref reason) = r.revert_reason {
+                    println!("reason: {reason}");
+                }
+                if let Some(ref err) = r.error {
+                    println!("rpc:    {err}");
+                }
+            }
+        }
+    }
+}

--- a/bin/gravity_cli/src/tx/trace.rs
+++ b/bin/gravity_cli/src/tx/trace.rs
@@ -1,0 +1,135 @@
+use alloy_primitives::B256;
+use alloy_provider::{Provider, ProviderBuilder};
+use clap::{Parser, ValueEnum};
+use serde_json::{json, Value};
+use std::{borrow::Cow, str::FromStr};
+
+use crate::{command::Executable, output::OutputFormat};
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum Tracer {
+    /// Geth callTracer — returns a tree of CALL/STATICCALL/DELEGATECALL frames
+    Call,
+    /// Geth prestateTracer — returns pre-execution state of touched accounts
+    Prestate,
+    /// Geth 4byteTracer — returns histogram of 4-byte selectors invoked
+    #[clap(name = "4byte")]
+    FourByte,
+    /// Opcode-level structured trace (default in reth / geth)
+    Opcode,
+    /// Geth noopTracer — for latency benchmarking
+    Noop,
+}
+
+impl Tracer {
+    /// Returns the geth-compatible tracer name, or None for the default
+    /// (opcode-level) tracer which is indicated by omitting the tracer field.
+    pub(crate) fn geth_name(self) -> Option<&'static str> {
+        match self {
+            Tracer::Call => Some("callTracer"),
+            Tracer::Prestate => Some("prestateTracer"),
+            Tracer::FourByte => Some("4byteTracer"),
+            Tracer::Noop => Some("noopTracer"),
+            Tracer::Opcode => None,
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct TraceCommand {
+    /// Transaction hash to trace
+    #[clap(value_name = "TX_HASH")]
+    pub tx_hash: String,
+
+    /// RPC URL
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Tracer to use
+    #[clap(long, value_enum, default_value = "call")]
+    pub tracer: Tracer,
+
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+impl Executable for TraceCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl TraceCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
+            anyhow::anyhow!("--rpc-url is required")
+        })?;
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+        let tx_hash = B256::from_str(&self.tx_hash)
+            .map_err(|e| anyhow::anyhow!("invalid tx hash: {e}"))?;
+
+        let opts = match Tracer::geth_name(self.tracer) {
+            Some(name) => json!({ "tracer": name }),
+            None => json!({}),
+        };
+        let params = json!([tx_hash, opts]);
+        let trace: Value = provider
+            .client()
+            .request(Cow::Borrowed("debug_traceTransaction"), params)
+            .await?;
+
+        render_trace(&trace, self.tracer, self.output_format);
+        Ok(())
+    }
+}
+
+pub fn render_trace(trace: &Value, tracer: Tracer, fmt: OutputFormat) {
+    match fmt {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(trace).unwrap_or_default());
+        }
+        OutputFormat::Plain => match tracer {
+            Tracer::Call => render_call_tree(trace, 0),
+            _ => {
+                // Other tracers have varied shapes; pretty-print the JSON.
+                println!("{}", serde_json::to_string_pretty(trace).unwrap_or_default());
+            }
+        },
+    }
+}
+
+/// Render a geth callTracer frame as an indented tree:
+///   CALL  from -> to  value=N gas=N/N
+///     CALL ...
+fn render_call_tree(frame: &Value, depth: usize) {
+    let pad = "  ".repeat(depth);
+    let type_ = frame.get("type").and_then(Value::as_str).unwrap_or("?");
+    let from = frame.get("from").and_then(Value::as_str).unwrap_or("?");
+    let to = frame.get("to").and_then(Value::as_str).unwrap_or("?");
+    let value = frame.get("value").and_then(Value::as_str).unwrap_or("0x0");
+    let gas = frame.get("gas").and_then(Value::as_str).unwrap_or("?");
+    let gas_used = frame.get("gasUsed").and_then(Value::as_str).unwrap_or("?");
+    let error = frame.get("error").and_then(Value::as_str);
+    let reverted = frame.get("revertReason").and_then(Value::as_str);
+
+    let tag = if reverted.is_some() || error.is_some() { "✗" } else { "•" };
+    print!("{pad}{tag} {type_} {from} → {to}");
+    if value != "0x0" {
+        print!(" value={value}");
+    }
+    print!(" gas={gas_used}/{gas}");
+    if let Some(e) = error {
+        print!(" error={e}");
+    }
+    if let Some(r) = reverted {
+        print!(" revert=\"{r}\"");
+    }
+    println!();
+
+    if let Some(calls) = frame.get("calls").and_then(Value::as_array) {
+        for call in calls {
+            render_call_tree(call, depth + 1);
+        }
+    }
+}

--- a/bin/gravity_cli/src/tx/trace.rs
+++ b/bin/gravity_cli/src/tx/trace.rs
@@ -62,22 +62,19 @@ impl Executable for TraceCommand {
 
 impl TraceCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
-        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
-            anyhow::anyhow!("--rpc-url is required")
-        })?;
+        let rpc_url =
+            self.rpc_url.clone().ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
         let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
-        let tx_hash = B256::from_str(&self.tx_hash)
-            .map_err(|e| anyhow::anyhow!("invalid tx hash: {e}"))?;
+        let tx_hash =
+            B256::from_str(&self.tx_hash).map_err(|e| anyhow::anyhow!("invalid tx hash: {e}"))?;
 
         let opts = match Tracer::geth_name(self.tracer) {
             Some(name) => json!({ "tracer": name }),
             None => json!({}),
         };
         let params = json!([tx_hash, opts]);
-        let trace: Value = provider
-            .client()
-            .request(Cow::Borrowed("debug_traceTransaction"), params)
-            .await?;
+        let trace: Value =
+            provider.client().request(Cow::Borrowed("debug_traceTransaction"), params).await?;
 
         render_trace(&trace, self.tracer, self.output_format);
         Ok(())

--- a/bin/gravity_cli/src/tx/trace_call.rs
+++ b/bin/gravity_cli/src/tx/trace_call.rs
@@ -1,0 +1,92 @@
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_provider::{Provider, ProviderBuilder};
+use clap::Parser;
+use serde_json::{json, Value};
+use std::{borrow::Cow, str::FromStr};
+
+use crate::{
+    command::Executable,
+    output::OutputFormat,
+    tx::{
+        common::parse_hex_data,
+        trace::{render_trace, Tracer},
+    },
+};
+
+#[derive(Debug, Parser)]
+pub struct TraceCallCommand {
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    #[clap(long)]
+    pub from: Option<String>,
+
+    #[clap(long)]
+    pub to: Option<String>,
+
+    #[clap(long, default_value = "0x")]
+    pub data: String,
+
+    #[clap(long, default_value = "0")]
+    pub value: String,
+
+    #[clap(long, default_value = "latest")]
+    pub block: String,
+
+    #[clap(long, value_enum, default_value = "call")]
+    pub tracer: Tracer,
+
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+impl Executable for TraceCallCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl TraceCallCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
+            anyhow::anyhow!("--rpc-url is required")
+        })?;
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+
+        let tx_json = build_call_object(&self)?;
+        let opts = match self.tracer.geth_name() {
+            Some(name) => json!({ "tracer": name }),
+            None => json!({}),
+        };
+
+        let params = json!([tx_json, self.block, opts]);
+        let trace: Value = provider
+            .client()
+            .request(Cow::Borrowed("debug_traceCall"), params)
+            .await?;
+
+        render_trace(&trace, self.tracer, self.output_format);
+        Ok(())
+    }
+}
+
+fn build_call_object(cmd: &TraceCallCommand) -> Result<Value, anyhow::Error> {
+    let mut obj = serde_json::Map::new();
+    if let Some(from) = &cmd.from {
+        let _ = Address::from_str(from).map_err(|e| anyhow::anyhow!("invalid --from: {e}"))?;
+        obj.insert("from".into(), json!(from));
+    }
+    if let Some(to) = &cmd.to {
+        let _ = Address::from_str(to).map_err(|e| anyhow::anyhow!("invalid --to: {e}"))?;
+        obj.insert("to".into(), json!(to));
+    }
+    let data = parse_hex_data(&cmd.data)
+        .ok_or_else(|| anyhow::anyhow!("--data is not valid hex"))?;
+    obj.insert("data".into(), json!(format!("0x{}", hex::encode::<Bytes>(data))));
+    let value =
+        U256::from_str(&cmd.value).map_err(|e| anyhow::anyhow!("invalid --value: {e}"))?;
+    obj.insert("value".into(), json!(format!("0x{value:x}")));
+    Ok(Value::Object(obj))
+}
+

--- a/bin/gravity_cli/src/tx/trace_call.rs
+++ b/bin/gravity_cli/src/tx/trace_call.rs
@@ -49,9 +49,8 @@ impl Executable for TraceCallCommand {
 
 impl TraceCallCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
-        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
-            anyhow::anyhow!("--rpc-url is required")
-        })?;
+        let rpc_url =
+            self.rpc_url.clone().ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
         let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
 
         let tx_json = build_call_object(&self)?;
@@ -61,10 +60,8 @@ impl TraceCallCommand {
         };
 
         let params = json!([tx_json, self.block, opts]);
-        let trace: Value = provider
-            .client()
-            .request(Cow::Borrowed("debug_traceCall"), params)
-            .await?;
+        let trace: Value =
+            provider.client().request(Cow::Borrowed("debug_traceCall"), params).await?;
 
         render_trace(&trace, self.tracer, self.output_format);
         Ok(())
@@ -81,12 +78,10 @@ fn build_call_object(cmd: &TraceCallCommand) -> Result<Value, anyhow::Error> {
         let _ = Address::from_str(to).map_err(|e| anyhow::anyhow!("invalid --to: {e}"))?;
         obj.insert("to".into(), json!(to));
     }
-    let data = parse_hex_data(&cmd.data)
-        .ok_or_else(|| anyhow::anyhow!("--data is not valid hex"))?;
+    let data =
+        parse_hex_data(&cmd.data).ok_or_else(|| anyhow::anyhow!("--data is not valid hex"))?;
     obj.insert("data".into(), json!(format!("0x{}", hex::encode::<Bytes>(data))));
-    let value =
-        U256::from_str(&cmd.value).map_err(|e| anyhow::anyhow!("invalid --value: {e}"))?;
+    let value = U256::from_str(&cmd.value).map_err(|e| anyhow::anyhow!("invalid --value: {e}"))?;
     obj.insert("value".into(), json!(format!("0x{value:x}")));
     Ok(Value::Object(obj))
 }
-


### PR DESCRIPTION
## Summary

Three new read-only helpers that wrap reth's debug RPC for the common \"what would happen / what happened\" developer questions:

- **`tx simulate --from --to --data [--value] [--block]`** — runs `eth_call` + `eth_estimateGas` and pretty-prints the outcome. Reverts are decoded for the two standard ABI signatures (`Error(string)`, `Panic(uint256)`); unknown selectors fall back to raw hex. Exit code is non-zero on revert so simulate can gate scripts.

- **`tx trace <hash> [--tracer call|prestate|4byte|opcode|noop]`** — wraps `debug_traceTransaction`. The `call` tracer is rendered as an indented tree (`• CALL 0xfrom → 0xto value=N gas=used/limit`); everything else prints pretty JSON.

- **`tx trace-call --from --to --data [--value] [--block] [--tracer ...]`** — wraps `debug_traceCall` for hypothetical calls, using the same tracers and rendering.

`--output json` on any of the three produces machine-readable output for scripting.

## Design notes

- **No node-side changes** — everything layers on reth methods already exposed (`eth_call`, `eth_estimateGas`, `debug_traceTransaction`, `debug_traceCall`).
- **Revert decoding** lives in `tx/common.rs` with unit tests for the standard selectors, the empty-data case, and the hex-fallback case. Custom-error ABI support is deferred.
- **Relationship with foundry's `cast`**: `cast` covers vanilla EVM flows; this PR focuses on gravity-specific simulation flow + making revert output first-class. No overlap we're duplicating.

## Test plan

- [x] Unit tests (revert decoding Error/Panic/empty/unknown, hex parsing) — 6 tests pass
- [x] `tx simulate` successful EOA transfer against localnet → prints `success / return / gas`
- [x] `tx simulate` with insufficient balance → `reverted`, exit 1
- [x] `tx trace <real tx hash>` (callTracer) → tree output with from/to/value/gas
- [x] `tx trace --tracer prestate` → pretty JSON passthrough
- [x] `tx trace-call` → successfully traces hypothetical call
- [x] `--output json` produces structured output for simulate and trace
- [x] Invalid tx hash → clear error, exit 1
- [x] Missing `--rpc-url` → clear error with `init` hint