### PR TITLE
feat(node,cli): expose on-demand pprof HTTP endpoint

### DIFF
--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -64,6 +64,9 @@ fn main() {
         command::SubCommands::Node(node_cmd) => match node_cmd.command {
             node::SubCommands::Start(start_cmd) => start_cmd.execute(),
             node::SubCommands::Stop(stop_cmd) => stop_cmd.execute(),
+            node::SubCommands::Pprof(pp) => match pp.command {
+                node::PprofSubCommands::Cpu(c) => c.execute(),
+            },
         },
         command::SubCommands::Dkg(dkg_cmd) => match dkg_cmd.command {
             dkg::SubCommands::Status(mut status_cmd) => {
@@ -162,6 +165,8 @@ fn apply_config_defaults(cmd: &mut Command, profile: &Option<config::ProfileConf
                     c.deploy_path.clone_from(&profile.deploy_path);
                 }
             }
+            // Pprof addr comes from its own flag/env; no profile mapping.
+            node::SubCommands::Pprof(_) => {}
         },
         command::SubCommands::Dkg(ref mut d) => match &mut d.command {
             dkg::SubCommands::Status(ref mut c) => {

--- a/bin/gravity_cli/src/node/mod.rs
+++ b/bin/gravity_cli/src/node/mod.rs
@@ -1,7 +1,11 @@
+mod pprof;
 mod start;
 mod stop;
 
 use clap::{Parser, Subcommand};
+
+pub use pprof::PprofCommand;
+pub use pprof::PprofSubCommands;
 
 use crate::node::{start::StartCommand, stop::StopCommand};
 
@@ -15,4 +19,6 @@ pub struct NodeCommand {
 pub enum SubCommands {
     Start(StartCommand),
     Stop(StopCommand),
+    /// Collect runtime profiles from a node that was started with --pprof_addr
+    Pprof(PprofCommand),
 }

--- a/bin/gravity_cli/src/node/mod.rs
+++ b/bin/gravity_cli/src/node/mod.rs
@@ -4,8 +4,7 @@ mod stop;
 
 use clap::{Parser, Subcommand};
 
-pub use pprof::PprofCommand;
-pub use pprof::PprofSubCommands;
+pub use pprof::{PprofCommand, PprofSubCommands};
 
 use crate::node::{start::StartCommand, stop::StopCommand};
 

--- a/bin/gravity_cli/src/node/pprof.rs
+++ b/bin/gravity_cli/src/node/pprof.rs
@@ -76,9 +76,8 @@ impl CpuCommand {
             std::io::stdout().write_all(&bytes)?;
         } else {
             let path = PathBuf::from(&self.output_file);
-            fs::write(&path, &bytes).map_err(|e| {
-                anyhow::anyhow!("failed to write {}: {e}", path.display())
-            })?;
+            fs::write(&path, &bytes)
+                .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
             eprintln!(
                 "wrote {} bytes to {} in {:.1}s",
                 bytes.len(),

--- a/bin/gravity_cli/src/node/pprof.rs
+++ b/bin/gravity_cli/src/node/pprof.rs
@@ -1,0 +1,92 @@
+use clap::{Parser, Subcommand};
+use std::{
+    fs,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use crate::command::Executable;
+
+#[derive(Debug, Parser)]
+pub struct PprofCommand {
+    #[command(subcommand)]
+    pub command: PprofSubCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PprofSubCommands {
+    /// Download an on-demand CPU profile from the node's pprof HTTP server.
+    /// Requires the node was started with `--pprof_addr <addr>`.
+    Cpu(CpuCommand),
+}
+
+#[derive(Debug, Parser)]
+pub struct CpuCommand {
+    /// pprof HTTP server address (e.g. 127.0.0.1:6060). Must match the node's
+    /// `--pprof_addr` flag.
+    #[clap(long, default_value = "127.0.0.1:6060", env = "GRAVITY_PPROF_ADDR")]
+    pub addr: String,
+
+    /// Profile duration in seconds (1..=300)
+    #[clap(long, default_value = "30")]
+    pub duration: u64,
+
+    /// Sampling frequency in Hz (default 99)
+    #[clap(long, default_value = "99")]
+    pub frequency: u32,
+
+    /// Output file path. Use `-` to write protobuf bytes to stdout.
+    #[clap(long = "output-file", default_value = "cpu.pb")]
+    pub output_file: String,
+}
+
+impl Executable for CpuCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl CpuCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let url = format!(
+            "http://{}/debug/pprof/profile?seconds={}&frequency={}",
+            self.addr.trim_start_matches("http://").trim_start_matches("https://"),
+            self.duration,
+            self.frequency,
+        );
+        // Server will hold the connection open for `duration` seconds — give
+        // it headroom plus a cushion for TCP / HTTP framing.
+        let timeout = Duration::from_secs(self.duration + 15);
+        let client = reqwest::Client::builder().timeout(timeout).build()?;
+
+        eprintln!("fetching {} (~{}s)…", url, self.duration);
+        let start = Instant::now();
+        let resp = client.get(&url).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_else(|_| "<unreadable>".into());
+            return Err(anyhow::anyhow!("pprof server returned HTTP {status}: {body}"));
+        }
+        let bytes = resp.bytes().await?;
+        let elapsed = start.elapsed();
+
+        if self.output_file == "-" {
+            use std::io::Write;
+            std::io::stdout().write_all(&bytes)?;
+        } else {
+            let path = PathBuf::from(&self.output_file);
+            fs::write(&path, &bytes).map_err(|e| {
+                anyhow::anyhow!("failed to write {}: {e}", path.display())
+            })?;
+            eprintln!(
+                "wrote {} bytes to {} in {:.1}s",
+                bytes.len(),
+                path.display(),
+                elapsed.as_secs_f64()
+            );
+            eprintln!("inspect with: go tool pprof -http=:8080 {}", path.display());
+        }
+        Ok(())
+    }
+}

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -54,6 +54,7 @@ tikv-jemallocator.workspace = true
 tikv-jemalloc-ctl.workspace = true
 tikv-jemalloc-sys.workspace = true
 pprof = { version = "0.14", features = ["flamegraph", "protobuf-codec"] }
+axum = "0.7.9"
 once_cell.workspace = true
 bytes.workspace = true
 dashmap.workspace = true

--- a/bin/gravity_node/src/main.rs
+++ b/bin/gravity_node/src/main.rs
@@ -36,6 +36,7 @@ use tracing::{info, warn};
 mod cli;
 mod consensus;
 mod mempool;
+mod pprof_server;
 pub mod relayer;
 mod reth_cli;
 mod reth_coordinator;
@@ -246,9 +247,22 @@ fn main() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
 
-    let _profiling_state =
-        if std::env::var("ENABLE_PPROF").is_ok() { Some(setup_pprof_profiler()) } else { None };
     let cli = Cli::parse();
+
+    // Prefer the on-demand HTTP pprof server when configured. If both are set
+    // we skip the periodic disk-dump mode because they share `ProfilerGuard`
+    // state and overlapping guards produce garbage profiles.
+    let pprof_addr = cli.gravity_node_config.pprof_addr.clone();
+    let _profiling_state = if pprof_addr.is_some() {
+        if std::env::var("ENABLE_PPROF").is_ok() {
+            warn!("ENABLE_PPROF and --pprof_addr both set; only the HTTP server will run");
+        }
+        None
+    } else if std::env::var("ENABLE_PPROF").is_ok() {
+        Some(setup_pprof_profiler())
+    } else {
+        None
+    };
 
     // For utility subcommands (stage, db, init, config, etc.), skip full node initialization
     // and just run the CLI command directly.
@@ -301,6 +315,15 @@ fn main() {
     let (consensus_args, latest_block_number, datadir_rx) =
         run_reth(cli, execution_args_rx, shutdown_tx.subscribe());
     let rt = tokio::runtime::Runtime::new().unwrap();
+
+    if let Some(addr) = pprof_addr {
+        rt.spawn(async move {
+            if let Err(e) = pprof_server::serve(addr).await {
+                warn!("pprof HTTP server exited: {e}");
+            }
+        });
+    }
+
     let chain_id = {
         let chain_info = consensus_args.provider.chain_spec().chain;
         match chain_info.into_kind() {

--- a/bin/gravity_node/src/pprof_server.rs
+++ b/bin/gravity_node/src/pprof_server.rs
@@ -43,18 +43,17 @@ fn default_freq() -> i32 {
 const MAX_SECONDS: u64 = 300;
 
 pub async fn serve(addr: String) -> Result<(), anyhow::Error> {
-    let socket_addr: std::net::SocketAddr = addr.parse().map_err(|e| {
-        anyhow::anyhow!("invalid --pprof_addr {addr}: {e}")
-    })?;
+    let socket_addr: std::net::SocketAddr =
+        addr.parse().map_err(|e| anyhow::anyhow!("invalid --pprof_addr {addr}: {e}"))?;
     let lock: ProfilingLock = Arc::new(Mutex::new(()));
     let app = Router::new()
         .route("/", get(index))
         .route("/debug/pprof/profile", get(profile))
         .with_state(lock);
 
-    let listener = TcpListener::bind(socket_addr).await.map_err(|e| {
-        anyhow::anyhow!("failed to bind pprof server on {socket_addr}: {e}")
-    })?;
+    let listener = TcpListener::bind(socket_addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to bind pprof server on {socket_addr}: {e}"))?;
     info!("pprof HTTP server listening on http://{socket_addr}");
     axum::serve(listener, app).await.map_err(|e| anyhow::anyhow!("pprof server error: {e}"))
 }
@@ -150,8 +149,7 @@ mod tests {
 
         // Profile — short, low frequency to keep the test fast
         let url = format!("http://{addr}/debug/pprof/profile?seconds=1&frequency=50");
-        let client =
-            reqwest::Client::builder().timeout(Duration::from_secs(20)).build().unwrap();
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(20)).build().unwrap();
         let resp = client.get(&url).send().await.unwrap();
         let status = resp.status();
         let headers = resp.headers().clone();

--- a/bin/gravity_node/src/pprof_server.rs
+++ b/bin/gravity_node/src/pprof_server.rs
@@ -1,0 +1,183 @@
+use axum::{
+    body::Body,
+    extract::{Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use pprof::{protos::Message, ProfilerGuard};
+use serde::Deserialize;
+use std::{sync::Arc, thread, time::Duration};
+use tokio::{net::TcpListener, sync::Mutex};
+use tracing::{info, warn};
+
+/// Process-wide lock so only one profile request runs at a time. `pprof` uses
+/// the global SIGPROF handler, and overlapping `ProfilerGuard`s produce
+/// meaningless data (or outright fail). This static is shared across every
+/// `serve()` instance in the process so two concurrent servers cannot race.
+static PROFILING_LOCK: once_cell::sync::Lazy<tokio::sync::Mutex<()>> =
+    once_cell::sync::Lazy::new(|| tokio::sync::Mutex::new(()));
+
+// Kept for symmetry / future state that may live per-server (e.g. last report
+// timestamp); currently empty but the type name stays in one place.
+type ProfilingLock = Arc<Mutex<()>>;
+
+#[derive(Debug, Deserialize)]
+struct ProfileParams {
+    /// Profile duration in seconds. Capped at 300s.
+    #[serde(default = "default_seconds")]
+    seconds: u64,
+    /// Sampling frequency in Hz (default 99, matches Go's pprof).
+    #[serde(default = "default_freq")]
+    frequency: i32,
+}
+
+fn default_seconds() -> u64 {
+    30
+}
+fn default_freq() -> i32 {
+    99
+}
+
+const MAX_SECONDS: u64 = 300;
+
+pub async fn serve(addr: String) -> Result<(), anyhow::Error> {
+    let socket_addr: std::net::SocketAddr = addr.parse().map_err(|e| {
+        anyhow::anyhow!("invalid --pprof_addr {addr}: {e}")
+    })?;
+    let lock: ProfilingLock = Arc::new(Mutex::new(()));
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/debug/pprof/profile", get(profile))
+        .with_state(lock);
+
+    let listener = TcpListener::bind(socket_addr).await.map_err(|e| {
+        anyhow::anyhow!("failed to bind pprof server on {socket_addr}: {e}")
+    })?;
+    info!("pprof HTTP server listening on http://{socket_addr}");
+    axum::serve(listener, app).await.map_err(|e| anyhow::anyhow!("pprof server error: {e}"))
+}
+
+async fn index() -> impl IntoResponse {
+    let body = "gravity-node pprof endpoint\n\
+                \n\
+                GET /debug/pprof/profile?seconds=N[&frequency=Hz]\n\
+                    Returns a protobuf CPU profile (content-type application/octet-stream).\n\
+                    Consume with `go tool pprof <url>` or `pprof -http=:8080 file.pb`.\n\
+                    seconds   default 30, max 300\n\
+                    frequency default 99 Hz\n";
+    (StatusCode::OK, [(header::CONTENT_TYPE, "text/plain")], body)
+}
+
+async fn profile(
+    State(_local): State<ProfilingLock>,
+    Query(params): Query<ProfileParams>,
+) -> Response {
+    let seconds = params.seconds.clamp(1, MAX_SECONDS);
+    let frequency = params.frequency.clamp(1, 1000);
+
+    // Serialize overlapping requests (process-wide) so we never hold two
+    // ProfilerGuards. The State lock is unused — kept for future per-server
+    // state that doesn't need to be global.
+    let Ok(_guard) = PROFILING_LOCK.try_lock() else {
+        warn!("pprof request rejected: another profile is already running");
+        return (
+            StatusCode::CONFLICT,
+            "another profile is already running; wait for it to finish\n",
+        )
+            .into_response();
+    };
+
+    info!("pprof: collecting {seconds}s CPU profile at {frequency} Hz");
+
+    // pprof uses SIGPROF + thread-local data; run the blocking collection off
+    // the async runtime so guard lifetimes never cross an await.
+    let result: Result<Vec<u8>, String> = tokio::task::spawn_blocking(move || {
+        let profiler =
+            ProfilerGuard::new(frequency).map_err(|e| format!("ProfilerGuard::new: {e}"))?;
+        thread::sleep(Duration::from_secs(seconds));
+        let report = profiler.report().build().map_err(|e| format!("report.build: {e}"))?;
+        let pb = report.pprof().map_err(|e| format!("report.pprof: {e}"))?;
+        let mut buf = Vec::with_capacity(1 << 16);
+        pb.write_to_vec(&mut buf).map_err(|e| format!("write_to_vec: {e}"))?;
+        Ok(buf)
+    })
+    .await
+    .unwrap_or_else(|e| Err(format!("spawn_blocking join: {e}")));
+
+    match result {
+        Ok(bytes) => (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (header::CONTENT_DISPOSITION, "attachment; filename=\"profile.pb\""),
+            ],
+            Body::from(bytes),
+        )
+            .into_response(),
+        Err(err) => {
+            warn!("pprof collection failed: {err}");
+            (StatusCode::INTERNAL_SERVER_ERROR, format!("profile collection failed: {err}\n"))
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Combined end-to-end: index, profile, and concurrency lock — all in
+    /// one test because `pprof` uses process-wide SIGPROF and splitting into
+    /// multiple `#[tokio::test]` functions makes them race on global profiler
+    /// state (cargo runs them in parallel by default).
+    #[tokio::test]
+    async fn pprof_server_end_to_end() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        tokio::spawn(async move {
+            let _ = serve(addr.to_string()).await;
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Index
+        let idx = reqwest::get(format!("http://{addr}/")).await.unwrap();
+        assert!(idx.status().is_success());
+        assert!(idx.text().await.unwrap().contains("/debug/pprof/profile"));
+
+        // Profile — short, low frequency to keep the test fast
+        let url = format!("http://{addr}/debug/pprof/profile?seconds=1&frequency=50");
+        let client =
+            reqwest::Client::builder().timeout(Duration::from_secs(20)).build().unwrap();
+        let resp = client.get(&url).send().await.unwrap();
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let bytes = resp.bytes().await.unwrap();
+        assert_eq!(status, StatusCode::OK, "body: {}", String::from_utf8_lossy(&bytes));
+        assert_eq!(headers.get(header::CONTENT_TYPE).unwrap(), "application/octet-stream");
+        assert!(!bytes.is_empty(), "profile response must not be empty");
+        // Protobuf tag byte: field 1 wire-type 2 = 0x0a, field 5 wire-type 0 = 0x28
+        assert!(
+            matches!(bytes[0], 0x0a | 0x28),
+            "unexpected first byte 0x{:02x}; body len={}",
+            bytes[0],
+            bytes.len()
+        );
+
+        // Concurrency: overlap two requests, expect 200 then 409
+        let url2 = format!("http://{addr}/debug/pprof/profile?seconds=2&frequency=50");
+        let h1 = tokio::spawn({
+            let c = client.clone();
+            let u = url2.clone();
+            async move { c.get(&u).send().await.map(|r| r.status()) }
+        });
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let r2 = client.get(&url2).send().await.unwrap();
+        assert_eq!(r2.status(), StatusCode::CONFLICT);
+        let s1 = h1.await.unwrap().unwrap();
+        assert_eq!(s1, StatusCode::OK);
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,4 +22,11 @@ pub struct GravityNodeArgs {
     #[arg(long = "relayer_config", value_name = "RELAYER_CONFIG", global = true)]
     /// Path to relayer configuration file (JSON format with URI to RPC URL mappings).
     pub relayer_config_path: Option<PathBuf>,
+
+    #[arg(long = "pprof_addr", value_name = "ADDR", global = true)]
+    /// Optional HTTP address (e.g. 127.0.0.1:6060) for an on-demand pprof
+    /// server. When set, exposes `GET /debug/pprof/profile?seconds=N` which
+    /// returns a protobuf-encoded CPU profile consumable by `go tool pprof`.
+    /// Disables the periodic disk-dump mode activated by `ENABLE_PPROF=1`.
+    pub pprof_addr: Option<String>,
 }


### PR DESCRIPTION
## Summary

The node previously supported only a hard-coded periodic CPU profiler (`ENABLE_PPROF=1`) that writes `.pb` files to disk every three minutes. That works for post-mortems but is awkward when you want to profile a specific interval — you have to scp the file off the node and match it to wall-clock by hand.

This PR adds an on-demand HTTP endpoint and a CLI wrapper.

## Node side

- **New `--pprof_addr <ADDR>` flag on `GravityNodeArgs`** (e.g. `127.0.0.1:6060`). When set, starts an axum HTTP server on the existing tokio runtime exposing:
  - `GET /` — index page documenting the endpoints
  - `GET /debug/pprof/profile?seconds=N[&frequency=Hz]` — returns a protobuf CPU profile consumable by `go tool pprof`
- **Concurrency**: a process-wide mutex serializes overlapping requests. `pprof` uses the global SIGPROF handler; overlapping `ProfilerGuard`s produce garbage data, so the second request gets `409 Conflict`.
- **Interaction with existing mode**: `--pprof_addr` disables the periodic disk-dump mode (`ENABLE_PPROF=1`) because they conflict over the same profiler state. A warning is emitted if both are set.

## CLI side

```
gravity-cli node pprof cpu [--addr ADDR] [--duration SECS] [--frequency HZ] [--output-file PATH]
```

- `--addr` defaults to `127.0.0.1:6060` (matches common local setup), overridable via `GRAVITY_PPROF_ADDR`.
- `--output-file -` streams protobuf bytes to stdout.
- On success prints the `go tool pprof -http=:8080 <file>` command to view the flamegraph.

## Scope

- **Heap profiling is out of scope.** Exposing jemalloc heap snapshots requires coordinating `MALLOC_CONF prof_prefix` with the HTTP server and reading back dump files; deferred to a follow-up.
- No changes to the periodic `ENABLE_PPROF` mode except the new precedence rule.

## Test plan

- [x] Integration test `pprof_server_end_to_end` (in-process): binds ephemeral port → index returns 200 + documents endpoint → profile returns 200 with `application/octet-stream` and valid protobuf tag byte → concurrent overlapping request returns 409 while the first succeeds with 200
- [x] `gravity_node --help` lists `--pprof_addr` with full description
- [x] `gravity-cli node pprof cpu --help` lists all flags
- [x] CLI error path: connecting to non-listening port → clean error with hint, exit 1
- [x] `cargo build -p gravity_node -p gravity_cli --profile quick-release` succeeds with `RUSTFLAGS="--cfg tokio_unstable"`