### PR TITLE
feat(cli): add node peers, mempool, and metrics subcommands

### DIFF
--- a/bin/gravity_cli/src/errors.rs
+++ b/bin/gravity_cli/src/errors.rs
@@ -52,5 +52,14 @@ pub fn suggest_fix(err: &anyhow::Error) -> Option<String> {
         );
     }
 
+    if msg_lower.contains("-32601") || msg_lower.contains("method not found") {
+        return Some(
+            "The node does not expose this RPC method. `admin_*` and `net_*` \
+             namespaces require the node to be started with the right \
+             `--http.api` list (e.g. `eth,net,admin,txpool`)."
+                .to_string(),
+        );
+    }
+
     None
 }

--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -64,6 +64,18 @@ fn main() {
         command::SubCommands::Node(node_cmd) => match node_cmd.command {
             node::SubCommands::Start(start_cmd) => start_cmd.execute(),
             node::SubCommands::Stop(stop_cmd) => stop_cmd.execute(),
+            node::SubCommands::Peers(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
+            node::SubCommands::Mempool(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
+            node::SubCommands::Metrics(mut c) => {
+                c.output_format = output_format;
+                c.execute()
+            }
         },
         command::SubCommands::Dkg(dkg_cmd) => match dkg_cmd.command {
             dkg::SubCommands::Status(mut status_cmd) => {
@@ -160,6 +172,21 @@ fn apply_config_defaults(cmd: &mut Command, profile: &Option<config::ProfileConf
             node::SubCommands::Stop(ref mut c) => {
                 if c.deploy_path.is_none() {
                     c.deploy_path.clone_from(&profile.deploy_path);
+                }
+            }
+            node::SubCommands::Peers(ref mut c) => {
+                if c.rpc_url.is_none() {
+                    c.rpc_url.clone_from(&profile.rpc_url);
+                }
+            }
+            node::SubCommands::Mempool(ref mut c) => {
+                if c.rpc_url.is_none() {
+                    c.rpc_url.clone_from(&profile.rpc_url);
+                }
+            }
+            node::SubCommands::Metrics(ref mut c) => {
+                if c.rpc_url.is_none() {
+                    c.rpc_url.clone_from(&profile.rpc_url);
                 }
             }
         },

--- a/bin/gravity_cli/src/node/mempool.rs
+++ b/bin/gravity_cli/src/node/mempool.rs
@@ -28,23 +28,13 @@ impl Executable for MempoolCommand {
 
 impl MempoolCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
-        let rpc_url = self
-            .rpc_url
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
+        let rpc_url =
+            self.rpc_url.clone().ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
         let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
 
-        let status: Value = provider
-            .client()
-            .request(Cow::Borrowed("txpool_status"), ())
-            .await?;
+        let status: Value = provider.client().request(Cow::Borrowed("txpool_status"), ()).await?;
         let content: Option<Value> = if self.content {
-            Some(
-                provider
-                    .client()
-                    .request(Cow::Borrowed("txpool_content"), ())
-                    .await?,
-            )
+            Some(provider.client().request(Cow::Borrowed("txpool_content"), ()).await?)
         } else {
             None
         };
@@ -63,8 +53,7 @@ impl MempoolCommand {
                     if let Some(p) = c.get("pending").and_then(Value::as_object) {
                         println!("\npending by sender:");
                         for (sender, nonces) in p {
-                            let n_txns =
-                                nonces.as_object().map(|o| o.len()).unwrap_or(0);
+                            let n_txns = nonces.as_object().map(|o| o.len()).unwrap_or(0);
                             println!("  {sender}  {n_txns} tx(s)");
                         }
                     }
@@ -76,7 +65,5 @@ impl MempoolCommand {
 }
 
 fn hex_u64(v: Option<&Value>) -> Option<u64> {
-    v.and_then(Value::as_str).and_then(|s| {
-        u64::from_str_radix(s.trim_start_matches("0x"), 16).ok()
-    })
+    v.and_then(Value::as_str).and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
 }

--- a/bin/gravity_cli/src/node/mempool.rs
+++ b/bin/gravity_cli/src/node/mempool.rs
@@ -1,0 +1,82 @@
+use alloy_provider::{Provider, ProviderBuilder};
+use clap::Parser;
+use serde_json::Value;
+use std::borrow::Cow;
+
+use crate::{command::Executable, output::OutputFormat};
+
+#[derive(Debug, Parser)]
+pub struct MempoolCommand {
+    /// RPC URL
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Also fetch and display `txpool_content` (heavier — emits every tx).
+    #[clap(long)]
+    pub content: bool,
+
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+impl Executable for MempoolCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl MempoolCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let rpc_url = self
+            .rpc_url
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+
+        let status: Value = provider
+            .client()
+            .request(Cow::Borrowed("txpool_status"), ())
+            .await?;
+        let content: Option<Value> = if self.content {
+            Some(
+                provider
+                    .client()
+                    .request(Cow::Borrowed("txpool_content"), ())
+                    .await?,
+            )
+        } else {
+            None
+        };
+
+        match self.output_format {
+            OutputFormat::Json => {
+                let combined = serde_json::json!({ "status": status, "content": content });
+                println!("{}", serde_json::to_string_pretty(&combined)?);
+            }
+            OutputFormat::Plain => {
+                let pending = hex_u64(status.get("pending")).unwrap_or(0);
+                let queued = hex_u64(status.get("queued")).unwrap_or(0);
+                println!("pending: {pending}");
+                println!("queued:  {queued}");
+                if let Some(c) = content.as_ref() {
+                    if let Some(p) = c.get("pending").and_then(Value::as_object) {
+                        println!("\npending by sender:");
+                        for (sender, nonces) in p {
+                            let n_txns =
+                                nonces.as_object().map(|o| o.len()).unwrap_or(0);
+                            println!("  {sender}  {n_txns} tx(s)");
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn hex_u64(v: Option<&Value>) -> Option<u64> {
+    v.and_then(Value::as_str).and_then(|s| {
+        u64::from_str_radix(s.trim_start_matches("0x"), 16).ok()
+    })
+}

--- a/bin/gravity_cli/src/node/metrics.rs
+++ b/bin/gravity_cli/src/node/metrics.rs
@@ -35,24 +35,17 @@ impl Executable for MetricsCommand {
 
 impl MetricsCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
-        let rpc_url = self
-            .rpc_url
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
+        let rpc_url =
+            self.rpc_url.clone().ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
         let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
 
         // Fire all queries in parallel — each is independent. Any single
         // failure becomes a None field rather than killing the whole command,
         // so `metrics` works even on nodes with partial RPC namespaces.
-        let peer_count_fut = provider
-            .client()
-            .request::<_, String>(Cow::Borrowed("net_peerCount"), ());
-        let txpool_fut = provider
-            .client()
-            .request::<_, Value>(Cow::Borrowed("txpool_status"), ());
-        let syncing_fut = provider
-            .client()
-            .request::<_, Value>(Cow::Borrowed("eth_syncing"), ());
+        let peer_count_fut =
+            provider.client().request::<_, String>(Cow::Borrowed("net_peerCount"), ());
+        let txpool_fut = provider.client().request::<_, Value>(Cow::Borrowed("txpool_status"), ());
+        let syncing_fut = provider.client().request::<_, Value>(Cow::Borrowed("eth_syncing"), ());
 
         let (chain_id, block_number, peer_count_hex, txpool_status, syncing) = tokio::join!(
             with_timeout(provider.get_chain_id()),
@@ -99,17 +92,11 @@ impl MetricsCommand {
                 );
                 show(
                     "txpool_pending",
-                    metrics
-                        .txpool_pending
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "?".into()),
+                    metrics.txpool_pending.map(|v| v.to_string()).unwrap_or_else(|| "?".into()),
                 );
                 show(
                     "txpool_queued",
-                    metrics
-                        .txpool_queued
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "?".into()),
+                    metrics.txpool_queued.map(|v| v.to_string()).unwrap_or_else(|| "?".into()),
                 );
                 let sync = match &metrics.syncing {
                     Some(Value::Bool(false)) => "no".to_string(),

--- a/bin/gravity_cli/src/node/metrics.rs
+++ b/bin/gravity_cli/src/node/metrics.rs
@@ -1,0 +1,143 @@
+use alloy_provider::{Provider, ProviderBuilder};
+use clap::Parser;
+use serde::Serialize;
+use serde_json::Value;
+use std::{borrow::Cow, time::Duration};
+
+use crate::{command::Executable, output::OutputFormat};
+
+#[derive(Debug, Parser)]
+pub struct MetricsCommand {
+    /// RPC URL
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+#[derive(Serialize)]
+struct NodeMetrics {
+    chain_id: Option<u64>,
+    block_number: Option<u64>,
+    peer_count: Option<u64>,
+    txpool_pending: Option<u64>,
+    txpool_queued: Option<u64>,
+    syncing: Option<Value>,
+}
+
+impl Executable for MetricsCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl MetricsCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let rpc_url = self
+            .rpc_url
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+
+        // Fire all queries in parallel — each is independent. Any single
+        // failure becomes a None field rather than killing the whole command,
+        // so `metrics` works even on nodes with partial RPC namespaces.
+        let peer_count_fut = provider
+            .client()
+            .request::<_, String>(Cow::Borrowed("net_peerCount"), ());
+        let txpool_fut = provider
+            .client()
+            .request::<_, Value>(Cow::Borrowed("txpool_status"), ());
+        let syncing_fut = provider
+            .client()
+            .request::<_, Value>(Cow::Borrowed("eth_syncing"), ());
+
+        let (chain_id, block_number, peer_count_hex, txpool_status, syncing) = tokio::join!(
+            with_timeout(provider.get_chain_id()),
+            with_timeout(provider.get_block_number()),
+            with_timeout(peer_count_fut),
+            with_timeout(txpool_fut),
+            with_timeout(syncing_fut),
+        );
+
+        let metrics = NodeMetrics {
+            chain_id: chain_id.ok(),
+            block_number: block_number.ok(),
+            peer_count: peer_count_hex.ok().and_then(parse_hex_u64),
+            txpool_pending: txpool_status
+                .as_ref()
+                .ok()
+                .and_then(|v| v.get("pending"))
+                .and_then(hex_u64_from_val),
+            txpool_queued: txpool_status
+                .as_ref()
+                .ok()
+                .and_then(|v| v.get("queued"))
+                .and_then(hex_u64_from_val),
+            syncing: syncing.ok(),
+        };
+
+        match self.output_format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&metrics)?);
+            }
+            OutputFormat::Plain => {
+                let show = |label: &str, value: String| println!("{label:18} {value}");
+                show(
+                    "chain_id",
+                    metrics.chain_id.map(|v| v.to_string()).unwrap_or_else(|| "?".into()),
+                );
+                show(
+                    "block_number",
+                    metrics.block_number.map(|v| v.to_string()).unwrap_or_else(|| "?".into()),
+                );
+                show(
+                    "peer_count",
+                    metrics.peer_count.map(|v| v.to_string()).unwrap_or_else(|| "?".into()),
+                );
+                show(
+                    "txpool_pending",
+                    metrics
+                        .txpool_pending
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "?".into()),
+                );
+                show(
+                    "txpool_queued",
+                    metrics
+                        .txpool_queued
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "?".into()),
+                );
+                let sync = match &metrics.syncing {
+                    Some(Value::Bool(false)) => "no".to_string(),
+                    Some(v) => serde_json::to_string(v).unwrap_or_else(|_| "?".into()),
+                    None => "?".into(),
+                };
+                show("syncing", sync);
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn with_timeout<T, E, F>(fut: F) -> Result<T, anyhow::Error>
+where
+    F: std::future::IntoFuture<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    tokio::time::timeout(Duration::from_secs(3), fut.into_future())
+        .await
+        .map_err(|_| anyhow::anyhow!("rpc timeout"))?
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+fn parse_hex_u64(s: String) -> Option<u64> {
+    u64::from_str_radix(s.trim_start_matches("0x"), 16).ok()
+}
+
+fn hex_u64_from_val(v: &Value) -> Option<u64> {
+    v.as_str().and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+}

--- a/bin/gravity_cli/src/node/mod.rs
+++ b/bin/gravity_cli/src/node/mod.rs
@@ -1,7 +1,14 @@
+mod mempool;
+mod metrics;
+mod peers;
 mod start;
 mod stop;
 
 use clap::{Parser, Subcommand};
+
+pub use mempool::MempoolCommand;
+pub use metrics::MetricsCommand;
+pub use peers::PeersCommand;
 
 use crate::node::{start::StartCommand, stop::StopCommand};
 
@@ -15,4 +22,10 @@ pub struct NodeCommand {
 pub enum SubCommands {
     Start(StartCommand),
     Stop(StopCommand),
+    /// List peers connected to the execution layer via admin_peers
+    Peers(PeersCommand),
+    /// Show txpool status (and optionally content) via txpool_* RPC
+    Mempool(MempoolCommand),
+    /// Aggregate node health metrics (chain_id, block, peers, mempool, sync)
+    Metrics(MetricsCommand),
 }

--- a/bin/gravity_cli/src/node/peers.rs
+++ b/bin/gravity_cli/src/node/peers.rs
@@ -1,0 +1,87 @@
+use alloy_provider::{Provider, ProviderBuilder};
+use clap::Parser;
+use serde_json::Value;
+use std::borrow::Cow;
+
+use crate::{command::Executable, output::OutputFormat};
+
+#[derive(Debug, Parser)]
+pub struct PeersCommand {
+    /// RPC URL
+    #[clap(long, env = "GRAVITY_RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Emit full JSON for every peer instead of a summary line.
+    #[clap(long)]
+    pub detail: bool,
+
+    #[clap(skip)]
+    pub output_format: OutputFormat,
+}
+
+impl Executable for PeersCommand {
+    fn execute(self) -> Result<(), anyhow::Error> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(self.execute_async())
+    }
+}
+
+impl PeersCommand {
+    async fn execute_async(self) -> Result<(), anyhow::Error> {
+        let rpc_url = self
+            .rpc_url
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+
+        let peers: Value = provider
+            .client()
+            .request(Cow::Borrowed("admin_peers"), ())
+            .await?;
+
+        match self.output_format {
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string_pretty(&peers)?);
+            }
+            OutputFormat::Plain => render_plain(&peers, self.detail),
+        }
+        Ok(())
+    }
+}
+
+fn render_plain(peers: &Value, detail: bool) {
+    let Some(arr) = peers.as_array() else {
+        println!("{peers}");
+        return;
+    };
+    if arr.is_empty() {
+        println!("(no peers)");
+        return;
+    }
+    println!("{} peer(s) connected:", arr.len());
+    for peer in arr {
+        if detail {
+            println!("{}", serde_json::to_string_pretty(peer).unwrap_or_default());
+            continue;
+        }
+        // Summary: id, direction, enode snippet, protocol hints
+        let id = peer.get("id").and_then(Value::as_str).unwrap_or("?");
+        let enode = peer.get("enode").and_then(Value::as_str).unwrap_or("?");
+        let network = peer
+            .get("network")
+            .map(|n| {
+                let inbound = n.get("inbound").and_then(Value::as_bool).unwrap_or(false);
+                if inbound {
+                    "inbound"
+                } else {
+                    "outbound"
+                }
+            })
+            .unwrap_or("?");
+        let name = peer.get("name").and_then(Value::as_str).unwrap_or("?");
+        // Shorten id for the table
+        let short_id = if id.len() > 16 { &id[..16] } else { id };
+        let short_enode = if enode.len() > 60 { &enode[..60] } else { enode };
+        println!("  {short_id}…  {network:8}  {name}  {short_enode}…");
+    }
+}

--- a/bin/gravity_cli/src/node/peers.rs
+++ b/bin/gravity_cli/src/node/peers.rs
@@ -28,16 +28,11 @@ impl Executable for PeersCommand {
 
 impl PeersCommand {
     async fn execute_async(self) -> Result<(), anyhow::Error> {
-        let rpc_url = self
-            .rpc_url
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
+        let rpc_url =
+            self.rpc_url.clone().ok_or_else(|| anyhow::anyhow!("--rpc-url is required"))?;
         let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
 
-        let peers: Value = provider
-            .client()
-            .request(Cow::Borrowed("admin_peers"), ())
-            .await?;
+        let peers: Value = provider.client().request(Cow::Borrowed("admin_peers"), ()).await?;
 
         match self.output_format {
             OutputFormat::Json => {


### PR DESCRIPTION
## Summary

Thin wrappers over reth's existing JSON-RPC so operators can ask the common health questions without remembering the RPC method names:

- **`node peers [--detail]`** → `admin_peers`. Default view shortens each peer into a single readable line (id prefix, inbound/outbound, client name, enode prefix); `--detail` dumps each entry as JSON; `--output json` emits the raw array.
- **`node mempool [--content]`** → `txpool_status`, optionally combined with `txpool_content` grouping pending tx counts by sender.
- **`node metrics`** → aggregates `chain_id`, `block_number`, `peer_count`, `txpool_pending / queued`, and `eth_syncing` into one snapshot. Each sub-query has an independent 3s timeout; failures become `?` / null fields so the command still works on nodes that expose only a subset of RPC namespaces.

Added a `-32601 / Method not found` hint in `errors.rs` pointing at the node's `--http.api` list — `admin_*` / `net_*` typically require opt-in that users don't always know about.

## No node-side changes

Every RPC method used is already exposed by reth when the relevant namespaces are enabled on the execution node.

## Test plan

- [x] `cargo build -p gravity_cli --profile quick-release` clean with `RUSTFLAGS=\"--cfg tokio_unstable\"`
- [x] `node metrics` against live localnet → `chain_id=31337, block_number=676, txpool_pending=0, syncing=no` displayed correctly; `peer_count=?` gracefully when `net_peerCount` not exposed
- [x] `node metrics --output json` → structured output with `null` for unexposed methods
- [x] `node mempool` against live localnet → `pending: 0 / queued: 0`
- [x] `node peers` against node without `admin` namespace → clean error + new hint
- [x] `node metrics` against unreachable RPC → all `?` fields, exit 0 (defensive)
- [x] `node mempool` without `--rpc-url` → clean required-flag error with `init` hint