### PR TITLE
feat(cluster): support RETH_CONFIG_TPL / RETH_CONFIG_VFN_TPL override in deploy.sh

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -166,10 +166,16 @@ configure_node() {
     
     # Generate validator.yaml from template
     envsubst < "$SCRIPT_DIR/templates/validator.yaml.tpl" > "$config_dir/validator.yaml"
-    
-    # Generate reth_config.json from template
-    envsubst < "$SCRIPT_DIR/templates/reth_config.json.tpl" > "$config_dir/reth_config.json"
-    
+
+    # Generate reth_config.json from template (supports override via env var, e.g. mainnet hardening)
+    local reth_tpl="${RETH_CONFIG_TPL:-$SCRIPT_DIR/templates/reth_config.json.tpl}"
+    if [ ! -f "$reth_tpl" ]; then
+        log_error "reth config template not found: $reth_tpl"
+        exit 1
+    fi
+    envsubst < "$reth_tpl" > "$config_dir/reth_config.json"
+    log_info "  Using reth config: $reth_tpl"
+
     # Render relayer_config.json from template (supports per-test-case override via env var)
     local relayer_tpl="${RELAYER_CONFIG_TPL:-$SCRIPT_DIR/templates/relayer_config.json.tpl}"
     if [ -f "$relayer_tpl" ]; then
@@ -280,10 +286,16 @@ configure_vfn() {
     
     # Generate validator_full_node.yaml from template
     envsubst < "$SCRIPT_DIR/templates/validator_full_node.yaml.tpl" > "$config_dir/validator_full_node.yaml"
-    
-    # Generate reth_config.json from template
-    envsubst < "$SCRIPT_DIR/templates/reth_config_vfn.json.tpl" > "$config_dir/reth_config.json"
-    
+
+    # Generate reth_config.json from template (supports override via env var)
+    local reth_tpl="${RETH_CONFIG_VFN_TPL:-$SCRIPT_DIR/templates/reth_config_vfn.json.tpl}"
+    if [ ! -f "$reth_tpl" ]; then
+        log_error "reth vfn config template not found: $reth_tpl"
+        exit 1
+    fi
+    envsubst < "$reth_tpl" > "$config_dir/reth_config.json"
+    log_info "  Using reth vfn config: $reth_tpl"
+
     # Render relayer_config.json from template
     local relayer_tpl="${RELAYER_CONFIG_TPL:-$SCRIPT_DIR/templates/relayer_config.json.tpl}"
     if [ -f "$relayer_tpl" ]; then


### PR DESCRIPTION
## Summary

- `cluster/deploy.sh` 暴露两个新环境变量让 operator 覆盖 reth 配置模板路径：
  - `RETH_CONFIG_TPL` — validator 节点用的模板，默认 `cluster/templates/reth_config.json.tpl`
  - `RETH_CONFIG_VFN_TPL` — VFN 节点用的模板，默认 `cluster/templates/reth_config_vfn.json.tpl`
- 模式和现有的 `RELAYER_CONFIG_TPL`（`deploy.sh:174`）一致，不影响默认行为

## 动机

测试集群模板（debug/trace/txpool RPC 全开、pool 容量 2⁴⁴、`--dev` 等）对 CI 和本地 e2e 是刚需，不能改。但同一份 `deploy.sh` 也要能跑主网前的编排（mainnet-sim、staged rollout），这些场景需要加固的配置。

用 env var 覆盖而不是新增另一个 deploy 脚本，是为了：
- 单一 source of truth（deploy 逻辑不 fork）
- 加固模板可以放在 [mono-grav/docs/mainnet/](https://github.com/Galxe/mono-grav/pull/3) 里和其他主网配套文件放一起
- 将来不同环境（staging/mainnet）各自 export 不同的模板路径即可

## 使用示例

```bash
# 默认（测试集群）
bash cluster/deploy.sh cluster.toml

# 主网加固模板
export RETH_CONFIG_TPL=/path/to/mono-grav/docs/mainnet/reth_config_mainnet.json.tpl
export RETH_CONFIG_VFN_TPL=/path/to/mono-grav/docs/mainnet/reth_config_mainnet_vfn.json.tpl
bash cluster/deploy.sh cluster.toml
```

## 关联

- 配合 https://github.com/Galxe/mono-grav/pull/3（`mainnet_config.json` 加固清单）
- 关联 Gravity 主网前修复 P1：
  - [P1][High] 关闭 txpool_content / inspect
  - [P1][High] 设置最低 gasPrice
  - 以及单账户 DoS / RPC Local 豁免 / per-tx gas cap 等加固

## Test plan

- [ ] 不设 env var 时，默认模板路径和之前一致（`git diff` 只改了模板**取值来源**，不改文件内容）
- [ ] 设 `RETH_CONFIG_TPL` 指向存在的文件时，`log_info` 输出 "Using reth config: \$path"
- [ ] 设 `RETH_CONFIG_TPL` 指向不存在的文件时，`log_error` + exit 1（现有逻辑只是 skip，这里改成硬失败——reth 配置缺了节点肯定跑不起来）
- [ ] 现有 CI (`gravity_e2e`) 无 env var 影响

## 非改动项

- mono-grav 侧暂时没有 `*.json.tpl` 形式的主网模板（`mainnet_config.json` 是具体值的单节点配置）。要真正用本 env var 跑多节点 mainnet 编排，需要在 mono-grav 里再加一份模板版本——scope 外，随 mono-grav PR 迭代

🤖 Generated with [Claude Code](https://claude.com/claude-code)