### PR TITLE
fix(consensus): drop RSA JWK updates with error log instead of forwarding

### DIFF
--- a/aptos-core/consensus/src/state_computer.rs
+++ b/aptos-core/consensus/src/state_computer.rs
@@ -61,7 +61,6 @@ use gaptos::{
 use std::{boxed::Box, iter::once, sync::Arc, time::Duration};
 
 /// JWK type name constants for consistent usage across SDK ↔ reth boundary
-const JWK_TYPE_RSA: &str = "0x1::jwks::RSA_JWK";
 const JWK_TYPE_UNSUPPORTED: &str = "0x1::jwks::Unsupported_JWK";
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -310,26 +309,22 @@ impl ExecutionProxy {
                         }
                     };
 
-                    Some(match aptos_jwk {
-                        JWK::RSA(rsa_jwk) => JWKStruct {
-                            type_name: JWK_TYPE_RSA.to_string(),
-                            data: match serde_json::to_vec(&rsa_jwk) {
-                                Ok(bytes) => bytes,
-                                Err(err) => {
-                                    warn!(
-                                        "failed to serialize RSA JWK for block {}: {}",
-                                        block.id(),
-                                        err
-                                    );
-                                    return None;
-                                }
-                            },
-                        },
-                        JWK::Unsupported(unsupported_jwk) => JWKStruct {
+                    match aptos_jwk {
+                        JWK::RSA(rsa_jwk) => {
+                            error!(
+                                "unexpected RSA JWK in validator transaction for block {}, issuer {:?}, version {}, kid {}: dropping",
+                                block.id(),
+                                update.issuer,
+                                update.version,
+                                rsa_jwk.kid,
+                            );
+                            None
+                        }
+                        JWK::Unsupported(unsupported_jwk) => Some(JWKStruct {
                             type_name: JWK_TYPE_UNSUPPORTED.to_string(),
                             data: unsupported_jwk.payload,
-                        },
-                    })
+                        }),
+                    }
                 })
                 .collect(),
         };
@@ -400,17 +395,23 @@ pub fn process_jwk_update_util(update: &ProviderJWKs, block: &Block) -> Vec<u8> 
         jwks: update
             .jwks
             .iter()
-            .map(|jwk| {
+            .filter_map(|jwk| {
                 let aptos_jwk = JWK::try_from(jwk).unwrap();
                 match aptos_jwk {
-                    JWK::RSA(rsa_jwk) => JWKStruct {
-                        type_name: JWK_TYPE_RSA.to_string(),
-                        data: serde_json::to_vec(&rsa_jwk).unwrap(),
-                    },
-                    JWK::Unsupported(unsupported_jwk) => JWKStruct {
+                    JWK::RSA(rsa_jwk) => {
+                        error!(
+                            "unexpected RSA JWK in validator transaction for block {}, issuer {:?}, version {}, kid {}: dropping",
+                            block.id(),
+                            update.issuer,
+                            update.version,
+                            rsa_jwk.kid,
+                        );
+                        None
+                    }
+                    JWK::Unsupported(unsupported_jwk) => Some(JWKStruct {
                         type_name: JWK_TYPE_UNSUPPORTED.to_string(),
                         data: unsupported_jwk.payload,
-                    },
+                    }),
                 }
             })
             .collect(),


### PR DESCRIPTION
## Summary
- RSA JWKs are never expected to reach `state_computer.rs` in this system (JWKs originate from the external `aptos-jwk-consensus` runtime, but we do not plan to ever surface RSA to the execution layer).
- Previously both `process_jwk_update` and `process_jwk_update_util` serialized `JWK::RSA` into `ExtraDataType::JWK` and forwarded it to the execution layer — no filtering, no visibility if one ever slipped through.
- Change: the RSA arm in both functions now logs an `error!` (with block id, issuer, version, kid) and filters the entry out. `process_jwk_update_util`'s `.map()` becomes `.filter_map()` so the drop is actually applied. The now-unused `JWK_TYPE_RSA` constant is removed.

Scope is deliberately narrow — this is a boundary-level firewall inside state_computer, not a change to upstream `aptos-jwk-consensus`. If the upstream ever produces an RSA JWK, it is now contained here and visible in logs.

## Test plan
- [x] `cargo check -p aptos-consensus` (local) passes.
- [ ] Run an E2E cluster and confirm no RSA JWK is observed in normal operation (no error logs fired).
- [ ] Optional: inject a synthetic RSA JWK via test and confirm the error log fires and the JWK is dropped from the serialized `ExtraDataType::JWK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)