### PR TITLE
feat(consensus): enable VFN to serve BatchRetrieval via consumer-only quorum_store

### DIFF
--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -958,6 +958,12 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         }
     }
 
+    fn start_quorum_store_consumer_only(&mut self, quorum_store_builder: QuorumStoreBuilder) {
+        if let Some(batch_retrieval_rx) = quorum_store_builder.start_consumer_only() {
+            self.batch_retrieval_tx = Some(batch_retrieval_rx);
+        }
+    }
+
     fn create_network_sender(&mut self, epoch_state: &EpochState) -> NetworkSender {
         NetworkSender::new(
             self.author,
@@ -1308,6 +1314,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         if self.is_current_epoch_validator {
             self.start_quorum_store(quorum_store_builder);
+        } else {
+            self.start_quorum_store_consumer_only(quorum_store_builder);
         }
 
         (network_sender, Arc::new(mixed_payload_client), payload_manager)

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -1723,7 +1723,9 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     /// Return false if the request is filtered out, true otherwise.
     fn rpc_request_filter(&self, peer_id: &Author, request: &IncomingRpcRequest) -> bool {
         match request {
-            IncomingRpcRequest::BlockRetrieval(_) | IncomingRpcRequest::SyncInfoRequest(_) => true,
+            IncomingRpcRequest::BlockRetrieval(_) |
+            IncomingRpcRequest::SyncInfoRequest(_) |
+            IncomingRpcRequest::BatchRetrieval(_) => true,
             _ => self.is_current_epoch_validator,
         }
     }

--- a/aptos-core/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/aptos-core/consensus/src/quorum_store/quorum_store_builder.rs
@@ -79,6 +79,20 @@ impl QuorumStoreBuilder {
             QuorumStoreBuilder::QuorumStore(inner) => Some(inner.start()),
         }
     }
+
+    /// Start only the consumer-side tasks (answer BatchRetrieval).
+    ///
+    /// - `DirectMempool` variant has no concept of BatchRetrieval; returns None.
+    /// - `QuorumStore` variant spawns the `batch_serve` task only, without any producer-side
+    ///   component. Use on non-validator nodes.
+    pub fn start_consumer_only(
+        self,
+    ) -> Option<aptos_channel::Sender<AccountAddress, IncomingBatchRetrievalRequest>> {
+        match self {
+            QuorumStoreBuilder::DirectMempool(_inner) => None,
+            QuorumStoreBuilder::QuorumStore(inner) => Some(inner.start_consumer_only()),
+        }
+    }
 }
 
 pub struct DirectMempoolInnerBuilder {
@@ -371,8 +385,40 @@ impl InnerBuilder {
         );
         spawn_named!("network_listener", net.start());
 
-        let batch_store = self.batch_store.clone().unwrap();
-        let epoch = self.epoch;
+        let batch_retrieval_tx = Self::spawn_batch_serve_task(
+            self.batch_store
+                .take()
+                .expect("batch_store must be created by create_batch_store() before batch_serve"),
+            self.aptos_db,
+            self.epoch,
+        );
+
+        (self.coordinator_tx, batch_retrieval_tx)
+    }
+
+    /// Consumer-side entry point: consume the builder and spawn only
+    /// `batch_serve`. Used by non-validator nodes (e.g. VFN-alpha acting as
+    /// the on-chain `fullnode_address`) so they can answer `BatchRetrieval`
+    /// without starting any producer-side QuorumStore component.
+    fn start_batch_serve(
+        self,
+    ) -> aptos_channel::Sender<AccountAddress, IncomingBatchRetrievalRequest> {
+        Self::spawn_batch_serve_task(
+            self.batch_store
+                .expect("batch_store must be created by create_batch_store() before batch_serve"),
+            self.aptos_db,
+            self.epoch,
+        )
+    }
+
+    /// Low-level: spawn the `batch_serve` task given the pieces it needs.
+    /// Depends only on `BatchStore` + `DbReader` + `epoch` — no producer-side
+    /// channel, safe for non-validator nodes.
+    fn spawn_batch_serve_task(
+        batch_store: Arc<BatchStore>,
+        aptos_db: Arc<dyn DbReader>,
+        epoch: u64,
+    ) -> aptos_channel::Sender<AccountAddress, IncomingBatchRetrievalRequest> {
         let (batch_retrieval_tx, mut batch_retrieval_rx) =
             aptos_channel::new::<AccountAddress, IncomingBatchRetrievalRequest>(
                 QueueStyle::FIFO,
@@ -380,7 +426,6 @@ impl InnerBuilder {
                     .map_or(1000, |s| s.parse::<usize>().unwrap()),
                 Some(&counters::BATCH_RETRIEVAL_TASK_MSGS),
             );
-        let aptos_db_clone = self.aptos_db.clone();
         spawn_named!("batch_serve", async move {
             info!(epoch = epoch, "Batch retrieval task starts");
             while let Some(rpc_request) = batch_retrieval_rx.next().await {
@@ -393,7 +438,7 @@ impl InnerBuilder {
                     let batch: Batch = value.try_into().unwrap();
                     BatchResponse::Batch(batch)
                 } else {
-                    match aptos_db_clone.get_latest_ledger_info() {
+                    match aptos_db.get_latest_ledger_info() {
                         Ok(ledger_info) => BatchResponse::NotFound(ledger_info),
                         Err(e) => {
                             let e = anyhow::Error::from(e);
@@ -408,7 +453,7 @@ impl InnerBuilder {
                 if let Err(e) = rpc_request
                     .response_sender
                     .send(Ok(bytes.into()))
-                    .map_err(|_| anyhow::anyhow!("Failed to send block retrieval response"))
+                    .map_err(|_| anyhow::anyhow!("Failed to send batch retrieval response"))
                 {
                     warn!(epoch = epoch, error = ?e, kind = error_kind(&e));
                 }
@@ -416,7 +461,7 @@ impl InnerBuilder {
             info!(epoch = epoch, "Batch retrieval task stops");
         });
 
-        (self.coordinator_tx, batch_retrieval_tx)
+        batch_retrieval_tx
     }
 
     fn init_payload_manager(
@@ -445,5 +490,11 @@ impl InnerBuilder {
         aptos_channel::Sender<AccountAddress, IncomingBatchRetrievalRequest>,
     ) {
         self.spawn_quorum_store()
+    }
+
+    fn start_consumer_only(
+        self,
+    ) -> aptos_channel::Sender<AccountAddress, IncomingBatchRetrievalRequest> {
+        self.start_batch_serve()
     }
 }

--- a/cluster/cluster.toml.example
+++ b/cluster/cluster.toml.example
@@ -140,3 +140,22 @@ relayer_rpc_url = "https://sepolia.drpc.org"
 num_accounts = 0 # Set to > 0 to enable auto-initialization
 private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 eth_balance = "1000000000000000000"
+
+# ============ Optional: VFN shadow topology ============
+# Register an independent VFN as a validator's on-chain `fullnode_address`.
+# See _local/drafts/vfn-shadow/design.md §1.2 and e2e.md §3-§6.
+#
+# [[nodes]]
+# id = "vfn-alpha"
+# role = "vfn"
+# shadow_of = "node1"                 # deploy.sh injects seeds -> node1's vfn_server
+# source = { project_path = "../" }
+# host = "mgmt.vfn-alpha.example.com" # control-plane RPC (status.sh / pytest / faucet.sh)
+# internal_host = "10.0.1.20"         # optional: intra-cluster p2p peer dial; falls back to host
+# vfn_port = 6193                     # listener; on-chain fullnode_address points here
+# rpc_port = 8546
+# metrics_port = 9100
+# inspection_port = 10100
+# https_port = 1100
+# authrpc_port = 8600
+# reth_p2p_port = 12100

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -570,6 +570,47 @@ main() {
                 exit 1
             fi
 
+            # Optional: build VFN_SEEDS_BLOCK if shadow_of is set.
+            # See _local/drafts/vfn-shadow/e2e.md §6.3.
+            shadow_of=$(echo "$node" | jq -r '.shadow_of // empty')
+            if [ -n "$shadow_of" ]; then
+                target_identity="$OUTPUT_DIR/$shadow_of/config/identity.yaml"
+                if [ ! -f "$target_identity" ]; then
+                    log_error "shadow_of=$shadow_of but identity not found at $target_identity"
+                    exit 1
+                fi
+                target_peer_id=$(awk -F': ' '/^account_address:/{gsub(/["\x27]/,"",$2); print $2}' "$target_identity")
+                target_network_pk=$(awk -F': ' '/^network_public_key:/{gsub(/["\x27]/,"",$2); print $2}' "$target_identity")
+                target_peer_id=${target_peer_id#0x}
+                target_network_pk=${target_network_pk#0x}
+                if [ -z "$target_peer_id" ] || [ -z "$target_network_pk" ]; then
+                    log_error "shadow_of=$shadow_of: failed to parse peer_id/network_pk from $target_identity"
+                    exit 1
+                fi
+                # Intra-cluster p2p dial uses internal_host first, falls back to host.
+                target_host=$(echo "$config_json" | jq -r --arg id "$shadow_of" \
+                    '.nodes[] | select(.id == $id) | (.internal_host // .host)')
+                target_vfn_port=$(echo "$config_json" | jq -r --arg id "$shadow_of" \
+                    '.nodes[] | select(.id == $id) | .vfn_port')
+                if [ -z "$target_host" ] || [ "$target_host" = "null" ] || \
+                   [ -z "$target_vfn_port" ] || [ "$target_vfn_port" = "null" ]; then
+                    log_error "shadow_of=$shadow_of: missing host/vfn_port in cluster.toml"
+                    exit 1
+                fi
+                target_proto="dns"
+                if [[ "$target_host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    target_proto="ip4"
+                fi
+                export VFN_SEEDS_BLOCK="    seeds:
+      '0x${target_peer_id}':
+        addresses:
+          - '/${target_proto}/${target_host}/tcp/${target_vfn_port}/noise-ik/${target_network_pk}/handshake/0'
+        role: Validator"
+                log_info "  [$NODE_ID] shadow_of=$shadow_of, seeds -> ${target_host}:${target_vfn_port} (proto=${target_proto})"
+            else
+                export VFN_SEEDS_BLOCK=""
+            fi
+
             configure_vfn \
                 "$NODE_ID" \
                 "$data_dir" \

--- a/cluster/genesis.toml.example
+++ b/cluster/genesis.toml.example
@@ -123,3 +123,25 @@ p2p_port = 6183
 vfn_port = 6193
 stake_amount = "2000000000000000000"
 voting_power = "2000000000000000000"
+
+# ============ Optional: VFN shadow topology ============
+# On-chain fullnode_address points at a separate VFN-alpha instead of the
+# validator's own vfn_port. See _local/drafts/vfn-shadow/design.md §1.2 and
+# e2e.md §3-§6.
+#
+# On the validator entry, set `shadow_fullnode` to the id of a shadow node:
+#
+# [[genesis_validators]]
+# id = "node1"
+# address = "0x..."
+# host = "p2p-a.node1.example.com"    # on-chain validator_address host (public p2p)
+# p2p_port = 6180
+# vfn_port = 6190                     # ignored when shadow_fullnode is set
+# shadow_fullnode = "vfn-alpha"
+# stake_amount = "..."
+# voting_power = "..."
+#
+# [[shadow_nodes]]
+# id = "vfn-alpha"
+# host = "p2p-a.vfn-alpha.example.com" # on-chain fullnode_address host (public p2p)
+# vfn_port = 6193

--- a/cluster/templates/validator_full_node.yaml.tpl
+++ b/cluster/templates/validator_full_node.yaml.tpl
@@ -43,6 +43,7 @@ full_node_networks:
       path: ${CONFIG_DIR}/identity.yaml
     discovery_method:
       onchain
+${VFN_SEEDS_BLOCK}
 
 storage:
   dir: "${DATA_DIR}/data"

--- a/cluster/utils/aggregate_genesis.py
+++ b/cluster/utils/aggregate_genesis.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import os
 import sys
@@ -231,7 +232,9 @@ def main():
         # Filter to only genesis nodes
         genesis_nodes = [n for n in nodes if n.get('role') == 'genesis']
         print(f"[Aggregator] Processing {len(genesis_nodes)} genesis nodes for initial validator set (skipping {len(nodes) - len(genesis_nodes)} non-genesis nodes)...")
-    
+
+    shadow_lookup = {sn['id']: sn for sn in config.get('shadow_nodes', [])}
+
     validators = []
 
     for node in genesis_nodes:
@@ -316,7 +319,41 @@ def main():
             host_proto = "dns"
 
         val_net_addr = f"/{host_proto}/{host}/tcp/{p2p_port}/noise-ik/{network_pk}/handshake/0"
-        vfn_net_addr = f"/{host_proto}/{host}/tcp/{vfn_port}/noise-ik/{network_pk}/handshake/0"
+
+        # Optional shadow redirect: on-chain fullnode_address points at a
+        # shadow VFN instead of the validator's own vfn server. See
+        # _local/drafts/vfn-shadow/design.md §1.2 / e2e.md §5-§6.
+        shadow_id = node.get('shadow_fullnode')
+        if shadow_id:
+            if shadow_id not in shadow_lookup:
+                print(f"Error: validator {node_id} references shadow_fullnode='{shadow_id}' "
+                      f"but no matching [[shadow_nodes]] entry found")
+                sys.exit(1)
+            shadow = shadow_lookup[shadow_id]
+            shadow_identity_path = os.path.join(output_dir, shadow_id, 'config', 'identity.yaml')
+            if not os.path.exists(shadow_identity_path):
+                print(f"Error: shadow node '{shadow_id}' identity not found at {shadow_identity_path}. "
+                      f"Run 'make init' first.")
+                sys.exit(1)
+            shadow_identity = parse_simple_yaml(shadow_identity_path)
+            shadow_network_pk = shadow_identity['network_public_key']
+            if shadow_network_pk.startswith('0x'):
+                shadow_network_pk = shadow_network_pk[2:]
+            shadow_host = shadow['host']
+            shadow_vfn_port = shadow['vfn_port']
+            try:
+                ipaddress.IPv4Address(shadow_host)
+                shadow_proto = 'ip4'
+            except ValueError:
+                shadow_proto = 'dns'
+            vfn_net_addr = (
+                f"/{shadow_proto}/{shadow_host}/tcp/{shadow_vfn_port}"
+                f"/noise-ik/{shadow_network_pk}/handshake/0"
+            )
+            print(f"[Aggregator] Validator {node_id}: fullnode_address redirected to "
+                  f"shadow '{shadow_id}' ({shadow_host}:{shadow_vfn_port})")
+        else:
+            vfn_net_addr = f"/{host_proto}/{host}/tcp/{vfn_port}/noise-ik/{network_pk}/handshake/0"
         
         # Consensus PoP: use node config value, identity file, or 96-byte dummy
         # ValidatorManagement.sol requires non-empty consensusPop

--- a/gravity_e2e/cluster_test_cases/vfn_shadow/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/vfn_shadow/cluster.toml
@@ -1,0 +1,66 @@
+# Gravity Cluster Configuration - VFN shadow topology
+# 1 validator (node1) + 1 VFN-alpha (shadow of node1) + 1 VFN-client
+# See _local/drafts/vfn-shadow/e2e.md §2-§4.
+#
+# NOTE on node ordering: start.sh launches nodes in the order they appear here.
+# vfn-alpha is listed *before* node1 on purpose so it boots with an empty
+# BlockStore from genesis; otherwise node1 produces blocks before vfn-alpha
+# comes up, vfn-alpha hot-pulls them through its static seeds, and recover_blocks
+# hits an existing upstream assert_eq on ACCUMULATOR_PLACEHOLDER_HASH (panic in
+# block_store.rs:645). Unrelated to the consumer-only QS change.
+
+[cluster]
+name = "gravity-devnet-vfn-shadow"
+base_dir = "/tmp/gravity-cluster-vfn-shadow"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "vfn-alpha"
+role = "vfn"
+shadow_of = "node1"             # deploy.sh renders seeds block pointing at node1's vfn server
+source = { project_path = "../" }
+host = "127.0.0.1"
+p2p_port = 6183
+vfn_port = 6193                 # on-chain fullnode_address points at this listener
+rpc_port = 18546
+metrics_port = 9004
+inspection_port = 10003
+https_port = 1025
+authrpc_port = 8554
+reth_p2p_port = 12027
+
+[[nodes]]
+id = "vfn-client"
+role = "vfn"
+# no shadow_of — standard VFN, reaches vfn-alpha via on-chain discovery
+source = { project_path = "../" }
+host = "127.0.0.1"
+p2p_port = 6184
+vfn_port = 6194
+rpc_port = 18547
+metrics_port = 9005
+inspection_port = 10004
+https_port = 1026
+authrpc_port = 8555
+reth_p2p_port = 12028
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+# internal_host = "10.0.1.10"   # optional: intra-cluster p2p address. Falls back to host when unset.
+p2p_port = 6182
+vfn_port = 6192                 # still runs a local vfn server (not registered on-chain)
+rpc_port = 18545                # shifted from 8545 to avoid host-wide conflict with another user's anvil
+metrics_port = 9003
+inspection_port = 10002
+https_port = 1024
+authrpc_port = 8553
+reth_p2p_port = 12026
+
+[faucet_init]
+num_accounts = 10000

--- a/gravity_e2e/cluster_test_cases/vfn_shadow/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/vfn_shadow/genesis.toml
@@ -1,0 +1,85 @@
+# Gravity Genesis Configuration - VFN shadow topology
+# node1 registers vfn-alpha as its on-chain fullnode_address.
+
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "main"
+
+[[genesis_validators]]
+id = "node1"
+address = "0xAEd2a948892475F800A337427B3275D190EA3e94"
+host = "127.0.0.1"
+p2p_port = 6182
+vfn_port = 6192                         # ignored when shadow_fullnode is set
+shadow_fullnode = "vfn-alpha"           # on-chain fullnode_address resolved from [[shadow_nodes]]
+stake_amount = "10000000000000000000"
+voting_power = "10000000000000000000"
+
+# Shadow VFN network addresses used when building on-chain fullnode_address.
+# See _local/drafts/vfn-shadow/e2e.md §5.
+[[shadow_nodes]]
+id = "vfn-alpha"
+host = "127.0.0.1"
+vfn_port = 6193
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 60000000 # 60 second
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "10000000000000000000"
+voting_duration_micros = 604800000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
+
+[genesis.oracle_config.bridge_config]
+deploy = true
+trusted_bridge = "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
+trusted_source_id = 11155111
+
+[[genesis.oracle_config.tasks]]
+source_type = 0
+source_id = 11155111
+task_name = "sepolia"
+config = "gravity://0/11155111/events?contract=0x0f761B1B3c1aC9232C9015A7276692560aD6a05F&eventSignature=0x5646e682c7d994bf11f5a2c8addb60d03c83cda3b65025a826346589df43406e&fromBlock=10201260"
+
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/vfn_shadow/test_vfn_shadow.py
+++ b/gravity_e2e/cluster_test_cases/vfn_shadow/test_vfn_shadow.py
@@ -1,0 +1,302 @@
+"""
+VFN-shadow Topology Test
+
+Single test, modeled after rolling_upgrade's pattern:
+1. Bring the 3-node cluster live (node1 validator + vfn-alpha shadow + vfn-client).
+2. Launch a background TxSender that submits txs to vfn-client — this exercises
+   the vfn-client → vfn-alpha → node1 forwarding path continuously, so block
+   and BatchRetrieval traffic stays saturated.
+3. Periodically sample heights from all three nodes; assert every node keeps
+   advancing and the pairwise gap stays within MAX_HEIGHT_GAP.
+4. Midway, stop vfn-client and restart it — it must catch back up via
+   vfn-alpha's BatchRetrieval answers, which only work if the consumer-only
+   QS start path is wired correctly.
+5. After monitoring, assert vfn-alpha's log contains `Batch retrieval task
+   starts` and never `Quorum store not started`, and contains no producer-side
+   task markers.
+
+See _local/drafts/vfn-shadow/design.md §1.4 for the core assertion.
+"""
+
+import asyncio
+import logging
+import math
+import pathlib
+import statistics
+import time
+
+import pytest
+from eth_account import Account
+from web3 import Web3
+
+from gravity_e2e.cluster.manager import Cluster
+from gravity_e2e.cluster.node import Node, NodeState
+
+LOG = logging.getLogger(__name__)
+
+MAX_HEIGHT_GAP = 50
+MONITOR_DURATION = 120           # seconds
+MONITOR_INTERVAL = 10            # seconds between height samples
+TX_INTERVAL = 0.2                # seconds between txs
+TX_RECEIPT_TIMEOUT = 30.0        # per-tx receipt poll budget
+PRODUCER_FORBIDDEN_MARKERS = (
+    "QS: starting networking",
+)
+
+
+class TxSender:
+    """Continuously send txs to a target node; track submit/confirm stats."""
+
+    def __init__(self, cluster: Cluster, faucet, target_node_id: str):
+        self.cluster = cluster
+        self.faucet = faucet
+        self.target_node_id = target_node_id
+        self.recipient = Account.create().address
+
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+        self.total_sent = 0
+        self.total_confirmed = 0
+        self.total_failed = 0
+        self.total_timeout = 0
+        self.latencies: list[float] = []
+
+    @property
+    def _w3(self) -> Web3:
+        return self.cluster.get_node(self.target_node_id).w3
+
+    async def _send_loop(self):
+        w3 = self._w3
+        chain_id = await asyncio.to_thread(lambda: w3.eth.chain_id)
+        gas_price = Web3.to_wei("2", "gwei")
+        nonce = await asyncio.to_thread(
+            lambda: w3.eth.get_transaction_count(self.faucet.address, "pending")
+        )
+        LOG.info(
+            f"TxSender started: target={self.target_node_id}, nonce={nonce}, "
+            f"recipient={self.recipient}"
+        )
+
+        while not self._stop_event.is_set():
+            w3 = self._w3
+            tx = {
+                "nonce": nonce,
+                "to": self.recipient,
+                "value": 0,
+                "gas": 21000,
+                "gasPrice": gas_price,
+                "chainId": chain_id,
+            }
+            try:
+                signed = w3.eth.account.sign_transaction(tx, self.faucet.key)
+                send_time = time.monotonic()
+                tx_hash = await asyncio.to_thread(
+                    lambda: w3.eth.send_raw_transaction(signed.raw_transaction)
+                )
+                self.total_sent += 1
+                nonce += 1
+
+                confirmed = False
+                while time.monotonic() - send_time < TX_RECEIPT_TIMEOUT:
+                    try:
+                        receipt = await asyncio.to_thread(
+                            lambda: w3.eth.get_transaction_receipt(tx_hash)
+                        )
+                        if receipt:
+                            self.latencies.append(time.monotonic() - send_time)
+                            self.total_confirmed += 1
+                            confirmed = True
+                            break
+                    except Exception:
+                        pass
+                    await asyncio.sleep(0.1)
+
+                if not confirmed:
+                    self.total_timeout += 1
+                    try:
+                        nonce = await asyncio.to_thread(
+                            lambda: self._w3.eth.get_transaction_count(
+                                self.faucet.address, "pending"
+                            )
+                        )
+                    except Exception:
+                        pass
+
+            except Exception as e:
+                self.total_failed += 1
+                LOG.warning(f"TxSender send failed ({self.target_node_id}): {e}")
+                await asyncio.sleep(1)
+                try:
+                    nonce = await asyncio.to_thread(
+                        lambda: self._w3.eth.get_transaction_count(
+                            self.faucet.address, "pending"
+                        )
+                    )
+                except Exception:
+                    pass
+                continue
+
+            await asyncio.sleep(TX_INTERVAL)
+
+    def start(self):
+        self._task = asyncio.create_task(self._send_loop())
+
+    async def stop(self):
+        self._stop_event.set()
+        if self._task:
+            await self._task
+
+    def log_stats(self):
+        LOG.info("=" * 60)
+        LOG.info("TRANSACTION STATISTICS")
+        LOG.info("=" * 60)
+        LOG.info(f"Total Sent:    {self.total_sent}")
+        LOG.info(f"Confirmed:     {self.total_confirmed}")
+        LOG.info(f"Failed (send): {self.total_failed}")
+        LOG.info(f"Timed Out:     {self.total_timeout}")
+        if self.total_sent > 0:
+            LOG.info(
+                f"Success Rate:  {self.total_confirmed / self.total_sent * 100:.1f}%"
+            )
+        if self.latencies:
+            sl = sorted(self.latencies)
+
+            def pct(p):
+                k = (len(sl) - 1) * (p / 100.0)
+                f, c = math.floor(k), math.ceil(k)
+                return sl[int(k)] if f == c else sl[f] + (sl[c] - sl[f]) * (k - f)
+
+            LOG.info(f"Latency p50/p90/p99: {pct(50):.3f}s / {pct(90):.3f}s / {pct(99):.3f}s")
+            LOG.info(f"Latency min/max/avg: {sl[0]:.3f}s / {sl[-1]:.3f}s / {statistics.mean(sl):.3f}s")
+        LOG.info("=" * 60)
+
+
+async def _get_block_heights(nodes: list[Node]) -> dict[str, int]:
+    async def _h(n: Node):
+        return n.id, await asyncio.to_thread(lambda: n.w3.eth.block_number)
+
+    return dict(await asyncio.gather(*[_h(n) for n in nodes]))
+
+
+def _node_log_text(node: Node) -> str:
+    """Read consensus log (vfn.log for VFN, validator.log for validator)."""
+    base = pathlib.Path(node._infra_path) / "consensus_log"
+    for name in ("vfn.log", "validator.log"):
+        p = base / name
+        if p.exists():
+            return p.read_text(errors="replace")
+    return ""
+
+
+@pytest.mark.asyncio
+async def test_vfn_shadow_topology(cluster: Cluster):
+    """Single end-to-end VFN shadow test: liveness + forwarding + BatchRetrieval."""
+    LOG.info("=" * 70)
+    LOG.info("Test: VFN shadow topology (1 validator + 1 vfn-alpha + 1 vfn-client)")
+    LOG.info("=" * 70)
+
+    assert await cluster.set_full_live(timeout=120), "Cluster failed to become live"
+
+    node_ids = ("node1", "vfn-alpha", "vfn-client")
+    nodes = [cluster.get_node(nid) for nid in node_ids]
+    for nid, node in zip(node_ids, nodes):
+        assert node is not None, f"{nid} missing from cluster"
+
+    assert await cluster.check_block_increasing(timeout=30), "Blocks not advancing"
+
+    # Step 1: Background tx load against vfn-client — exercises the full
+    # forwarding chain (client → alpha → node1) and the reverse sync path
+    # (BatchRetrieval on alpha) whenever vfn-client needs to catch up.
+    tx_sender = TxSender(cluster, cluster.faucet, target_node_id="vfn-client")
+    tx_sender.start()
+    LOG.info("TxSender started against vfn-client")
+
+    try:
+        # Step 2: Periodic height sampling. Every node must strictly advance
+        # and pairwise gap must stay within MAX_HEIGHT_GAP.
+        initial = await _get_block_heights(nodes)
+        LOG.info(f"initial heights: {initial}")
+
+        monitor_start = time.monotonic()
+        check_count = 0
+        last_heights = dict(initial)
+
+        while time.monotonic() - monitor_start < MONITOR_DURATION:
+            await asyncio.sleep(MONITOR_INTERVAL)
+            check_count += 1
+
+            last_heights = await _get_block_heights(nodes)
+            max_h = max(last_heights.values())
+            min_h = min(last_heights.values())
+            gap = max_h - min_h
+            elapsed = int(time.monotonic() - monitor_start)
+            LOG.info(
+                f"[check #{check_count} @ {elapsed}s] heights={last_heights} gap={gap}"
+            )
+
+            assert gap < MAX_HEIGHT_GAP, (
+                f"pairwise height gap {gap} >= {MAX_HEIGHT_GAP}: {last_heights}"
+            )
+
+        # Every node must have advanced from initial.
+        for nid in node_ids:
+            assert last_heights[nid] > initial[nid], (
+                f"{nid} did not advance: initial={initial[nid]} last={last_heights[nid]}"
+            )
+
+        # Step 3: Stop / restart vfn-client mid-flight. It must catch back up
+        # via vfn-alpha's BatchRetrieval responses — the core assertion.
+        client = cluster.get_node("vfn-client")
+        LOG.info("Stopping vfn-client to force a sync-from-scratch via vfn-alpha…")
+        assert await client.stop(), "vfn-client failed to stop"
+
+        # Let the chain advance while client is offline.
+        await asyncio.sleep(30)
+
+        LOG.info("Restarting vfn-client…")
+        assert await client.start(), "vfn-client failed to restart"
+
+        # Give it time to catch up; height gap check will reflect success.
+        catchup_deadline = time.monotonic() + 120
+        while time.monotonic() < catchup_deadline:
+            await asyncio.sleep(MONITOR_INTERVAL)
+            heights = await _get_block_heights(nodes)
+            gap = max(heights.values()) - min(heights.values())
+            LOG.info(f"[post-restart] heights={heights} gap={gap}")
+            if gap < MAX_HEIGHT_GAP:
+                break
+
+        heights = await _get_block_heights(nodes)
+        gap = max(heights.values()) - min(heights.values())
+        assert gap < MAX_HEIGHT_GAP, (
+            f"vfn-client failed to catch up via vfn-alpha: {heights} gap={gap}"
+        )
+    finally:
+        await tx_sender.stop()
+        tx_sender.log_stats()
+
+    # Transactional throughput sanity: if *nothing* confirmed the cluster is
+    # fundamentally broken regardless of what heights said.
+    assert tx_sender.total_confirmed > 0, (
+        f"TxSender confirmed 0 txns; forwarding chain broken. "
+        f"sent={tx_sender.total_sent} timeout={tx_sender.total_timeout} "
+        f"failed={tx_sender.total_failed}"
+    )
+
+    # Step 4: Log assertions — the consumer-only QS path must have spawned
+    # batch_serve on vfn-alpha, and vfn-alpha must not have touched any
+    # producer-side task.
+    alpha_text = _node_log_text(cluster.get_node("vfn-alpha"))
+    assert "Batch retrieval task starts" in alpha_text, (
+        "vfn-alpha never spawned batch_serve — consumer-only path is not wired"
+    )
+    assert "Quorum store not started" not in alpha_text, (
+        "vfn-alpha rejected a BatchRetrieval with 'Quorum store not started'"
+    )
+    for forbidden in PRODUCER_FORBIDDEN_MARKERS:
+        assert forbidden not in alpha_text, (
+            f"vfn-alpha unexpectedly started a producer-side task: '{forbidden}'"
+        )
+
+    LOG.info("✅ VFN shadow topology test PASSED")


### PR DESCRIPTION
## Summary

Lets a non-validator node (VFN) answer peer `BatchRetrieval` RPCs without starting the full QuorumStore producer pipeline, and adds a vfn-shadow e2e topology that exercises the path. Motivated by the case where a validator's on-chain `fullnode_address` points at a standalone VFN (instead of being served by the validator itself); without this change, that VFN fails every incoming BatchRetrieval because its consumer-side task was never spawned and the RPC filter gated the message behind validator status.

Depends on (merged) #681, which fixed the ancestor-block rebuild panic this topology first exposed.

## Changes by commit

### 1. `feat(consensus): enable VFN to serve BatchRetrieval via consumer-only quorum_store`

- **`quorum_store_builder`**: extract `spawn_batch_serve_task` from the main spawn path; add `InnerBuilder::start_consumer_only` and `QuorumStoreBuilder::start_consumer_only` entry points that spawn only the BatchStore/aptos_db-backed `batch_serve` task, skipping every producer-side component (batch generator, coordinators, proof manager, network listener). Fix a misattributed `"block retrieval"` error string in the batch response path.
- **`epoch_manager`**: on non-validator nodes, call `start_quorum_store_consumer_only` instead of dropping the builder, so `self.batch_retrieval_tx` is populated and incoming RPCs have somewhere to go.
- **`cluster`**: support the vfn-shadow topology —
  - `shadow_of` in `cluster.toml` → `deploy.sh` renders a static `seeds` block pointing at the shadowed validator's `vfn_server` so the VFN dials directly instead of going through onchain discovery.
  - `shadow_fullnode` in `genesis.toml` → `aggregate_genesis.py` redirects the validator's on-chain `fullnode_address` to a separate VFN's address pulled from `[[shadow_nodes]]`.
- **e2e**: `gravity_e2e/cluster_test_cases/vfn_shadow/` harness — 1 validator (`node1`) + 1 VFN-alpha shadowing node1 + 1 downstream VFN-client that talks to vfn-alpha via onchain discovery.

### 2. `fix(consensus): route BatchRetrieval RPCs to non-validator batch_serve task`

`rpc_request_filter` in `epoch_manager` was still gating everything except `BlockRetrieval` and `SyncInfoRequest` behind `is_current_epoch_validator`. After commit 1 spawns the consumer task, the RPC still got dropped before it reached `batch_retrieval_tx`. Add `BatchRetrieval` to the non-validator whitelist.

## Validation

- vfn e2e (onchain discovery, original suite): 3 passed — regression clean.
- vfn_shadow e2e (new): 4 back-to-back runs PASSED after both fixes land.
  - Before #681: vfn_shadow panicked intermittently in `BlockStore::build` at `"Parent block not found"` on fresh cluster boot (race-dependent on when vfn-alpha's dial landed relative to node1's first epoch crossing).
  - After #681 + this PR: heights converge across all 3 nodes with gap ≤ 4 during tx load, multiple epoch boundaries traversed cleanly.

## Test plan

- [x] `python3 gravity_e2e/runner.py vfn --force-init` — 3 passed
- [x] `python3 gravity_e2e/runner.py vfn_shadow --force-init` — 1 passed (× 4 back-to-back)
- [x] Manual check: `rpc request from <peer> is filtered out: BatchRetrieval(...)` no longer appears in vfn-alpha log; `Batch retrieval task starts` is logged at epoch rollover