### PR TITLE
feat(consensus/e2e): support PublicFullnode via NodeType-aware sync paths

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -33,50 +33,74 @@ jobs:
         id: dup
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pull all expression inputs through env so potentially-untrusted
+          # values (e.g. branch names) can't be interpolated directly into
+          # the inline script. See GH Actions script-injection hardening.
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          WF: ${{ inputs.workflow_file }}
+          THIS_RUN: ${{ github.run_id }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Use PR branch instead of head_sha so that the check is PR-wide,
-          # not commit-specific.  Once CI passes on any commit in the PR,
-          # subsequent approvals (even after new pushes) will be skipped.
-          # The author can always re-run manually if needed.
-          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Candidates are workflow runs on the same branch, but "same branch"
+          # alone is not a safe duplicate key: a reused branch name (e.g. a
+          # prior PR's branch that was force-pushed for a new PR) would match
+          # stale runs from a different PR. So for each candidate run we ask
+          # `commits/{head_sha}/pulls` whether the current PR number is
+          # associated with that SHA — only then is it a real duplicate of
+          # this PR.
+          belongs_to_pr() {
+            local sha="$1"
+            local count
+            count=$(gh api "repos/${REPO}/commits/${sha}/pulls" \
+              --jq "[.[]? | select(.number == ${PR_NUMBER})] | length" 2>/dev/null || echo 0)
+            [ "${count:-0}" -gt 0 ]
+          }
 
-          # Check for in-progress runs on this PR (any commit)
-          IN_PROGRESS=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/${{ inputs.workflow_file }}/runs?branch=${PR_BRANCH}" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .status == \"in_progress\")] | length")
-          if [ "$IN_PROGRESS" -gt "0" ]; then
-            echo "CI already in progress for branch ${PR_BRANCH}. Skipping."
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          # In-progress runs whose head_sha belongs to this PR
+          IN_PROGRESS_PAIRS=$(gh api \
+            "repos/${REPO}/actions/workflows/${WF}/runs?branch=${PR_BRANCH}" \
+            --jq "[.workflow_runs[] | select(.id != ${THIS_RUN} and .status == \"in_progress\")] | .[] | \"\(.id) \(.head_sha)\"")
 
-          # Check for successful runs on this PR (any commit) — but only
-          # count runs where real test jobs actually ran (not just gate +
-          # skipped downstream jobs)
-          SUCCESSFUL_RUN_IDS=$(gh api \
-            "repos/${{ github.repository }}/actions/workflows/${{ inputs.workflow_file }}/runs?branch=${PR_BRANCH}" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .conclusion == \"success\")] | .[].id")
+          while IFS=' ' read -r RUN_ID HEAD_SHA; do
+            [ -z "$RUN_ID" ] && continue
+            if belongs_to_pr "$HEAD_SHA"; then
+              echo "CI already in progress for PR #${PR_NUMBER} (run #${RUN_ID}, sha ${HEAD_SHA}). Skipping."
+              echo "should_run=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done <<< "$IN_PROGRESS_PAIRS"
+
+          # Successful runs whose head_sha belongs to this PR — and only
+          # count runs where real test jobs actually executed (not just gate
+          # + skipped downstream jobs).
+          SUCCESSFUL_PAIRS=$(gh api \
+            "repos/${REPO}/actions/workflows/${WF}/runs?branch=${PR_BRANCH}" \
+            --jq "[.workflow_runs[] | select(.id != ${THIS_RUN} and .conclusion == \"success\")] | .[] | \"\(.id) \(.head_sha)\"")
 
           HAS_REAL_SUCCESS=false
-          for RUN_ID in $SUCCESSFUL_RUN_IDS; do
-            # Count jobs that actually completed (not skipped), excluding gate jobs
+          while IFS=' ' read -r RUN_ID HEAD_SHA; do
+            [ -z "$RUN_ID" ] && continue
+            belongs_to_pr "$HEAD_SHA" || continue
+
             REAL_JOBS=$(gh api \
-              "repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs" \
+              "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
               --jq '[.jobs[] | select(.conclusion == "success" and (.name | test("(?i)gate") | not))] | length')
             if [ "$REAL_JOBS" -gt "0" ]; then
-              echo "Found previous run #$RUN_ID with real test execution on branch ${PR_BRANCH}."
+              echo "Found previous run #${RUN_ID} (sha ${HEAD_SHA}) on PR #${PR_NUMBER} with real test execution."
               HAS_REAL_SUCCESS=true
               break
             fi
-          done
+          done <<< "$SUCCESSFUL_PAIRS"
 
           if [ "$HAS_REAL_SUCCESS" = "true" ]; then
-            echo "CI already passed for branch ${PR_BRANCH}. Skipping."
+            echo "CI already passed for PR #${PR_NUMBER}. Skipping."
             echo "should_run=false" >> $GITHUB_OUTPUT
           else
             echo "should_run=true" >> $GITHUB_OUTPUT
@@ -88,12 +112,13 @@ jobs:
         if: steps.dup.outputs.should_run == 'true' && github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IGNORE_PATTERNS: ${{ inputs.ignore_patterns }}
         run: |
           CHANGED_FILES=$(gh api \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            "repos/${REPO}/pulls/${PR_NUMBER}/files?per_page=100" \
             --paginate --jq '.[].filename')
-
-          IGNORE_PATTERNS="${{ inputs.ignore_patterns }}"
 
           # Split pipe-separated patterns into an array
           IFS='|' read -ra PATTERNS <<< "$IGNORE_PATTERNS"
@@ -134,10 +159,10 @@ jobs:
       # ── 3. Final decision ──────────────────────────────────────────────
       - name: Determine final result
         id: final
+        env:
+          DUP_RESULT: ${{ steps.dup.outputs.should_run }}
+          FILE_RESULT: ${{ steps.files.outputs.has_relevant }}
         run: |
-          DUP_RESULT="${{ steps.dup.outputs.should_run }}"
-          FILE_RESULT="${{ steps.files.outputs.has_relevant }}"
-
           # If dup check already said no, skip
           if [ "$DUP_RESULT" != "true" ]; then
             echo "should_run=false" >> $GITHUB_OUTPUT

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -79,7 +79,8 @@ use gaptos::{
     aptos_channels::{aptos_channel, message_queues::QueueStyle},
     aptos_config::{
         config::{
-            ConsensusConfig, DagConsensusConfig, ExecutionConfig, NodeConfig, QcAggregatorType,
+            ConsensusConfig, DagConsensusConfig, ExecutionConfig, NodeConfig, NodeType,
+            QcAggregatorType,
         },
         network_id::{NetworkId, PeerNetworkId},
     },
@@ -179,7 +180,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     bounded_executor: BoundedExecutor,
     // recovery_mode is set to true when the recovery manager is spawned
     recovery_mode: bool,
-    is_validator: bool,
+    node_type: NodeType,
     is_current_epoch_validator: bool,
     aptos_time_service: gaptos::aptos_time_service::TimeService,
     dag_rpc_tx: Option<aptos_channel::Sender<AccountAddress, IncomingDAGRequest>>,
@@ -195,6 +196,19 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     sync_info_tx: mpsc::Sender<Option<(Author, Box<SyncInfo>)>>,
     sync_info_rx: mpsc::Receiver<Option<(Author, Box<SyncInfo>)>>,
     inflight_request_sync_info: bool,
+}
+
+/// For non-validator consensus paths (sync-path BlockRetrieval / SyncInfoRequest /
+/// BatchRetrieval), map the node's static identity to the `NetworkId` it uses to
+/// reach upstream peers. VFN talks to its validator via `Vfn`; PFN talks to
+/// VFN/IVFN via `Public`. A mis-configured node that is classified as `Validator`
+/// but has fallen out of the active validator set falls back to `Vfn` — this
+/// preserves the pre-PFN behavior.
+fn fullnode_side_network_id(node_type: NodeType) -> NetworkId {
+    match node_type {
+        NodeType::Validator | NodeType::ValidatorFullnode => NetworkId::Vfn,
+        NodeType::PublicFullnode => NetworkId::Public,
+    }
 }
 
 impl<P: OnChainConfigProvider> EpochManager<P> {
@@ -216,7 +230,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         rand_storage: Arc<dyn RandStorage<AugmentedData>>,
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
     ) -> Self {
-        let is_validator = node_config.base.role.is_validator();
+        let node_type = NodeType::extract_from_config(node_config);
         // Read author from identity_blob_path in safety_rules config
         let author = node_config
             .consensus
@@ -226,7 +240,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             .expect("identity_blob must be configured in safety_rules.initial_safety_rules_config")
             .account_address
             .expect("account_address must be set in identity blob");
-        if is_validator {
+        if node_type.is_validator() {
             assert_eq!(
                 node_config
                     .validator_network
@@ -277,7 +291,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             batch_retrieval_tx: None,
             bounded_executor,
             recovery_mode: false,
-            is_validator,
+            node_type,
             is_current_epoch_validator: false,
             dag_rpc_tx: None,
             dag_shutdown_tx: None,
@@ -716,7 +730,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                     if self.is_current_epoch_validator {
                         NetworkId::Validator
                     } else {
-                        NetworkId::Vfn
+                        fullnode_side_network_id(self.node_type)
                     },
                     self.author,
                 ),
@@ -932,6 +946,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             onchain_jwk_consensus_config,
             fast_rand_config,
             validator_components,
+            fullnode_side_network_id(self.node_type),
         );
 
         round_manager.init(last_vote).await;
@@ -1122,7 +1137,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         info!("Updated proposer reth address map for epoch {}", payload.epoch());
 
         self.is_current_epoch_validator = false;
-        if self.is_validator {
+        if self.node_type.is_validator() {
             for validator in validator_set.active_validators.iter() {
                 if validator.account_address == self.author {
                     self.is_current_epoch_validator = true;
@@ -1814,25 +1829,26 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             return
         }
 
+        let network_id = fullnode_side_network_id(self.node_type);
         let peers = self
             .network_sender
             .network_client
             .get_available_peers()
             .expect("failed to get available peers");
         // TODO(nekomoto): Check if this peer self is in available peers
-        let vfn_peers = peers
+        let candidate_peers = peers
             .iter()
-            .filter(|peer| peer.network_id() == NetworkId::Vfn)
+            .filter(|peer| peer.network_id() == network_id)
             .map(|peer| peer.peer_id())
             .collect::<Vec<_>>();
-        if vfn_peers.is_empty() {
+        if candidate_peers.is_empty() {
             sample!(
                 SampleRate::Duration(Duration::from_secs(5)),
-                warn!("No vfn peers available");
+                warn!("No {network_id:?} peers available for sync info");
             );
             return;
         }
-        let peer = vfn_peers[thread_rng().gen_range(0, vfn_peers.len())];
+        let peer = candidate_peers[thread_rng().gen_range(0, candidate_peers.len())];
 
         let mut sync_info_tx = self.sync_info_tx.clone();
         let client = self.network_sender.network_client.clone();
@@ -1842,7 +1858,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 .send_to_peer_rpc(
                     ConsensusMsg::SyncInfoRequest,
                     Duration::from_secs(5),
-                    PeerNetworkId::new(NetworkId::Vfn, peer),
+                    PeerNetworkId::new(network_id, peer),
                 )
                 .await;
             match result {

--- a/aptos-core/consensus/src/round_manager.rs
+++ b/aptos-core/consensus/src/round_manager.rs
@@ -250,6 +250,10 @@ pub struct RoundManager {
     futures: FuturesUnordered<Pin<Box<dyn Future<Output = (anyhow::Result<()>, Block)> + Send>>>,
     wait_change_epoch_flag: bool,
     validator_components: Option<ValidatorComponents>,
+    /// Network used by `create_block_retriever` when this node is not a current-epoch
+    /// validator (sync-path BlockRetrieval). Pre-computed by `EpochManager` from the
+    /// node's static `NodeType`; `RoundManager` stays `NodeType`-agnostic.
+    non_validator_network_id: NetworkId,
 }
 
 pub(crate) struct ValidatorComponents {
@@ -283,6 +287,7 @@ impl RoundManager {
         jwk_consensus_config: OnChainJWKConsensusConfig,
         fast_rand_config: Option<RandConfig>,
         validator_components: Option<ValidatorComponents>,
+        non_validator_network_id: NetworkId,
     ) -> Self {
         // when decoupled execution is false,
         // the counter is still static.
@@ -310,6 +315,7 @@ impl RoundManager {
             futures: FuturesUnordered::new(),
             wait_change_epoch_flag: false,
             validator_components,
+            non_validator_network_id,
         }
     }
 
@@ -329,6 +335,7 @@ impl RoundManager {
                     .collect(),
             )
         } else {
+            let network_id = self.non_validator_network_id;
             let available_peers = self
                 .network
                 .consensus_network_client
@@ -337,7 +344,7 @@ impl RoundManager {
                 .map(|peers| {
                     peers
                         .iter()
-                        .filter(|peer| peer.network_id() == NetworkId::Vfn)
+                        .filter(|peer| peer.network_id() == network_id)
                         .map(|peer| peer.peer_id())
                         .collect::<Vec<_>>()
                 })
@@ -345,7 +352,7 @@ impl RoundManager {
                     error!("Failed to get available peers: {:?}", e);
                     vec![]
                 });
-            (NetworkId::Vfn, available_peers)
+            (network_id, available_peers)
         };
         BlockRetriever::new(
             network_id,

--- a/aptos-core/consensus/src/round_manager_fuzzing.rs
+++ b/aptos-core/consensus/src/round_manager_fuzzing.rs
@@ -233,6 +233,7 @@ fn create_node_for_fuzzing() -> RoundManager {
             Arc::new(proposal_generator),
             Arc::new(Mutex::new(MetricsSafetyRules::new(Box::new(safety_rules), storage.clone()))),
         )),
+        NetworkId::Vfn,
     )
 }
 

--- a/aptos-core/consensus/src/round_manager_test.rs
+++ b/aptos-core/consensus/src/round_manager_test.rs
@@ -352,6 +352,7 @@ impl NodeSetup {
             onchain_jwk_consensus_config.clone(),
             None,
             Some(validator_components),
+            NetworkId::Vfn,
         );
         block_on(round_manager.init(last_vote_sent));
         Self {

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -257,6 +257,118 @@ STOP_SCRIPT
     chmod +x "$data_dir/script/stop.sh"
 }
 
+# Configure PFN (public-fullnode) function
+configure_pfn() {
+    local node_id="$1"
+    local data_dir="$2"
+    local genesis_path="$3"
+    local binary_path="$4"
+    local identity_src="$5"
+    local waypoint_src="$6"
+
+    local config_dir="$data_dir/config"
+
+    log_info "  [$node_id] [pfn] configuring..."
+
+    mkdir -p "$config_dir"
+    cp "$identity_src" "$config_dir/identity.yaml"
+    cp "$waypoint_src" "$config_dir/waypoint.txt"
+
+    export NODE_ID="$node_id"
+    export DATA_DIR="$data_dir"
+    export CONFIG_DIR="$config_dir"
+    export GENESIS_PATH="$genesis_path"
+    export BINARY_PATH="$binary_path"
+
+    # PFN listens on Public network at P2P_PORT (no Vfn network at all).
+    envsubst < "$SCRIPT_DIR/templates/public_full_node.yaml.tpl" > "$config_dir/public_full_node.yaml"
+
+    local reth_tpl="${RETH_CONFIG_PFN_TPL:-$SCRIPT_DIR/templates/reth_config_pfn.json.tpl}"
+    if [ ! -f "$reth_tpl" ]; then
+        log_error "reth pfn config template not found: $reth_tpl"
+        exit 1
+    fi
+    envsubst < "$reth_tpl" > "$config_dir/reth_config.json"
+    log_info "  Using reth pfn config: $reth_tpl"
+
+    if [ "$WS_PORT" != "null" ]; then
+        local tmp="$config_dir/reth_config.json.tmp"
+        jq --argjson port "$WS_PORT" \
+           --arg origins "$RPC_WS_ORIGINS" \
+           --arg api "$RPC_WS_API" \
+           '.reth_args += {"ws":"", "ws.port":$port, "ws.addr":"0.0.0.0", "ws.origins":$origins, "ws.api":$api}' \
+           "$config_dir/reth_config.json" > "$tmp" && mv "$tmp" "$config_dir/reth_config.json"
+    fi
+
+    cat > "$data_dir/script/start.sh" << 'START_SCRIPT'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="$SCRIPT_DIR/.."
+
+if [ -e "${WORKSPACE}/script/node.pid" ]; then
+    pid=$(cat "${WORKSPACE}/script/node.pid")
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "Node is already running with PID $pid"
+        exit 1
+    fi
+fi
+
+reth_config="${WORKSPACE}/config/reth_config.json"
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: 'jq' is required but not installed."
+    exit 1
+fi
+
+reth_args_array=()
+while IFS= read -r key && IFS= read -r value; do
+    if [ -z "$value" ] || [ "$value" == "null" ]; then
+        reth_args_array+=( "--${key}" )
+    else
+        reth_args_array+=( "--${key}=${value}" )
+    fi
+done < <(jq -r '.reth_args | to_entries[] | .key, .value' "$reth_config")
+
+env_vars_array=()
+while IFS= read -r key && IFS= read -r value; do
+    if [ -n "$value" ] && [ "$value" != "null" ]; then
+        env_vars_array+=( "${key}=${value}" )
+    fi
+done < <(jq -r '.env_vars | to_entries[] | .key, .value' "$reth_config")
+
+export RUST_BACKTRACE=1
+pid=$(
+    env ${env_vars_array[*]} ${WORKSPACE}/bin/gravity_node node \
+        ${reth_args_array[*]} \
+        > "${WORKSPACE}/logs/debug.log" 2>&1 &
+    echo $!
+)
+echo $pid > "${WORKSPACE}/script/node.pid"
+echo "Started PFN node with PID $pid"
+START_SCRIPT
+    chmod +x "$data_dir/script/start.sh"
+
+    cat > "$data_dir/script/stop.sh" << 'STOP_SCRIPT'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE="$SCRIPT_DIR/.."
+
+if [ -e "${WORKSPACE}/script/node.pid" ]; then
+    pid=$(cat "${WORKSPACE}/script/node.pid")
+    if kill -0 "$pid" 2>/dev/null; then
+        kill "$pid"
+        echo "Stopped node (PID: $pid)"
+    else
+        echo "Node not running (stale PID file)"
+    fi
+    rm -f "${WORKSPACE}/script/node.pid"
+else
+    echo "No PID file found"
+fi
+STOP_SCRIPT
+    chmod +x "$data_dir/script/stop.sh"
+}
+
 # Configure VFN node function
 configure_vfn() {
     local node_id="$1"
@@ -532,13 +644,34 @@ main() {
         export P2P_PORT_RETH=$(echo "$node" | jq -r '.reth_p2p_port')
         
         role=$(echo "$node" | jq -r '.role // empty')
-        
+
         # Validate role is specified
         if [ -z "$role" ]; then
-            log_error "Node $NODE_ID must specify 'role' (genesis, validator, or vfn)"
+            log_error "Node $NODE_ID must specify 'role' (genesis, validator, vfn, or pfn)"
             exit 1
         fi
-        
+
+        # Resolve discovery_method. Per-node override wins; otherwise the
+        # default is role-driven — validator/vfn use onchain, pfn emits nothing
+        # (seed-only). Valid values: onchain | none. Omit to take the default.
+        discovery_method=$(echo "$node" | jq -r '.discovery_method // empty')
+        if [ -z "$discovery_method" ]; then
+            case "$role" in
+                genesis|validator|vfn) discovery_method="onchain" ;;
+                pfn)                   discovery_method="" ;;
+                *)                     discovery_method="" ;;
+            esac
+        fi
+        if [ -n "$discovery_method" ]; then
+            export DISCOVERY_METHOD_NETWORK_BLOCK="  discovery_method:
+    ${discovery_method}"
+            export DISCOVERY_METHOD_FULLNODE_BLOCK="    discovery_method:
+      ${discovery_method}"
+        else
+            export DISCOVERY_METHOD_NETWORK_BLOCK=""
+            export DISCOVERY_METHOD_FULLNODE_BLOCK=""
+        fi
+
         data_dir=$(echo "$node" | jq -r '.data_dir // empty')
         if [ -z "$data_dir" ]; then
             data_dir="$base_dir/$NODE_ID"
@@ -561,7 +694,73 @@ main() {
         
         waypoint_src="$OUTPUT_DIR/waypoint.txt"
         
-        if [ "$role" == "vfn" ]; then
+        if [ "$role" == "pfn" ]; then
+            # Public Full Node. Listens on Public network at P2P_PORT; dials a
+            # VFN/IVFN via a static seed on the Public network (public_seed_of
+            # in cluster.toml). On-chain discovery is enabled but typically
+            # points at a Vfn-network address for the validator's fullnode,
+            # which is wrong net for PFN — seeds are the dependable path.
+            identity_src="$OUTPUT_DIR/$NODE_ID/config/identity.yaml"
+
+            if [ ! -f "$identity_src" ]; then
+                log_error "Identity not found for $NODE_ID at $identity_src"
+                exit 1
+            fi
+
+            if [ "$P2P_PORT" == "null" ]; then
+                log_error "PFN $NODE_ID requires p2p_port (Public listener)"
+                exit 1
+            fi
+
+            public_seed_of=$(echo "$node" | jq -r '.public_seed_of // empty')
+            if [ -n "$public_seed_of" ]; then
+                target_identity="$OUTPUT_DIR/$public_seed_of/config/identity.yaml"
+                if [ ! -f "$target_identity" ]; then
+                    log_error "public_seed_of=$public_seed_of but identity not found at $target_identity"
+                    exit 1
+                fi
+                target_peer_id=$(awk -F': ' '/^account_address:/{gsub(/["\x27]/,"",$2); print $2}' "$target_identity")
+                target_network_pk=$(awk -F': ' '/^network_public_key:/{gsub(/["\x27]/,"",$2); print $2}' "$target_identity")
+                target_peer_id=${target_peer_id#0x}
+                target_network_pk=${target_network_pk#0x}
+                if [ -z "$target_peer_id" ] || [ -z "$target_network_pk" ]; then
+                    log_error "public_seed_of=$public_seed_of: failed to parse peer_id/network_pk from $target_identity"
+                    exit 1
+                fi
+                target_host=$(echo "$config_json" | jq -r --arg id "$public_seed_of" \
+                    '.nodes[] | select(.id == $id) | (.internal_host // .host)')
+                target_public_port=$(echo "$config_json" | jq -r --arg id "$public_seed_of" \
+                    '.nodes[] | select(.id == $id) | .public_port')
+                if [ -z "$target_host" ] || [ "$target_host" = "null" ] || \
+                   [ -z "$target_public_port" ] || [ "$target_public_port" = "null" ]; then
+                    log_error "public_seed_of=$public_seed_of: missing host/public_port in cluster.toml"
+                    exit 1
+                fi
+                target_proto="dns"
+                if [[ "$target_host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    target_proto="ip4"
+                fi
+                # ValidatorFullNode is the role for the upstream peer that serves
+                # this PFN. It lands in `upstream_roles(Public, FullNode)` —
+                # see gravity-aptos/config/src/network_id.rs:176-180.
+                export PFN_SEEDS_BLOCK="    seeds:
+      '0x${target_peer_id}':
+        addresses:
+          - '/${target_proto}/${target_host}/tcp/${target_public_port}/noise-ik/${target_network_pk}/handshake/0'
+        role: ValidatorFullNode"
+                log_info "  [$NODE_ID] public_seed_of=$public_seed_of, seeds -> ${target_host}:${target_public_port} (proto=${target_proto})"
+            else
+                export PFN_SEEDS_BLOCK=""
+            fi
+
+            configure_pfn \
+                "$NODE_ID" \
+                "$data_dir" \
+                "$genesis_path" \
+                "$node_binary" \
+                "$identity_src" \
+                "$waypoint_src"
+        elif [ "$role" == "vfn" ]; then
             # VFN node
             identity_src="$OUTPUT_DIR/$NODE_ID/config/identity.yaml"
 
@@ -609,6 +808,26 @@ main() {
                 log_info "  [$NODE_ID] shadow_of=$shadow_of, seeds -> ${target_host}:${target_vfn_port} (proto=${target_proto})"
             else
                 export VFN_SEEDS_BLOCK=""
+            fi
+
+            # Optional: second full_node_networks entry on Public so PFN peers
+            # can dial this VFN. Only emitted when cluster.toml sets public_port.
+            public_port=$(echo "$node" | jq -r '.public_port // empty')
+            if [ -n "$public_port" ] && [ "$public_port" != "null" ]; then
+                # Public listener is seed-accept-only: no on-chain discovery
+                # (fullnode_address encodes the Vfn listener, not this Public
+                # port) and no outbound dialing. PFNs reach us via their own
+                # static seeds pointing here.
+                export PUBLIC_NETWORK_BLOCK="  - network_id: public
+    listen_address: \"/ip4/0.0.0.0/tcp/${public_port}\"
+    identity:
+      type: \"from_file\"
+      path: ${data_dir}/config/identity.yaml
+    discovery_method:
+      none"
+                log_info "  [$NODE_ID] Public listener enabled on port ${public_port}"
+            else
+                export PUBLIC_NETWORK_BLOCK=""
             fi
 
             configure_vfn \

--- a/cluster/templates/public_full_node.yaml.tpl
+++ b/cluster/templates/public_full_node.yaml.tpl
@@ -1,5 +1,5 @@
 base:
-  role: "validator"
+  role: "full_node"
   data_dir: "${DATA_DIR}/data"
   waypoint:
     from_file: "${CONFIG_DIR}/waypoint.txt"
@@ -34,29 +34,19 @@ consensus:
       backlog_txn_limit_count: 50000
       backlog_per_validator_batch_limit_count: 2000
 
-validator_network:
-  network_id: validator
-  listen_address: "/ip4/0.0.0.0/tcp/${P2P_PORT}"
-${DISCOVERY_METHOD_NETWORK_BLOCK}
-  mutual_authentication: true
-  identity:
-    type: "from_file"
-    path: ${CONFIG_DIR}/identity.yaml
-
 full_node_networks:
-  - network_id:
-      private: "vfn"
-    listen_address: "/ip4/0.0.0.0/tcp/${VFN_PORT}"
+  - network_id: public
+    listen_address: "/ip4/0.0.0.0/tcp/${P2P_PORT}"
     identity:
       type: "from_file"
       path: ${CONFIG_DIR}/identity.yaml
 ${DISCOVERY_METHOD_FULLNODE_BLOCK}
-    mutual_authentication: false
+${PFN_SEEDS_BLOCK}
 
 storage:
   dir: "${DATA_DIR}/data"
 
-log_file_path: "${DATA_DIR}/consensus_log/validator.log"
+log_file_path: "${DATA_DIR}/consensus_log/vfn.log"
 
 inspection_service:
   port: ${INSPECTION_PORT}
@@ -65,4 +55,5 @@ inspection_service:
 mempool:
   capacity_per_user: 20000
 
-https_server_address: 0.0.0.0:${HTTPS_PORT}
+logger:
+  level: INFO

--- a/cluster/templates/reth_config_pfn.json.tpl
+++ b/cluster/templates/reth_config_pfn.json.tpl
@@ -1,0 +1,35 @@
+{
+    "reth_args": {
+        "chain": "${GENESIS_PATH}",
+        "http": "",
+        "http.port": ${RPC_PORT},
+        "http.corsdomain": "${RPC_HTTP_CORSDOMAIN}",
+        "http.api": "${RPC_HTTP_API}",
+        "http.addr": "0.0.0.0",
+        "dev": "",
+        "port": ${P2P_PORT_RETH},
+        "authrpc.port": ${AUTHRPC_PORT},
+        "authrpc.addr": "0.0.0.0",
+        "metrics": "0.0.0.0:${METRICS_PORT}",
+        "log.file.filter": "info",
+        "log.stdout.filter": "error",
+        "datadir": "${DATA_DIR}/data/reth",
+        "datadir.static-files": "${DATA_DIR}/data/reth",
+        "gravity_node_config": "${CONFIG_DIR}/public_full_node.yaml",
+        "log.file.directory": "${DATA_DIR}/execution_logs/",
+        "rpc.max-subscriptions-per-connection": 20000,
+        "rpc.max-connections": 20000,
+        "txpool.max-new-pending-txs-notifications": 1000000,
+        "txpool.max-pending-txns": 1000000,
+        "txpool.pending-max-count": 17592186044415,
+        "txpool.pending-max-size": 17592186044415,
+        "txpool.basefee-max-count": 17592186044415,
+        "txpool.basefee-max-size": 17592186044415,
+        "txpool.queued-max-count": 17592186044415,
+        "txpool.queued-max-size": 17592186044415,
+        "ipcdisable": ""
+    },
+    "env_vars": {
+        "BATCH_INSERT_TIME": 20
+    }
+}

--- a/cluster/templates/validator_full_node.yaml.tpl
+++ b/cluster/templates/validator_full_node.yaml.tpl
@@ -41,9 +41,9 @@ full_node_networks:
     identity:
       type: "from_file"
       path: ${CONFIG_DIR}/identity.yaml
-    discovery_method:
-      onchain
+${DISCOVERY_METHOD_FULLNODE_BLOCK}
 ${VFN_SEEDS_BLOCK}
+${PUBLIC_NETWORK_BLOCK}
 
 storage:
   dir: "${DATA_DIR}/data"

--- a/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/cluster.toml
@@ -1,0 +1,69 @@
+# Gravity Cluster Configuration - PFN + VFN-shadow topology
+# 1 validator (node1) + 1 VFN-alpha (shadow of node1, Vfn + Public listeners)
+# + 1 PFN (dials vfn-alpha via Public seed).
+#
+# Verifies the C1-C4 epoch_manager PFN changes: SyncInfoRequest / BlockRetrieval
+# from a PublicFullnode now use NetworkId::Public (previously hard-coded Vfn).
+# See _local/drafts/pfn/epoch-manager-pfn-role.md.
+#
+# NOTE on node ordering: start.sh launches nodes in the order they appear
+# here. Same reasoning as vfn_shadow — vfn-alpha boots first so it starts
+# from genesis, then node1 joins, then pfn-client catches up via Public seed.
+
+[cluster]
+name = "gravity-devnet-pfn-vfn-shadow"
+base_dir = "/tmp/gravity-cluster-pfn-vfn-shadow"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "vfn-alpha"
+role = "vfn"
+shadow_of = "node1"             # Vfn seeds -> node1's Vfn listener (6192)
+public_port = 6195              # extra Public listener so pfn-client can dial
+# Skip on-chain discovery: as node1's registered fullnode_address encodes
+# vfn-alpha's own identity, on-chain discovery would produce a self-dial
+# that Noise rejects (handshake.rs:346). Seeds already reach the upstream.
+discovery_method = "none"
+source = { project_path = "../" }
+host = "127.0.0.1"
+p2p_port = 6183
+vfn_port = 6193
+rpc_port = 18546
+metrics_port = 9004
+inspection_port = 10003
+https_port = 1025
+authrpc_port = 8554
+reth_p2p_port = 12027
+
+[[nodes]]
+id = "pfn-client"
+role = "pfn"
+public_seed_of = "vfn-alpha"    # PFN dials vfn-alpha's public_port (6195)
+source = { project_path = "../" }
+host = "127.0.0.1"
+p2p_port = 6196                 # Public listener
+rpc_port = 18547
+metrics_port = 9005
+inspection_port = 10004
+authrpc_port = 8555
+reth_p2p_port = 12028
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+p2p_port = 6182
+vfn_port = 6192
+rpc_port = 18545
+metrics_port = 9003
+inspection_port = 10002
+https_port = 1024
+authrpc_port = 8553
+reth_p2p_port = 12026
+
+[faucet_init]
+num_accounts = 10000

--- a/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/genesis.toml
@@ -1,0 +1,85 @@
+# Gravity Genesis Configuration - PFN + VFN-shadow topology
+# node1 registers vfn-alpha as its on-chain fullnode_address.
+# Identical to vfn_shadow/genesis.toml — the PFN-specific differences live
+# purely in cluster.toml.
+
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "main"
+
+[[genesis_validators]]
+id = "node1"
+address = "0xAEd2a948892475F800A337427B3275D190EA3e94"
+host = "127.0.0.1"
+p2p_port = 6182
+vfn_port = 6192                         # ignored when shadow_fullnode is set
+shadow_fullnode = "vfn-alpha"           # on-chain fullnode_address -> vfn-alpha:6193
+stake_amount = "10000000000000000000"
+voting_power = "10000000000000000000"
+
+[[shadow_nodes]]
+id = "vfn-alpha"
+host = "127.0.0.1"
+vfn_port = 6193
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 60000000 # 60 second
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "10000000000000000000"
+voting_duration_micros = 604800000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
+
+[genesis.oracle_config.bridge_config]
+deploy = true
+trusted_bridge = "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
+trusted_source_id = 11155111
+
+[[genesis.oracle_config.tasks]]
+source_type = 0
+source_id = 11155111
+task_name = "sepolia"
+config = "gravity://0/11155111/events?contract=0x0f761B1B3c1aC9232C9015A7276692560aD6a05F&eventSignature=0x5646e682c7d994bf11f5a2c8addb60d03c83cda3b65025a826346589df43406e&fromBlock=10201260"
+
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/test_pfn_vfn_shadow.py
+++ b/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/test_pfn_vfn_shadow.py
@@ -1,0 +1,296 @@
+"""
+PFN + VFN-shadow Topology Test
+
+Tests that a PublicFullnode (PFN) can sync consensus state through a shadow
+VFN. Exercises the C1-C4 changes in `_local/drafts/pfn/epoch-manager-pfn-role.md`:
+non-validator sync paths (SyncInfoRequest / BlockRetrieval) now resolve the
+network via `fullnode_side_network_id(node_type)` instead of hard-coded
+`NetworkId::Vfn`, so a PFN sends them on its Public network and talks to
+vfn-alpha on Public port 6195.
+
+Topology:
+- node1: validator (on-chain fullnode_address -> vfn-alpha:vfn_port)
+- vfn-alpha: VFN shadow of node1; listens on Vfn (6193, to node1) + Public (6195, for PFN)
+- pfn-client: PFN; Public network only, static seed pointing at vfn-alpha:6195
+
+Flow:
+1. Bring the cluster live.
+2. Background TxSender against node1 keeps the chain producing blocks.
+3. Periodically sample block heights on all three nodes; pfn-client must
+   strictly advance and stay within MAX_HEIGHT_GAP of the validator.
+4. Stop pfn-client mid-flight, let the chain advance, restart it; it must
+   catch up through vfn-alpha's Public listener.
+5. Log assertions on pfn-client: sync_info traffic flowed over Public
+   (indirect evidence — pfn-client never reports "No Public peers available").
+
+If request_sync_info / BlockRetrieval had still been hard-coded to Vfn, the
+PFN log would fill with "No Vfn peers available" and heights would never
+advance. Block progression is the primary assertion.
+"""
+
+import asyncio
+import logging
+import math
+import pathlib
+import statistics
+import time
+
+import pytest
+from eth_account import Account
+from web3 import Web3
+
+from gravity_e2e.cluster.manager import Cluster
+from gravity_e2e.cluster.node import Node
+
+LOG = logging.getLogger(__name__)
+
+MAX_HEIGHT_GAP = 50
+MONITOR_DURATION = 120           # seconds
+MONITOR_INTERVAL = 10            # seconds between height samples
+TX_INTERVAL = 0.2                # seconds between txs
+TX_RECEIPT_TIMEOUT = 30.0
+
+
+class TxSender:
+    """Continuously send txs to a target node; track submit/confirm stats."""
+
+    def __init__(self, cluster: Cluster, faucet, target_node_id: str):
+        self.cluster = cluster
+        self.faucet = faucet
+        self.target_node_id = target_node_id
+        self.recipient = Account.create().address
+
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+        self.total_sent = 0
+        self.total_confirmed = 0
+        self.total_failed = 0
+        self.total_timeout = 0
+        self.latencies: list[float] = []
+
+    @property
+    def _w3(self) -> Web3:
+        return self.cluster.get_node(self.target_node_id).w3
+
+    async def _send_loop(self):
+        w3 = self._w3
+        chain_id = await asyncio.to_thread(lambda: w3.eth.chain_id)
+        gas_price = Web3.to_wei("2", "gwei")
+        nonce = await asyncio.to_thread(
+            lambda: w3.eth.get_transaction_count(self.faucet.address, "pending")
+        )
+        LOG.info(
+            f"TxSender started: target={self.target_node_id}, nonce={nonce}, "
+            f"recipient={self.recipient}"
+        )
+
+        while not self._stop_event.is_set():
+            w3 = self._w3
+            tx = {
+                "nonce": nonce,
+                "to": self.recipient,
+                "value": 0,
+                "gas": 21000,
+                "gasPrice": gas_price,
+                "chainId": chain_id,
+            }
+            try:
+                signed = w3.eth.account.sign_transaction(tx, self.faucet.key)
+                send_time = time.monotonic()
+                tx_hash = await asyncio.to_thread(
+                    lambda: w3.eth.send_raw_transaction(signed.raw_transaction)
+                )
+                self.total_sent += 1
+                nonce += 1
+
+                confirmed = False
+                while time.monotonic() - send_time < TX_RECEIPT_TIMEOUT:
+                    try:
+                        receipt = await asyncio.to_thread(
+                            lambda: w3.eth.get_transaction_receipt(tx_hash)
+                        )
+                        if receipt:
+                            self.latencies.append(time.monotonic() - send_time)
+                            self.total_confirmed += 1
+                            confirmed = True
+                            break
+                    except Exception:
+                        pass
+                    await asyncio.sleep(0.1)
+
+                if not confirmed:
+                    self.total_timeout += 1
+                    try:
+                        nonce = await asyncio.to_thread(
+                            lambda: self._w3.eth.get_transaction_count(
+                                self.faucet.address, "pending"
+                            )
+                        )
+                    except Exception:
+                        pass
+
+            except Exception as e:
+                self.total_failed += 1
+                LOG.warning(f"TxSender send failed ({self.target_node_id}): {e}")
+                await asyncio.sleep(1)
+                try:
+                    nonce = await asyncio.to_thread(
+                        lambda: self._w3.eth.get_transaction_count(
+                            self.faucet.address, "pending"
+                        )
+                    )
+                except Exception:
+                    pass
+                continue
+
+            await asyncio.sleep(TX_INTERVAL)
+
+    def start(self):
+        self._task = asyncio.create_task(self._send_loop())
+
+    async def stop(self):
+        self._stop_event.set()
+        if self._task:
+            await self._task
+
+    def log_stats(self):
+        LOG.info("=" * 60)
+        LOG.info("TRANSACTION STATISTICS")
+        LOG.info("=" * 60)
+        LOG.info(f"Total Sent:    {self.total_sent}")
+        LOG.info(f"Confirmed:     {self.total_confirmed}")
+        LOG.info(f"Failed (send): {self.total_failed}")
+        LOG.info(f"Timed Out:     {self.total_timeout}")
+        if self.total_sent > 0:
+            LOG.info(
+                f"Success Rate:  {self.total_confirmed / self.total_sent * 100:.1f}%"
+            )
+        if self.latencies:
+            sl = sorted(self.latencies)
+
+            def pct(p):
+                k = (len(sl) - 1) * (p / 100.0)
+                f, c = math.floor(k), math.ceil(k)
+                return sl[int(k)] if f == c else sl[f] + (sl[c] - sl[f]) * (k - f)
+
+            LOG.info(f"Latency p50/p90/p99: {pct(50):.3f}s / {pct(90):.3f}s / {pct(99):.3f}s")
+            LOG.info(f"Latency min/max/avg: {sl[0]:.3f}s / {sl[-1]:.3f}s / {statistics.mean(sl):.3f}s")
+        LOG.info("=" * 60)
+
+
+async def _get_block_heights(nodes: list[Node]) -> dict[str, int]:
+    async def _h(n: Node):
+        return n.id, await asyncio.to_thread(lambda: n.w3.eth.block_number)
+
+    return dict(await asyncio.gather(*[_h(n) for n in nodes]))
+
+
+def _node_log_text(node: Node) -> str:
+    """Read consensus log (vfn.log for VFN/PFN, validator.log for validator)."""
+    base = pathlib.Path(node._infra_path) / "consensus_log"
+    for name in ("vfn.log", "validator.log"):
+        p = base / name
+        if p.exists():
+            return p.read_text(errors="replace")
+    return ""
+
+
+@pytest.mark.asyncio
+async def test_pfn_vfn_shadow_topology(cluster: Cluster):
+    """PFN sync through a shadow VFN — verifies C1-C4 PFN-role changes."""
+    LOG.info("=" * 70)
+    LOG.info("Test: PFN + VFN-shadow (1 validator + 1 vfn-alpha + 1 pfn-client)")
+    LOG.info("=" * 70)
+
+    assert await cluster.set_full_live(timeout=120), "Cluster failed to become live"
+
+    node_ids = ("node1", "vfn-alpha", "pfn-client")
+    nodes = [cluster.get_node(nid) for nid in node_ids]
+    for nid, node in zip(node_ids, nodes):
+        assert node is not None, f"{nid} missing from cluster"
+
+    assert await cluster.check_block_increasing(timeout=30), "Blocks not advancing"
+
+    # Drive the chain from the validator side — pfn-client is purely a sync sink.
+    tx_sender = TxSender(cluster, cluster.faucet, target_node_id="node1")
+    tx_sender.start()
+    LOG.info("TxSender started against node1")
+
+    try:
+        initial = await _get_block_heights(nodes)
+        LOG.info(f"initial heights: {initial}")
+
+        monitor_start = time.monotonic()
+        check_count = 0
+        last_heights = dict(initial)
+
+        while time.monotonic() - monitor_start < MONITOR_DURATION:
+            await asyncio.sleep(MONITOR_INTERVAL)
+            check_count += 1
+
+            last_heights = await _get_block_heights(nodes)
+            max_h = max(last_heights.values())
+            min_h = min(last_heights.values())
+            gap = max_h - min_h
+            elapsed = int(time.monotonic() - monitor_start)
+            LOG.info(
+                f"[check #{check_count} @ {elapsed}s] heights={last_heights} gap={gap}"
+            )
+
+            assert gap < MAX_HEIGHT_GAP, (
+                f"pairwise height gap {gap} >= {MAX_HEIGHT_GAP}: {last_heights}"
+            )
+
+        for nid in node_ids:
+            assert last_heights[nid] > initial[nid], (
+                f"{nid} did not advance: initial={initial[nid]} last={last_heights[nid]}"
+            )
+
+        # Stop/restart pfn-client — must catch back up through vfn-alpha's
+        # Public listener. The C3/C4 path is what makes this work.
+        client = cluster.get_node("pfn-client")
+        LOG.info("Stopping pfn-client to force sync-from-scratch via vfn-alpha…")
+        assert await client.stop(), "pfn-client failed to stop"
+
+        await asyncio.sleep(30)
+
+        LOG.info("Restarting pfn-client…")
+        assert await client.start(), "pfn-client failed to restart"
+
+        catchup_deadline = time.monotonic() + 120
+        while time.monotonic() < catchup_deadline:
+            await asyncio.sleep(MONITOR_INTERVAL)
+            heights = await _get_block_heights(nodes)
+            gap = max(heights.values()) - min(heights.values())
+            LOG.info(f"[post-restart] heights={heights} gap={gap}")
+            if gap < MAX_HEIGHT_GAP:
+                break
+
+        heights = await _get_block_heights(nodes)
+        gap = max(heights.values()) - min(heights.values())
+        assert gap < MAX_HEIGHT_GAP, (
+            f"pfn-client failed to catch up via vfn-alpha: {heights} gap={gap}"
+        )
+    finally:
+        await tx_sender.stop()
+        tx_sender.log_stats()
+
+    assert tx_sender.total_confirmed > 0, (
+        f"TxSender confirmed 0 txns; cluster fundamentally broken. "
+        f"sent={tx_sender.total_sent} timeout={tx_sender.total_timeout} "
+        f"failed={tx_sender.total_failed}"
+    )
+
+    # Log-level sanity checks on pfn-client: if request_sync_info had still been
+    # hard-coded to Vfn, the PFN log would be full of "No Vfn peers available"
+    # warnings. With C3 applied it now reads "No Public peers available" only
+    # when the upstream is genuinely down — and since we've been advancing
+    # blocks, it should not be saturated with such warnings.
+    client_text = _node_log_text(cluster.get_node("pfn-client"))
+    assert "No Vfn peers available" not in client_text, (
+        "pfn-client emitted 'No Vfn peers available' — request_sync_info still "
+        "routing on Vfn instead of Public. C3 regression."
+    )
+
+    LOG.info("✅ PFN + VFN-shadow topology test PASSED")

--- a/gravity_e2e/cluster_test_cases/vfn_shadow/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/vfn_shadow/cluster.toml
@@ -21,6 +21,11 @@ waypoint_path = "./artifacts/waypoint.txt"
 id = "vfn-alpha"
 role = "vfn"
 shadow_of = "node1"             # deploy.sh renders seeds block pointing at node1's vfn server
+# On-chain discovery would produce (peer_id=node1.account_address, addr=vfn-alpha's own endpoint)
+# because node1's fullnode_address is registered with vfn-alpha's identity. The resulting dial
+# aims at 127.0.0.1:vfn_port — vfn-alpha itself — and only gets rejected at the Noise self-dial
+# guard (handshake.rs:346). Skip the pointless round-trip: seeds already cover the upstream.
+discovery_method = "none"
 source = { project_path = "../" }
 host = "127.0.0.1"
 p2p_port = 6183

--- a/gravity_e2e/gravity_e2e/cluster/node.py
+++ b/gravity_e2e/gravity_e2e/cluster/node.py
@@ -35,6 +35,7 @@ class NodeRole(Enum):
     # Validator node but NOT in initial genesis (can join later)
     VALIDATOR = "validator"
     VFN = "vfn"  # Full node, uses onchain discovery
+    PFN = "pfn"  # Public full node, Public-network-only, dials VFN via seeds
 
     @classmethod
     def from_str(cls, value: str) -> "NodeRole":


### PR DESCRIPTION
## Summary

- Make consensus non-validator sync paths NodeType-aware so PublicFullnode (PFN) works.
- Add PFN role support to cluster deploy tooling + new `pfn_vfn_shadow` e2e.

## Context

`EpochManager` was hard-coding `NetworkId::Vfn` in three non-validator sync paths:

1. `init_payload_provider` (QuorumStore `PeerNetworkId`)
2. `request_sync_info`
3. `RoundManager::create_block_retriever`

This worked for VFN because "non-validator" == "VFN" by implicit assumption. A PFN has no Vfn network instance, so `get_available_peers().filter(Vfn)` returns empty and block sync silently stalls.

## Changes

**Consensus (`aptos-core/consensus`)**

- `EpochManager`: `is_validator: bool` → `node_type: NodeType`. Add local `fullnode_side_network_id()` helper (`Validator`/`ValidatorFullnode` → `Vfn`, `PublicFullnode` → `Public`).
- `RoundManager` takes a `non_validator_network_id: NetworkId` ctor param so it stays NodeType-agnostic; `EpochManager` pre-computes it.
- `is_current_epoch_validator` is untouched — epoch-level flag, orthogonal to static NodeType.

**Cluster (`cluster/`)**

- `deploy.sh`: new `role = \"pfn\"` branch + `configure_pfn()`. Honor per-node `discovery_method` (defaults: validator/vfn → `onchain`, pfn → `none`). Honor `public_port` on VFN nodes to emit an additive Public listener (seed-accept-only) for PFN peers.
- New templates `public_full_node.yaml.tpl` + `reth_config_pfn.json.tpl`.
- Existing templates read `discovery_method` from template variables instead of hard-coding.

**E2E (`gravity_e2e/`)**

- New `cluster_test_cases/pfn_vfn_shadow`: 1 validator + 1 shadow VFN (dual Vfn+Public listeners) + 1 PFN via Public seed. Asserts PFN tracks validator within `MAX_HEIGHT_GAP`, catches up after a mid-flight stop/restart, and never emits `No Vfn peers available` (pre-refactor failure signal).
- `NodeRole` enum gains `PFN`.
- `vfn_shadow/cluster.toml` — vfn-alpha now explicitly sets `discovery_method = \"none\"`. As node1's on-chain `fullnode_address` encodes vfn-alpha's identity, on-chain discovery on vfn-alpha produced a self-dial (silently caught at `handshake.rs:346`, no functional effect). Now seeds-only, no wasted handshake.

## Test plan

- [x] `RUSTFLAGS=\"--cfg tokio_unstable\" cargo check -p aptos-consensus --tests`
- [x] `RUSTFLAGS=\"--cfg tokio_unstable\" cargo build -p gravity_node --profile quick-release`
- [x] `python3 gravity_e2e/runner.py pfn_vfn_shadow --force-init` (passes: PFN advanced 198 → 696 blocks alongside validator with gap ≤ 19; caught up from 752 → 918 after 30s downtime; 100% tx confirm rate).
- [x] `python3 gravity_e2e/runner.py vfn_shadow --force-init` (regression — still passes).