### PR TITLE
combined: cluster deploy env override + gravity_cli KMS signer + consensus tier-1 audit fixes

### DIFF
--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -508,9 +508,18 @@ impl BufferManager {
         self.commit_proof_rb_handle.take();
         // purge the incoming blocks queue
         while let Ok(Some(_)) = self.block_rx.try_next() {}
-        // Wait for ongoing tasks to finish before sending back ack.
+        // Wait for ongoing tasks to finish before sending back ack, with a timeout
+        // to prevent permanent deadlock if a task is leaked.
         get_block_buffer_manager().release_inflight_blocks().await;
+        let reset_deadline = Instant::now() + Duration::from_secs(30);
         while self.ongoing_tasks.load(Ordering::SeqCst) > 0 {
+            if Instant::now() >= reset_deadline {
+                error!(
+                    "BufferManager reset timed out after 30s with {} ongoing tasks still pending. Breaking out to avoid deadlock.",
+                    self.ongoing_tasks.load(Ordering::SeqCst),
+                );
+                break;
+            }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
@@ -1015,10 +1024,17 @@ impl BufferManager {
                     self.advance_signing_root().await
                     })
                 },
-                Some(Ok(round)) = self.persisting_phase_rx.next() => {
-                    // see where `need_backpressure()` is called.
-                    self.highest_committed_round = round;
-                    counters::FINALIZED_EXECUTED_BLOCK_COUNTER.set(self.highest_committed_round as f64);
+                Some(result) = self.persisting_phase_rx.next() => {
+                    match result {
+                        Ok(round) => {
+                            // see where `need_backpressure()` is called.
+                            self.highest_committed_round = round;
+                            counters::FINALIZED_EXECUTED_BLOCK_COUNTER.set(self.highest_committed_round as f64);
+                        },
+                        Err(e) => {
+                            error!("Persisting phase failed: {:?}. Pipeline may stall if not recovered.", e);
+                        },
+                    }
                 },
                 Some(rpc_request) = verified_commit_msg_rx.next() => {
                     monitor!("buffer_manager_process_commit_message",

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -1032,6 +1032,9 @@ impl BufferManager {
                             counters::FINALIZED_EXECUTED_BLOCK_COUNTER.set(self.highest_committed_round as f64);
                         },
                         Err(e) => {
+                            // TODO: consider triggering a pipeline reset here to recover from
+                            // persist failures, since the committed blocks have already been
+                            // popped from the buffer and cannot be retried without a reset.
                             error!("Persisting phase failed: {:?}. Pipeline may stall if not recovered.", e);
                         },
                     }

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -515,7 +515,7 @@ impl BufferManager {
         while self.ongoing_tasks.load(Ordering::SeqCst) > 0 {
             if Instant::now() >= reset_deadline {
                 error!(
-                    "BufferManager reset timed out after 30s with {} ongoing tasks still pending. Breaking out to avoid deadlock.",
+                    "BufferManager reset timed out with {} tasks pending, breaking out",
                     self.ongoing_tasks.load(Ordering::SeqCst),
                 );
                 break;
@@ -1035,7 +1035,9 @@ impl BufferManager {
                             // TODO: consider triggering a pipeline reset here to recover from
                             // persist failures, since the committed blocks have already been
                             // popped from the buffer and cannot be retried without a reset.
-                            error!("Persisting phase failed: {:?}. Pipeline may stall if not recovered.", e);
+                            error!(
+                                "Persisting phase failed: {:?}. Pipeline may stall.", e
+                            );
                         },
                     }
                 },

--- a/aptos-core/consensus/src/quorum_store/batch_generator.rs
+++ b/aptos-core/consensus/src/quorum_store/batch_generator.rs
@@ -219,6 +219,16 @@ impl BatchGenerator {
                 batches.push(batch);
                 *total_batches_remaining = total_batches_remaining.saturating_sub(1);
                 txns_remaining -= num_batch_txns;
+            } else {
+                // Skip oversized transaction that exceeds sender_max_batch_bytes on its own.
+                // Without this, the loop would spin forever since txns_remaining never decreases.
+                warn!(
+                    "Skipping oversized transaction ({} bytes) that exceeds sender_max_batch_bytes ({})",
+                    txns.first().map_or(0, |txn| txn.txn_bytes_len()),
+                    self.config.sender_max_batch_bytes,
+                );
+                txns.drain(0..1);
+                txns_remaining -= 1;
             }
         }
     }

--- a/aptos-core/consensus/src/quorum_store/batch_generator.rs
+++ b/aptos-core/consensus/src/quorum_store/batch_generator.rs
@@ -223,7 +223,7 @@ impl BatchGenerator {
                 // Skip oversized transaction that exceeds sender_max_batch_bytes on its own.
                 // Without this, the loop would spin forever since txns_remaining never decreases.
                 warn!(
-                    "Skipping oversized transaction ({} bytes) that exceeds sender_max_batch_bytes ({})",
+                    "Skipping oversized txn ({} bytes, limit {})",
                     txns.first().map_or(0, |txn| txn.txn_bytes_len()),
                     self.config.sender_max_batch_bytes,
                 );

--- a/aptos-core/consensus/src/quorum_store/network_listener.rs
+++ b/aptos-core/consensus/src/quorum_store/network_listener.rs
@@ -41,15 +41,17 @@ impl NetworkListener {
                     // TODO: does the assumption have to be that network listener is shutdown first?
                     VerifiedEvent::Shutdown(ack_tx) => {
                         info!("QS: shutdown network listener received");
-                        ack_tx.send(()).expect("Failed to send shutdown ack to QuorumStore");
+                        if ack_tx.send(()).is_err() {
+                            error!("Failed to send shutdown ack to QuorumStore");
+                        }
                         break;
                     }
                     VerifiedEvent::SignedBatchInfo(signed_batch_infos) => {
                         let cmd = ProofCoordinatorCommand::AppendSignature(*signed_batch_infos);
-                        self.proof_coordinator_tx
-                            .send(cmd)
-                            .await
-                            .expect("Could not send signed_batch_info to proof_coordinator");
+                        if self.proof_coordinator_tx.send(cmd).await.is_err() {
+                            error!("Failed to send signed_batch_info to proof_coordinator — receiver dropped");
+                            break;
+                        }
                     }
                     VerifiedEvent::BatchMsg(batch_msg) => {
                         let author = batch_msg.author();
@@ -64,17 +66,21 @@ impl NetworkListener {
                             self.remote_batch_coordinator_tx.len(),
                             idx
                         );
-                        self.remote_batch_coordinator_tx[idx]
+                        if self.remote_batch_coordinator_tx[idx]
                             .send(BatchCoordinatorCommand::NewBatches(author, batches))
                             .await
-                            .expect("Could not send remote batch");
+                            .is_err()
+                        {
+                            error!("Failed to send remote batch to batch_coordinator — receiver dropped");
+                            break;
+                        }
                     }
                     VerifiedEvent::ProofOfStoreMsg(proofs) => {
                         let cmd = ProofManagerCommand::ReceiveProofs(*proofs);
-                        self.proof_manager_tx
-                            .send(cmd)
-                            .await
-                            .expect("could not push Proof proof_of_store");
+                        if self.proof_manager_tx.send(cmd).await.is_err() {
+                            error!("Failed to send proof_of_store to proof_manager — receiver dropped");
+                            break;
+                        }
                     }
                     _ => {
                         unreachable!()

--- a/aptos-core/consensus/src/quorum_store/network_listener.rs
+++ b/aptos-core/consensus/src/quorum_store/network_listener.rs
@@ -49,7 +49,9 @@ impl NetworkListener {
                     VerifiedEvent::SignedBatchInfo(signed_batch_infos) => {
                         let cmd = ProofCoordinatorCommand::AppendSignature(*signed_batch_infos);
                         if self.proof_coordinator_tx.send(cmd).await.is_err() {
-                            error!("Failed to send signed_batch_info to proof_coordinator — receiver dropped");
+                            error!(
+                                "Failed to send signed_batch_info to proof_coordinator — receiver dropped"
+                            );
                             break;
                         }
                     }
@@ -71,14 +73,18 @@ impl NetworkListener {
                             .await
                             .is_err()
                         {
-                            error!("Failed to send remote batch to batch_coordinator — receiver dropped");
+                            error!(
+                                "Failed to send remote batch to batch_coordinator — receiver dropped"
+                            );
                             break;
                         }
                     }
                     VerifiedEvent::ProofOfStoreMsg(proofs) => {
                         let cmd = ProofManagerCommand::ReceiveProofs(*proofs);
                         if self.proof_manager_tx.send(cmd).await.is_err() {
-                            error!("Failed to send proof_of_store to proof_manager — receiver dropped");
+                            error!(
+                                "Failed to send proof_of_store to proof_manager — receiver dropped"
+                            );
                             break;
                         }
                     }

--- a/bin/gravity_cli/Cargo.toml
+++ b/bin/gravity_cli/Cargo.toml
@@ -49,4 +49,4 @@ colored.workspace = true
 
 # GCP KMS signer (used by the optional --kms flag in validator/stake commands).
 async-trait = "0.1"
-google-cloud-kms = "0.7"
+google-cloud-kms = "0.6"

--- a/bin/gravity_cli/Cargo.toml
+++ b/bin/gravity_cli/Cargo.toml
@@ -24,13 +24,15 @@ bcs.workspace = true
 sha3.workspace = true
 tiny-keccak = { version = "2.0", features = ["sha3"] }
 rand_core = { version = "0.6", features = ["std"] }
-k256 = { version = "0.13.0", features = ["ecdsa"] }
+k256 = { version = "0.13.0", features = ["ecdsa", "pem"] }
 tokio = { version = "1.35", features = ["full"] }
 alloy-primitives = { version = "1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-provider = { version = "1.0.37", features = ["reqwest"], default-features = false }
 alloy-signer = { version = "1.0.37", default-features = false }
 alloy-signer-local = { version = "1.0.37", default-features = false }
 alloy-contract = { version = "1.0.37", default-features = false }
+alloy-consensus = { version = "1.0.37", default-features = false }
+alloy-network = { version = "1.0.37", default-features = false }
 alloy-sol-types = { version = "1.3.1", default-features = false }
 alloy-sol-macro = "1.3.1"
 alloy-transport-http = { version = "1.0.37", features = ["reqwest-rustls-tls"], default-features = false }
@@ -44,3 +46,7 @@ rpassword = "5"
 toml.workspace = true
 clap_complete.workspace = true
 colored.workspace = true
+
+# GCP KMS signer (used by the optional --kms flag in validator/stake commands).
+async-trait = "0.1"
+google-cloud-kms = "0.7"

--- a/bin/gravity_cli/src/main.rs
+++ b/bin/gravity_cli/src/main.rs
@@ -9,6 +9,7 @@ pub mod genesis;
 pub mod init;
 pub mod node;
 pub mod output;
+pub mod signer;
 pub mod stake;
 pub mod status;
 pub mod unwind;

--- a/bin/gravity_cli/src/signer/kms.rs
+++ b/bin/gravity_cli/src/signer/kms.rs
@@ -1,0 +1,216 @@
+//! Google Cloud KMS-backed implementation of [`alloy_signer::Signer`] and
+//! [`alloy_network::TxSigner`] for secp256k1 EVM signatures.
+//!
+//! ## Lifecycle
+//!
+//! [`GcpKmsSigner::new`] does one network call to Cloud KMS at construction
+//! time to fetch the key version's public key. From the public key it derives
+//! the EVM address (`keccak256(uncompressed_pub[1..])[12..]`). After that,
+//! `address()` and `chain_id()` are cheap accessors.
+//!
+//! Each `sign_hash` call does:
+//!
+//! 1. KMS `AsymmetricSign` on the 32-byte digest.
+//! 2. Parse the DER `(r, s)` returned by KMS.
+//! 3. Normalize `s` to the EIP-2 low-S half so verifying code that rejects
+//!    high-S signatures (which Ethereum does) accepts the result.
+//! 4. Try `v ∈ {0, 1}` for the recovery id; pick the one that recovers to
+//!    the same public key we cached at construction.
+//!
+//! ## Authentication
+//!
+//! Authentication uses Application Default Credentials. On a GCE VM with a
+//! bound service account, this picks up the metadata-server token with no
+//! extra config. Locally it honours `GOOGLE_APPLICATION_CREDENTIALS`.
+
+use alloy_consensus::SignableTransaction;
+use alloy_network::TxSigner;
+use alloy_primitives::{Address, ChainId, B256, Signature, U256};
+use alloy_signer::k256::{
+    ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey},
+    elliptic_curve::sec1::ToEncodedPoint,
+};
+use alloy_signer::{Result as SignerResult, Signer};
+use async_trait::async_trait;
+use google_cloud_kms::client::{Client, ClientConfig};
+use google_cloud_kms::grpc::kms::v1::{
+    digest::Digest as DigestVariant, AsymmetricSignRequest, Digest, GetPublicKeyRequest,
+};
+use sha3::{Digest as _, Keccak256};
+
+/// EVM signer that delegates raw signing to a Cloud KMS asymmetric key.
+///
+/// Construct with [`GcpKmsSigner::new`]. The signer is `Clone` only via the
+/// underlying [`Client`], which is itself cheap to clone (an `Arc` internally).
+#[derive(Clone)]
+pub struct GcpKmsSigner {
+    client: Client,
+    key_resource: String,
+    address: Address,
+    verifying_key: VerifyingKey,
+    chain_id: Option<ChainId>,
+}
+
+impl std::fmt::Debug for GcpKmsSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcpKmsSigner")
+            .field("key_resource", &self.key_resource)
+            .field("address", &self.address)
+            .field("chain_id", &self.chain_id)
+            .finish()
+    }
+}
+
+impl GcpKmsSigner {
+    /// Connect to Cloud KMS, fetch the key's public key, and cache the
+    /// derived EVM address.
+    ///
+    /// `key_resource` must be the full key-version resource path, e.g.
+    /// `projects/<P>/locations/<L>/keyRings/<R>/cryptoKeys/<K>/cryptoKeyVersions/1`.
+    /// (`SignerArgs::resolve` normalizes the path before getting here.)
+    pub async fn new(key_resource: String) -> anyhow::Result<Self> {
+        let config = ClientConfig::default()
+            .with_auth()
+            .await
+            .map_err(|e| anyhow::anyhow!("KMS auth setup failed: {e}"))?;
+        let client = Client::new(config)
+            .await
+            .map_err(|e| anyhow::anyhow!("KMS client connect failed: {e}"))?;
+
+        let resp = client
+            .get_public_key(
+                GetPublicKeyRequest { name: key_resource.clone(), ..Default::default() },
+                None,
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("KMS GetPublicKey failed: {e}"))?;
+
+        let verifying_key = parse_secp256k1_pem(&resp.pem)
+            .map_err(|e| anyhow::anyhow!("KMS pubkey parse failed: {e}"))?;
+        let address = address_from_verifying_key(&verifying_key);
+
+        Ok(Self { client, key_resource, address, verifying_key, chain_id: None })
+    }
+}
+
+#[async_trait]
+impl Signer for GcpKmsSigner {
+    async fn sign_hash(&self, hash: &B256) -> SignerResult<Signature> {
+        let resp = self
+            .client
+            .asymmetric_sign(
+                AsymmetricSignRequest {
+                    name: self.key_resource.clone(),
+                    digest: Some(Digest {
+                        digest: Some(DigestVariant::Sha256(hash.as_slice().to_vec())),
+                    }),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .map_err(|e| alloy_signer::Error::other(format!("KMS AsymmetricSign failed: {e}")))?;
+
+        let mut sig = K256Signature::from_der(&resp.signature)
+            .map_err(|e| alloy_signer::Error::other(format!("DER parse failed: {e}")))?;
+
+        // EIP-2 low-S form. Ethereum rejects high-S signatures.
+        if let Some(normalized) = sig.normalize_s() {
+            sig = normalized;
+        }
+
+        let parity = recover_parity(hash.as_slice(), &sig, &self.verifying_key).map_err(|e| {
+            alloy_signer::Error::other(format!("recovery id resolution failed: {e}"))
+        })?;
+
+        let r = U256::from_be_slice(&sig.r().to_bytes());
+        let s = U256::from_be_slice(&sig.s().to_bytes());
+        Ok(Signature::new(r, s, parity))
+    }
+
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id
+    }
+
+    fn set_chain_id(&mut self, chain_id: Option<ChainId>) {
+        self.chain_id = chain_id;
+    }
+}
+
+#[async_trait]
+impl TxSigner<Signature> for GcpKmsSigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut dyn SignableTransaction<Signature>,
+    ) -> SignerResult<Signature> {
+        let hash = tx.signature_hash();
+        self.sign_hash(&hash).await
+    }
+}
+
+/// Parse a PEM-encoded SubjectPublicKeyInfo holding a secp256k1 point into
+/// a `VerifyingKey`. KMS returns this exact format from `GetPublicKey`.
+fn parse_secp256k1_pem(pem: &str) -> Result<VerifyingKey, anyhow::Error> {
+    use alloy_signer::k256::pkcs8::DecodePublicKey;
+    VerifyingKey::from_public_key_pem(pem)
+        .map_err(|e| anyhow::anyhow!("PEM/SPKI decode: {e}"))
+}
+
+/// EVM address: `keccak256(uncompressed_pubkey_without_0x04_prefix)[12..]`.
+fn address_from_verifying_key(vk: &VerifyingKey) -> Address {
+    let point = vk.to_encoded_point(/* compress = */ false);
+    let bytes = point.as_bytes();
+    debug_assert_eq!(bytes[0], 0x04, "expected uncompressed sec1 encoding");
+    let hash = Keccak256::digest(&bytes[1..]);
+    Address::from_slice(&hash[12..])
+}
+
+/// Try `v=0` and `v=1`; pick the one whose recovered key matches `expected`.
+/// Returns `true` for the y-odd parity (Ethereum's V=28 / yParity=1) and
+/// `false` for y-even (V=27 / yParity=0).
+fn recover_parity(
+    digest: &[u8],
+    sig: &K256Signature,
+    expected: &VerifyingKey,
+) -> Result<bool, anyhow::Error> {
+    for v in 0u8..=1 {
+        let rid = RecoveryId::try_from(v)
+            .map_err(|e| anyhow::anyhow!("invalid recovery id {v}: {e}"))?;
+        if let Ok(recovered) = VerifyingKey::recover_from_prehash(digest, sig, rid) {
+            if recovered == *expected {
+                return Ok(v == 1);
+            }
+        }
+    }
+    Err(anyhow::anyhow!("no recovery id matched the expected public key"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::address_from_verifying_key;
+    use alloy_primitives::address;
+    use alloy_signer::k256::ecdsa::{SigningKey, VerifyingKey};
+
+    /// Confirm address derivation matches the well-known Ethereum test vector
+    /// for the all-ones private key.
+    #[test]
+    fn address_derivation_matches_known_vector() {
+        // Anvil account #0 — privkey 0xac09…ff80 → 0xf39F…2266
+        let priv_hex = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let bytes = hex::decode(priv_hex).unwrap();
+        let sk = SigningKey::from_slice(&bytes).unwrap();
+        let vk = VerifyingKey::from(&sk);
+        assert_eq!(
+            address_from_verifying_key(&vk),
+            address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
+        );
+    }
+}

--- a/bin/gravity_cli/src/signer/kms.rs
+++ b/bin/gravity_cli/src/signer/kms.rs
@@ -49,6 +49,11 @@ pub struct GcpKmsSigner {
     key_resource: String,
     address: Address,
     verifying_key: VerifyingKey,
+    /// Informational only — `sign_hash` signs whatever 32-byte digest the
+    /// caller hands us (typically `tx.signature_hash()`, which already folds
+    /// the chain_id in via EIP-155). Kept to satisfy the `Signer` trait
+    /// contract; alloy's wallet machinery may call `set_chain_id` but we
+    /// never consume the stored value in the sign path.
     chain_id: Option<ChainId>,
 }
 
@@ -70,10 +75,13 @@ impl GcpKmsSigner {
     /// `projects/<P>/locations/<L>/keyRings/<R>/cryptoKeys/<K>/cryptoKeyVersions/1`.
     /// (`SignerArgs::resolve` normalizes the path before getting here.)
     pub async fn new(key_resource: String) -> anyhow::Result<Self> {
-        let config = ClientConfig::default()
-            .with_auth()
-            .await
-            .map_err(|e| anyhow::anyhow!("KMS auth setup failed: {e}"))?;
+        let config = ClientConfig::default().with_auth().await.map_err(|e| {
+            anyhow::anyhow!(
+                "KMS auth setup failed: {e} — check Application Default Credentials: on GCE \
+                 the VM's service account must be bound with cloud-platform scope; locally set \
+                 GOOGLE_APPLICATION_CREDENTIALS or run `gcloud auth application-default login`"
+            )
+        })?;
         let client = Client::new(config)
             .await
             .map_err(|e| anyhow::anyhow!("KMS client connect failed: {e}"))?;
@@ -99,6 +107,14 @@ impl GcpKmsSigner {
 #[async_trait]
 impl Signer for GcpKmsSigner {
     async fn sign_hash(&self, hash: &B256) -> SignerResult<Signature> {
+        // `hash` is the caller-supplied 32-byte digest to sign — for Ethereum
+        // it is `keccak256(rlp(tx))`, not a SHA-256 output. We nonetheless
+        // submit it through `DigestVariant::Sha256` because on GCP KMS the
+        // `digest` oneof is a **type tag** matching the key's algorithm
+        // (`EC_SIGN_SECP256K1_SHA256` → SHA-256-sized slot): KMS signs the
+        // 32 bytes as-is and does NOT re-hash. Re-hashing would only happen
+        // if we used the sibling `data` field. This matches how AWS KMS is
+        // driven by alloy-signer-aws for the same Ethereum signing use case.
         let resp = self
             .client
             .asymmetric_sign(

--- a/bin/gravity_cli/src/signer/kms.rs
+++ b/bin/gravity_cli/src/signer/kms.rs
@@ -12,10 +12,10 @@
 //!
 //! 1. KMS `AsymmetricSign` on the 32-byte digest.
 //! 2. Parse the DER `(r, s)` returned by KMS.
-//! 3. Normalize `s` to the EIP-2 low-S half so verifying code that rejects
-//!    high-S signatures (which Ethereum does) accepts the result.
-//! 4. Try `v ∈ {0, 1}` for the recovery id; pick the one that recovers to
-//!    the same public key we cached at construction.
+//! 3. Normalize `s` to the EIP-2 low-S half so verifying code that rejects high-S signatures (which
+//!    Ethereum does) accepts the result.
+//! 4. Try `v ∈ {0, 1}` for the recovery id; pick the one that recovers to the same public key we
+//!    cached at construction.
 //!
 //! ## Authentication
 //!
@@ -25,16 +25,17 @@
 
 use alloy_consensus::SignableTransaction;
 use alloy_network::TxSigner;
-use alloy_primitives::{Address, ChainId, B256, Signature, U256};
-use alloy_signer::k256::{
-    ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey},
-    elliptic_curve::sec1::ToEncodedPoint,
+use alloy_primitives::{Address, ChainId, Signature, B256, U256};
+use alloy_signer::{
+    k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey},
+    Result as SignerResult, Signer,
 };
-use alloy_signer::{Result as SignerResult, Signer};
 use async_trait::async_trait;
-use google_cloud_kms::client::{Client, ClientConfig};
-use google_cloud_kms::grpc::kms::v1::{
-    digest::Digest as DigestVariant, AsymmetricSignRequest, Digest, GetPublicKeyRequest,
+use google_cloud_kms::{
+    client::{Client, ClientConfig},
+    grpc::kms::v1::{
+        digest::Digest as DigestVariant, AsymmetricSignRequest, Digest, GetPublicKeyRequest,
+    },
 };
 use sha3::{Digest as _, Keccak256};
 
@@ -78,10 +79,7 @@ impl GcpKmsSigner {
             .map_err(|e| anyhow::anyhow!("KMS client connect failed: {e}"))?;
 
         let resp = client
-            .get_public_key(
-                GetPublicKeyRequest { name: key_resource.clone(), ..Default::default() },
-                None,
-            )
+            .get_public_key(GetPublicKeyRequest { name: key_resource.clone() }, None)
             .await
             .map_err(|e| anyhow::anyhow!("KMS GetPublicKey failed: {e}"))?;
 
@@ -90,6 +88,11 @@ impl GcpKmsSigner {
         let address = address_from_verifying_key(&verifying_key);
 
         Ok(Self { client, key_resource, address, verifying_key, chain_id: None })
+    }
+
+    /// The EVM address derived from the KMS key's public key at construction.
+    pub fn address(&self) -> Address {
+        self.address
     }
 }
 
@@ -160,8 +163,7 @@ impl TxSigner<Signature> for GcpKmsSigner {
 /// a `VerifyingKey`. KMS returns this exact format from `GetPublicKey`.
 fn parse_secp256k1_pem(pem: &str) -> Result<VerifyingKey, anyhow::Error> {
     use alloy_signer::k256::pkcs8::DecodePublicKey;
-    VerifyingKey::from_public_key_pem(pem)
-        .map_err(|e| anyhow::anyhow!("PEM/SPKI decode: {e}"))
+    VerifyingKey::from_public_key_pem(pem).map_err(|e| anyhow::anyhow!("PEM/SPKI decode: {e}"))
 }
 
 /// EVM address: `keccak256(uncompressed_pubkey_without_0x04_prefix)[12..]`.
@@ -182,8 +184,8 @@ fn recover_parity(
     expected: &VerifyingKey,
 ) -> Result<bool, anyhow::Error> {
     for v in 0u8..=1 {
-        let rid = RecoveryId::try_from(v)
-            .map_err(|e| anyhow::anyhow!("invalid recovery id {v}: {e}"))?;
+        let rid =
+            RecoveryId::try_from(v).map_err(|e| anyhow::anyhow!("invalid recovery id {v}: {e}"))?;
         if let Ok(recovered) = VerifyingKey::recover_from_prehash(digest, sig, rid) {
             if recovered == *expected {
                 return Ok(v == 1);

--- a/bin/gravity_cli/src/signer/mod.rs
+++ b/bin/gravity_cli/src/signer/mod.rs
@@ -1,11 +1,16 @@
 //! Shared "where does the EVM signing key come from?" plumbing for
 //! gravity_cli subcommands that submit on-chain transactions.
 //!
-//! Three sources are supported, mutually exclusive:
+//! Two sources are supported:
 //!
-//! 1. `--kms <resource>`        — Cloud KMS (key never leaves the HSM).
-//! 2. `--private-key-env <VAR>` — read the hex private key from an env var.
-//! 3. _(default)_               — interactive `rpassword` prompt on stdin.
+//! 1. `--kms <resource>` — Cloud KMS (key never leaves the HSM).
+//! 2. _(default)_        — interactive `rpassword` prompt on stdin.
+//!
+//! There is deliberately no "read the hex key from an env var" option: a
+//! plaintext private key in an env var is visible in `/proc/<pid>/environ`,
+//! can leak into shell history or CI logs, and offers no real security
+//! advantage over the stdin prompt while adding attack surface. If you
+//! need non-interactive signing, use `--kms`.
 //!
 //! Add to a subcommand by flattening:
 //!
@@ -39,7 +44,8 @@ pub use kms::GcpKmsSigner;
 /// CLI arguments selecting the signing key source for an on-chain command.
 #[derive(Debug, Clone, Args)]
 pub struct SignerArgs {
-    /// Sign with a key held in Google Cloud KMS instead of a local private key.
+    /// Sign with a key held in Google Cloud KMS instead of prompting for a
+    /// plaintext private key on stdin.
     ///
     /// Format: `projects/<P>/locations/<L>/keyRings/<R>/cryptoKeys/<K>/cryptoKeyVersions/<V>`.
     /// The trailing `/cryptoKeyVersions/<V>` may be omitted; in that case
@@ -47,19 +53,8 @@ pub struct SignerArgs {
     ///
     /// Authentication is via Application Default Credentials. On GCE, this
     /// means the VM's attached service account (no static credentials).
-    #[clap(long, value_name = "RESOURCE", conflicts_with = "private_key_env")]
+    #[clap(long, value_name = "RESOURCE")]
     pub kms: Option<String>,
-
-    /// Read the hex private key (with or without `0x` prefix) from this
-    /// environment variable instead of prompting on stdin.
-    ///
-    /// Intended for CI / automation where the env var is injected by a
-    /// secrets manager. Prefer `--kms` for interactive / production use:
-    /// a plaintext key in an env var is visible to anyone with access to
-    /// `/proc/<pid>/environ`, and inline invocations (`GRAV_KEY=… cli …`)
-    /// may leak into shell history.
-    #[clap(long, value_name = "ENV_VAR")]
-    pub private_key_env: Option<String>,
 }
 
 /// Output of [`SignerArgs::resolve`]: a wallet ready for `ProviderBuilder`,
@@ -81,7 +76,11 @@ impl SignerArgs {
             let address = signer.address();
             Ok(ResolvedSigner { wallet: EthereumWallet::from(signer), address })
         } else {
-            let hex = read_private_key_hex(self.private_key_env.as_deref())?;
+            let raw = rpassword::prompt_password_stdout(
+                "Enter private key (hex, with or without 0x prefix): ",
+            )
+            .map_err(|e| anyhow::anyhow!("failed to read private key: {e}"))?;
+            let hex = raw.trim();
             let bytes = hex::decode(hex.trim_start_matches("0x"))
                 .map_err(|e| anyhow::anyhow!("invalid private key hex: {e}"))?;
             let signing_key = SigningKey::from_slice(&bytes)
@@ -100,19 +99,6 @@ fn normalize_kms_resource(s: &str) -> String {
     } else {
         format!("{trimmed}/cryptoKeyVersions/1")
     }
-}
-
-fn read_private_key_hex(env_var: Option<&str>) -> anyhow::Result<String> {
-    let raw = match env_var {
-        Some(name) => std::env::var(name).map_err(|_| {
-            anyhow::anyhow!("env var `{name}` is not set (referenced by --private-key-env)")
-        })?,
-        None => rpassword::prompt_password_stdout(
-            "Enter private key (hex, with or without 0x prefix): ",
-        )
-        .map_err(|e| anyhow::anyhow!("failed to read private key: {e}"))?,
-    };
-    Ok(raw.trim().to_string())
 }
 
 #[cfg(test)]

--- a/bin/gravity_cli/src/signer/mod.rs
+++ b/bin/gravity_cli/src/signer/mod.rs
@@ -1,0 +1,139 @@
+//! Shared "where does the EVM signing key come from?" plumbing for
+//! gravity_cli subcommands that submit on-chain transactions.
+//!
+//! Three sources are supported, mutually exclusive:
+//!
+//! 1. `--kms <resource>`        — Cloud KMS (key never leaves the HSM).
+//! 2. `--private-key-env <VAR>` — read the hex private key from an env var.
+//! 3. _(default)_               — interactive `rpassword` prompt on stdin.
+//!
+//! Add to a subcommand by flattening:
+//!
+//! ```ignore
+//! #[derive(Debug, Parser)]
+//! pub struct MyCmd {
+//!     // ... other flags ...
+//!     #[clap(flatten)]
+//!     pub signer: crate::signer::SignerArgs,
+//! }
+//! ```
+//!
+//! Then in `execute_async`:
+//!
+//! ```ignore
+//! let resolved = self.signer.resolve().await?;
+//! let provider = ProviderBuilder::new()
+//!     .wallet(resolved.wallet)
+//!     .connect_http(self.rpc_url.parse()?);
+//! ```
+
+use alloy_network::EthereumWallet;
+use alloy_primitives::Address;
+use alloy_signer::k256::ecdsa::SigningKey;
+use alloy_signer_local::PrivateKeySigner;
+use clap::Args;
+
+mod kms;
+pub use kms::GcpKmsSigner;
+
+/// CLI arguments selecting the signing key source for an on-chain command.
+#[derive(Debug, Clone, Args)]
+pub struct SignerArgs {
+    /// Sign with a key held in Google Cloud KMS instead of a local private key.
+    ///
+    /// Format: `projects/<P>/locations/<L>/keyRings/<R>/cryptoKeys/<K>/cryptoKeyVersions/<V>`.
+    /// The trailing `/cryptoKeyVersions/<V>` may be omitted; in that case
+    /// version `1` is used.
+    ///
+    /// Authentication is via Application Default Credentials. On GCE, this
+    /// means the VM's attached service account (no static credentials).
+    #[clap(long, value_name = "RESOURCE", conflicts_with = "private_key_env")]
+    pub kms: Option<String>,
+
+    /// Read the hex private key (with or without `0x` prefix) from this
+    /// environment variable instead of prompting on stdin.
+    #[clap(long, value_name = "ENV_VAR")]
+    pub private_key_env: Option<String>,
+}
+
+/// Output of [`SignerArgs::resolve`]: a wallet ready for `ProviderBuilder`,
+/// plus the EVM address it signs as.
+pub struct ResolvedSigner {
+    pub wallet: EthereumWallet,
+    pub address: Address,
+}
+
+impl SignerArgs {
+    /// Construct the signer described by these args.
+    ///
+    /// `--kms` makes a network call to KMS to fetch the public key (so the
+    /// address can be derived). The default stdin path blocks on the prompt.
+    pub async fn resolve(&self) -> anyhow::Result<ResolvedSigner> {
+        if let Some(resource) = &self.kms {
+            let resource = normalize_kms_resource(resource);
+            let signer = GcpKmsSigner::new(resource).await?;
+            let address = signer.address();
+            Ok(ResolvedSigner { wallet: EthereumWallet::from(signer), address })
+        } else {
+            let hex = read_private_key_hex(self.private_key_env.as_deref())?;
+            let bytes = hex::decode(hex.trim_start_matches("0x"))
+                .map_err(|e| anyhow::anyhow!("invalid private key hex: {e}"))?;
+            let signing_key = SigningKey::from_slice(&bytes)
+                .map_err(|e| anyhow::anyhow!("invalid private key: {e}"))?;
+            let signer = PrivateKeySigner::from(signing_key);
+            let address = signer.address();
+            Ok(ResolvedSigner { wallet: EthereumWallet::from(signer), address })
+        }
+    }
+}
+
+fn normalize_kms_resource(s: &str) -> String {
+    let trimmed = s.trim().trim_end_matches('/');
+    if trimmed.contains("/cryptoKeyVersions/") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/cryptoKeyVersions/1")
+    }
+}
+
+fn read_private_key_hex(env_var: Option<&str>) -> anyhow::Result<String> {
+    let raw = match env_var {
+        Some(name) => std::env::var(name).map_err(|_| {
+            anyhow::anyhow!("env var `{name}` is not set (referenced by --private-key-env)")
+        })?,
+        None => rpassword::prompt_password_stdout(
+            "Enter private key (hex, with or without 0x prefix): ",
+        )
+        .map_err(|e| anyhow::anyhow!("failed to read private key: {e}"))?,
+    };
+    Ok(raw.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_kms_resource;
+
+    #[test]
+    fn normalize_appends_default_version() {
+        let in_ = "projects/p/locations/us-west1/keyRings/r/cryptoKeys/k";
+        assert_eq!(
+            normalize_kms_resource(in_),
+            "projects/p/locations/us-west1/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1"
+        );
+    }
+
+    #[test]
+    fn normalize_keeps_explicit_version() {
+        let in_ = "projects/p/locations/us-west1/keyRings/r/cryptoKeys/k/cryptoKeyVersions/3";
+        assert_eq!(normalize_kms_resource(in_), in_);
+    }
+
+    #[test]
+    fn normalize_strips_trailing_slash() {
+        let in_ = "projects/p/locations/us-west1/keyRings/r/cryptoKeys/k/";
+        assert_eq!(
+            normalize_kms_resource(in_),
+            "projects/p/locations/us-west1/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1"
+        );
+    }
+}

--- a/bin/gravity_cli/src/signer/mod.rs
+++ b/bin/gravity_cli/src/signer/mod.rs
@@ -52,6 +52,12 @@ pub struct SignerArgs {
 
     /// Read the hex private key (with or without `0x` prefix) from this
     /// environment variable instead of prompting on stdin.
+    ///
+    /// Intended for CI / automation where the env var is injected by a
+    /// secrets manager. Prefer `--kms` for interactive / production use:
+    /// a plaintext key in an env var is visible to anyone with access to
+    /// `/proc/<pid>/environ`, and inline invocations (`GRAV_KEY=… cli …`)
+    /// may leak into shell history.
     #[clap(long, value_name = "ENV_VAR")]
     pub private_key_env: Option<String>,
 }

--- a/bin/gravity_cli/src/stake/create.rs
+++ b/bin/gravity_cli/src/stake/create.rs
@@ -1,8 +1,6 @@
 use alloy_primitives::{Bytes, TxKind, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::eth::{BlockNumberOrTag, TransactionInput, TransactionRequest};
-use alloy_signer::k256::ecdsa::SigningKey;
-use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent};
 use clap::Parser;
 
@@ -10,6 +8,7 @@ use crate::{
     command::Executable,
     contract::{Staking, STAKING_ADDRESS},
     output::OutputFormat,
+    signer::SignerArgs,
     util::{format_ether, parse_ether},
 };
 
@@ -38,6 +37,12 @@ pub struct CreateCommand {
     /// Output format (injected from global flag)
     #[clap(skip)]
     pub output_format: OutputFormat,
+
+    /// Signing-key source: defaults to interactive stdin prompt, or pass
+    /// `--kms <resource>` to sign via Cloud KMS, or `--private-key-env <VAR>`
+    /// to read the hex key from an env var.
+    #[clap(flatten)]
+    pub signer: SignerArgs,
 }
 
 impl Executable for CreateCommand {
@@ -68,24 +73,16 @@ impl CreateCommand {
         if !is_json {
             println!("   RPC URL: {rpc_url}");
         }
-        let private_key_input = rpassword::prompt_password_stdout(
-            "Enter private key (hex, with or without 0x prefix): ",
-        )
-        .map_err(|e| anyhow::anyhow!("Failed to read private key: {e}"))?;
-        let private_key_str =
-            private_key_input.trim().strip_prefix("0x").unwrap_or(private_key_input.trim());
-        let private_key_bytes = hex::decode(private_key_str)?;
-        let private_key = SigningKey::from_slice(private_key_bytes.as_slice())
-            .map_err(|e| anyhow::anyhow!("Invalid private key: {e}"))?;
-        let signer = PrivateKeySigner::from(private_key);
-        let wallet_address = signer.address();
+        let resolved = self.signer.resolve().await?;
+        let wallet_address = resolved.address;
         if !is_json {
             println!("   Wallet address: {wallet_address:?}");
             println!("   Staking contract: {STAKING_ADDRESS:?}");
         }
 
         // Create provider
-        let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url.parse()?);
+        let provider =
+            ProviderBuilder::new().wallet(resolved.wallet).connect_http(rpc_url.parse()?);
 
         let chain_id = provider.get_chain_id().await?;
         if !is_json {

--- a/bin/gravity_cli/src/stake/create.rs
+++ b/bin/gravity_cli/src/stake/create.rs
@@ -38,9 +38,6 @@ pub struct CreateCommand {
     #[clap(skip)]
     pub output_format: OutputFormat,
 
-    /// Signing-key source: defaults to interactive stdin prompt, or pass
-    /// `--kms <resource>` to sign via Cloud KMS, or `--private-key-env <VAR>`
-    /// to read the hex key from an env var.
     #[clap(flatten)]
     pub signer: SignerArgs,
 }

--- a/bin/gravity_cli/src/validator/join.rs
+++ b/bin/gravity_cli/src/validator/join.rs
@@ -1,8 +1,6 @@
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::eth::{TransactionInput, TransactionRequest};
-use alloy_signer::k256::ecdsa::SigningKey;
-use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent, SolType, SolValue};
 use clap::Parser;
 use std::str::FromStr;
@@ -13,6 +11,7 @@ use crate::{
         status_from_u8, Staking, ValidatorManagement, ValidatorRecord, ValidatorStatus,
         STAKING_ADDRESS, VALIDATOR_MANAGER_ADDRESS,
     },
+    signer::SignerArgs,
     util::format_ether,
 };
 
@@ -60,6 +59,12 @@ pub struct JoinCommand {
     /// Fullnode network address in /ip4/{host}/tcp/{port} or /dns/{domain}/tcp/{port} format
     #[clap(long)]
     pub fullnode_network_address: String,
+
+    /// Signing-key source: defaults to interactive stdin prompt, or pass
+    /// `--kms <resource>` to sign via Cloud KMS, or `--private-key-env <VAR>`
+    /// to read the hex key from an env var.
+    #[clap(flatten)]
+    pub signer: SignerArgs,
 }
 
 impl Executable for JoinCommand {
@@ -83,24 +88,16 @@ impl JoinCommand {
         println!("1. Initializing connection...");
 
         println!("   RPC URL: {rpc_url}");
-        let private_key_input = rpassword::prompt_password_stdout(
-            "Enter private key (hex, with or without 0x prefix): ",
-        )
-        .map_err(|e| anyhow::anyhow!("Failed to read private key: {e}"))?;
-        let private_key_str =
-            private_key_input.trim().strip_prefix("0x").unwrap_or(private_key_input.trim());
-        let private_key_bytes = hex::decode(private_key_str)?;
-        let private_key = SigningKey::from_slice(private_key_bytes.as_slice())
-            .map_err(|e| anyhow::anyhow!("Invalid private key: {e}"))?;
-        let signer = PrivateKeySigner::from(private_key);
-        let wallet_address = signer.address();
+        let resolved = self.signer.resolve().await?;
+        let wallet_address = resolved.address;
         println!("   Wallet address: {wallet_address:?}");
 
         println!("   ValidatorManagement: {VALIDATOR_MANAGER_ADDRESS:?}");
         println!("   Staking: {STAKING_ADDRESS:?}");
 
         // Create provider
-        let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url.parse()?);
+        let provider =
+            ProviderBuilder::new().wallet(resolved.wallet).connect_http(rpc_url.parse()?);
 
         let chain_id = provider.get_chain_id().await?;
         println!("   Chain ID: {chain_id}");

--- a/bin/gravity_cli/src/validator/join.rs
+++ b/bin/gravity_cli/src/validator/join.rs
@@ -60,9 +60,6 @@ pub struct JoinCommand {
     #[clap(long)]
     pub fullnode_network_address: String,
 
-    /// Signing-key source: defaults to interactive stdin prompt, or pass
-    /// `--kms <resource>` to sign via Cloud KMS, or `--private-key-env <VAR>`
-    /// to read the hex key from an env var.
     #[clap(flatten)]
     pub signer: SignerArgs,
 }

--- a/bin/gravity_cli/src/validator/leave.rs
+++ b/bin/gravity_cli/src/validator/leave.rs
@@ -1,8 +1,6 @@
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::eth::{TransactionInput, TransactionRequest};
-use alloy_signer::k256::ecdsa::SigningKey;
-use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent, SolType, SolValue};
 use clap::Parser;
 use std::str::FromStr;
@@ -13,6 +11,7 @@ use crate::{
         status_from_u8, ValidatorManagement, ValidatorRecord, ValidatorStatus,
         VALIDATOR_MANAGER_ADDRESS,
     },
+    signer::SignerArgs,
     util::format_ether,
 };
 
@@ -33,6 +32,12 @@ pub struct LeaveCommand {
     /// StakePool address (validator identity)
     #[clap(long)]
     pub stake_pool: String,
+
+    /// Signing-key source: defaults to interactive stdin prompt, or pass
+    /// `--kms <resource>` to sign via Cloud KMS, or `--private-key-env <VAR>`
+    /// to read the hex key from an env var.
+    #[clap(flatten)]
+    pub signer: SignerArgs,
 }
 
 impl Executable for LeaveCommand {
@@ -56,23 +61,15 @@ impl LeaveCommand {
         println!("1. Initializing connection...");
 
         println!("   RPC URL: {rpc_url}");
-        let private_key_input = rpassword::prompt_password_stdout(
-            "Enter private key (hex, with or without 0x prefix): ",
-        )
-        .map_err(|e| anyhow::anyhow!("Failed to read private key: {e}"))?;
-        let private_key_str =
-            private_key_input.trim().strip_prefix("0x").unwrap_or(private_key_input.trim());
-        let private_key_bytes = hex::decode(private_key_str)?;
-        let private_key = SigningKey::from_slice(private_key_bytes.as_slice())
-            .map_err(|e| anyhow::anyhow!("Invalid private key: {e}"))?;
-        let signer = PrivateKeySigner::from(private_key);
-        let wallet_address = signer.address();
+        let resolved = self.signer.resolve().await?;
+        let wallet_address = resolved.address;
         println!("   Wallet address: {wallet_address:?}");
 
         println!("   Contract address: {VALIDATOR_MANAGER_ADDRESS:?}");
 
         // Create provider
-        let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url.parse()?);
+        let provider =
+            ProviderBuilder::new().wallet(resolved.wallet).connect_http(rpc_url.parse()?);
 
         let chain_id = provider.get_chain_id().await?;
         println!("   Chain ID: {chain_id}\n");

--- a/bin/gravity_cli/src/validator/leave.rs
+++ b/bin/gravity_cli/src/validator/leave.rs
@@ -33,9 +33,6 @@ pub struct LeaveCommand {
     #[clap(long)]
     pub stake_pool: String,
 
-    /// Signing-key source: defaults to interactive stdin prompt, or pass
-    /// `--kms <resource>` to sign via Cloud KMS, or `--private-key-env <VAR>`
-    /// to read the hex key from an env var.
     #[clap(flatten)]
     pub signer: SignerArgs,
 }

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -166,10 +166,16 @@ configure_node() {
     
     # Generate validator.yaml from template
     envsubst < "$SCRIPT_DIR/templates/validator.yaml.tpl" > "$config_dir/validator.yaml"
-    
-    # Generate reth_config.json from template
-    envsubst < "$SCRIPT_DIR/templates/reth_config.json.tpl" > "$config_dir/reth_config.json"
-    
+
+    # Generate reth_config.json from template (supports override via env var, e.g. mainnet hardening)
+    local reth_tpl="${RETH_CONFIG_TPL:-$SCRIPT_DIR/templates/reth_config.json.tpl}"
+    if [ ! -f "$reth_tpl" ]; then
+        log_error "reth config template not found: $reth_tpl"
+        exit 1
+    fi
+    envsubst < "$reth_tpl" > "$config_dir/reth_config.json"
+    log_info "  Using reth config: $reth_tpl"
+
     # Render relayer_config.json from template (supports per-test-case override via env var)
     local relayer_tpl="${RELAYER_CONFIG_TPL:-$SCRIPT_DIR/templates/relayer_config.json.tpl}"
     if [ -f "$relayer_tpl" ]; then
@@ -280,9 +286,15 @@ configure_vfn() {
     
     # Generate validator_full_node.yaml from template
     envsubst < "$SCRIPT_DIR/templates/validator_full_node.yaml.tpl" > "$config_dir/validator_full_node.yaml"
-    
-    # Generate reth_config.json from template
-    envsubst < "$SCRIPT_DIR/templates/reth_config_vfn.json.tpl" > "$config_dir/reth_config.json"
+
+    # Generate reth_config.json from template (supports override via env var)
+    local reth_tpl="${RETH_CONFIG_VFN_TPL:-$SCRIPT_DIR/templates/reth_config_vfn.json.tpl}"
+    if [ ! -f "$reth_tpl" ]; then
+        log_error "reth vfn config template not found: $reth_tpl"
+        exit 1
+    fi
+    envsubst < "$reth_tpl" > "$config_dir/reth_config.json"
+    log_info "  Using reth vfn config: $reth_tpl"
 
     # Optionally enable WebSocket RPC (only when ws_port is set in cluster.toml)
     if [ "$WS_PORT" != "null" ]; then


### PR DESCRIPTION
## Summary

Roll-up of three independent PRs to cut CI runs down from 3 to 1. The changes sit in completely disjoint parts of the tree, so they are squashed here purely for CI economy — not because they share logic.

**Supersedes**:
- #678 — `feat(cluster): support RETH_CONFIG_TPL / RETH_CONFIG_VFN_TPL override`
- #672 — `feat(gravity_cli): add --kms flag for Cloud KMS-backed EVM signing`
- #652 — `fix(consensus): address 4 tier-1 stability issues from audit`

All three will be closed with a pointer here once this is open.

## What each piece does

### 1. `cluster/deploy.sh` — reth config template override (was #678)

Exposes two env vars so operators can override the reth template path without forking `deploy.sh`:
- `RETH_CONFIG_TPL` — validator template (default `cluster/templates/reth_config.json.tpl`)
- `RETH_CONFIG_VFN_TPL` — VFN template (default `cluster/templates/reth_config_vfn.json.tpl`)

Mirrors the existing `RELAYER_CONFIG_TPL` pattern. No behavior change when unset.

**Motivation**: test-cluster templates (debug/trace/txpool open, pool capacity 2⁴⁴, `--dev`) must stay as-is for CI + local e2e; mainnet/pre-mainnet staging needs a hardened template. Using env vars keeps a single `deploy.sh` and lets the hardened template live in `mono-grav/docs/mainnet/` (see `Galxe/mono-grav#3`).

Conflict note: rebasing #678 onto current `main` required a 3-way merge in `configure_vfn` because main has since landed a WS RPC block there. Both changes are preserved — env-var template loading runs first, then the optional WS RPC injection via `jq`.

### 2. `bin/gravity_cli` — `--kms` flag for Cloud KMS-backed EVM signing (was #672)

Adds an opt-in `--kms <resource>` flag to `validator join`, `validator leave`, and `stake create` so they sign EVM txs with a key held in GCP KMS instead of a plaintext key. The existing `rpassword` stdin prompt is unchanged when `--kms` is not passed.

New `bin/gravity_cli/src/signer/`:
- `SignerArgs` — `clap` struct flattened into the three command structs
- `SignerArgs::resolve() -> ResolvedSigner` — returns `(EthereumWallet, Address)` from either `GcpKmsSigner` or the stdin prompt
- `GcpKmsSigner` — implements `alloy_signer::Signer` + `alloy_network::TxSigner<Signature>`; handles DER → (r,s), EIP-2 low-S normalization, and recovery-id brute-force against the cached public key
- Deps: `google-cloud-kms = "0.6"`, `async-trait`, `alloy-network`, `alloy-consensus`; `pem` feature on `k256`

Counterpart to the infra work under `mono-grav/scripts/kms/` (key rings + per-node SAs + IAM bindings). Does not touch the consensus/identity-key path (BLS12381/X25519) — that lives in `mono-grav/scripts/identity-manager/`.

**Why no `--private-key-env`**: an earlier revision had one; removed because env-var plaintext keys are visible in `/proc/<pid>/environ` and leak into shell history / CI logs, with no real advantage over the stdin prompt. If non-interactive signing is needed, use `--kms`.

### 3. `aptos-core/consensus/` — 4 tier-1 stability fixes (was #652)

Production-path bugs from [gravity-audit](https://github.com/Galxe/gravity-audit/issues) triage — triggerable without any malicious input (oversized tx, disk hiccup, task leak, component crash):

| File | Issue | Fix |
|------|-------|-----|
| `quorum_store/batch_generator.rs` | `Galxe/gravity-audit#62` | Infinite loop in `push_bucket_to_batches` when oversized tx heads the queue → skip with warning |
| `pipeline/buffer_manager.rs` | `Galxe/gravity-audit#54` | `tokio::select!` silently dropped persist-phase errors → `Some(Err(e))` arm now logs (TODO left for full pipeline-reset recovery) |
| `pipeline/buffer_manager.rs` | `Galxe/gravity-audit#55` | `BufferManager::reset()` spin loop had no timeout → 30 s deadline to prevent deadlock |
| `quorum_store/network_listener.rs` | `Galxe/gravity-audit#65` | `.expect()` on channel sends cascaded panic across quorum store → graceful `error!` + `break` |

Closes `Galxe/gravity-audit#62`, `#54`, `#55`, `#65`.

(The genesis-alignment commit that was in #652's original series — `6d27ed2844` — is intentionally not cherry-picked: its equivalent already landed on `main` via #651 `b41c3ec380`.)

## Commits

```
8 commits on top of main:
  feat(cluster): support RETH_CONFIG_TPL / RETH_CONFIG_VFN_TPL override
  feat(gravity_cli): add --kms flag for Cloud KMS-backed EVM signing
  fix(gravity_cli/signer): pass fmt + clippy
  fix(gravity_cli/signer): address review feedback
  feat(gravity_cli/signer): drop --private-key-env; only --kms or stdin
  fix(consensus): address 4 tier-1 stability issues from audit
  fix(consensus): add TODO for persist-phase recovery in buffer_manager
  style: fix fmt and shorten log messages to respect line length
```

## Diff footprint

11 files, +475 / −66:
- 1 file in `cluster/`
- 7 files in `bin/gravity_cli/`
- 3 files in `aptos-core/consensus/`

## Verification

- `git diff origin/feat/cli-kms-signer..HEAD -- bin/gravity_cli/` → empty (exact match)
- `git diff origin/fix/audit-tier1-stability-fixes..HEAD -- aptos-core/consensus/…` → only 1 line, which is main's own `block_hash` field addition (not a regression from the cherry-pick)
- `cluster/deploy.sh` hand-merged for the `configure_vfn` conflict; `bash -n` passes

## Test plan

- [ ] CI green (this is the whole point of squashing three PRs into one)
- [ ] `gravity_cli validator join …` (no `--kms`) — stdin prompt unchanged
- [ ] `gravity_cli validator join … --kms projects/…/cryptoKeys/nodeN` against a real KMS key on testnet (this piece was never exercised against live KMS, only unit tests on pure functions)
- [ ] `bash cluster/deploy.sh cluster.toml` with no env vars → default templates, identical behavior
- [ ] `RETH_CONFIG_VFN_TPL=/path/to/hardened.tpl bash cluster/deploy.sh …` → uses override, `log_info` prints the path
- [ ] Consensus audit fixes: existing consensus tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)