### PR TITLE
fix(docker): export RPC HTTP defaults in render-cluster-config.sh

### DIFF
--- a/docker/gravity_node/render-cluster-config.sh
+++ b/docker/gravity_node/render-cluster-config.sh
@@ -24,7 +24,10 @@ export CONFIG_DIR=/gravity/config
 export GENESIS_PATH=/gravity/config/genesis.json
 export RELAYER_RPC_URL="${RELAYER_RPC_URL:-https://sepolia.drpc.org}"
 
-# reth_config{,_vfn}.json.tpl placeholders — kept in sync with cluster/deploy.sh.
+# HARDCODED devnet defaults (open CORS, full API incl. debug namespace).
+# Unlike cluster/deploy.sh, this script does NOT read cluster.toml [rpc];
+# do NOT reuse for mainnet without wiring that through first — otherwise
+# debug_* endpoints are exposed to any origin.
 # TODO: factor into a shared snippet sourced by both scripts.
 export RPC_HTTP_CORSDOMAIN="${RPC_HTTP_CORSDOMAIN:-*}"
 export RPC_HTTP_API="${RPC_HTTP_API:-debug,eth,net,trace,txpool,web3,rpc}"

--- a/docker/gravity_node/render-cluster-config.sh
+++ b/docker/gravity_node/render-cluster-config.sh
@@ -24,6 +24,11 @@ export CONFIG_DIR=/gravity/config
 export GENESIS_PATH=/gravity/config/genesis.json
 export RELAYER_RPC_URL="${RELAYER_RPC_URL:-https://sepolia.drpc.org}"
 
+# reth_config{,_vfn}.json.tpl placeholders — kept in sync with cluster/deploy.sh.
+# TODO: factor into a shared snippet sourced by both scripts.
+export RPC_HTTP_CORSDOMAIN="${RPC_HTTP_CORSDOMAIN:-*}"
+export RPC_HTTP_API="${RPC_HTTP_API:-debug,eth,net,trace,txpool,web3,rpc}"
+
 render_validator() {
     local node_id="$1"
     local dir="$OUT/$node_id"


### PR DESCRIPTION
## Summary

- #663 turned \`http.corsdomain\` / \`http.api\` in \`cluster/templates/reth_config{,_vfn}.json.tpl\` into \`\${RPC_HTTP_CORSDOMAIN}\` / \`\${RPC_HTTP_API}\` placeholders and moved the defaults into \`cluster/deploy.sh\` (L438-441).
- \`docker/gravity_node/render-cluster-config.sh\` (added in #680) renders the same templates but does **not** go through \`deploy.sh\`, so \`envsubst\` was replacing those placeholders with empty strings. Empty \`http.api\` means **no RPC methods enabled** — the docker cluster's JSON-RPC is broken on current \`main\`.
- This PR exports the same defaults \`deploy.sh\` uses so the rendered \`reth_config.json\` matches the pre-#663 behavior byte-for-byte.
- A \`TODO\` is left in the script: the proper follow-up is to factor the four RPC defaults (HTTP CORS/API + WS origins/API) into a shared snippet that both \`deploy.sh\` and \`render-cluster-config.sh\` source, so adding a new RPC method / tightening CORS in the future is a one-line change.

## Why this minimal patch instead of the shared-snippet refactor

Unblocks the docker cluster path immediately with a 5-line diff, zero risk to \`deploy.sh\`, and no impact on the WS opt-in (VFN nodes in \`render-cluster-config.sh\` don't set \`ws_port\`, so that path is untouched). The refactor is tracked inline.

## Test plan

- [x] \`envsubst < cluster/templates/reth_config.json.tpl\` now produces valid JSON with \`"http.corsdomain": "*"\` and the full \`debug,eth,net,trace,txpool,web3,rpc\` API list (verified locally against both \`reth_config.json.tpl\` and \`reth_config_vfn.json.tpl\`).
- [ ] \`cd docker/gravity_node && ./render-cluster-config.sh\` regenerates \`config/{node1..node4,vfn1}/reth_config.json\` with non-empty \`http.corsdomain\` / \`http.api\`.
- [ ] \`IMAGE_TAG=ci docker compose -f docker-compose.cluster.yaml up -d\` brings up the 4+1 topology and \`eth_blockNumber\` on \`8545..8548\` / \`8550\` returns an increasing hex block number (re-run the #680 verification on top of current \`main\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)