### PR TITLE
fix(e2e): unblock CI broken by 50 Gwei min base fee + LOG_DIR default

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -367,7 +367,7 @@ configure_node() {
     export NODE_ID="$node_id"
     export DATA_DIR="$data_dir"
     export STORAGE_DIR="${node_storage_dir:-$data_dir/data}"
-    export LOG_DIR="${node_log_dir:-$STORAGE_DIR}"
+    export LOG_DIR="${node_log_dir:-$data_dir}"
     export CONFIG_DIR="$config_dir"
     export GENESIS_PATH="$genesis_path"
     export BINARY_PATH="$binary_path"
@@ -485,7 +485,7 @@ configure_pfn() {
     export NODE_ID="$node_id"
     export DATA_DIR="$data_dir"
     export STORAGE_DIR="${node_storage_dir:-$data_dir/data}"
-    export LOG_DIR="${node_log_dir:-$STORAGE_DIR}"
+    export LOG_DIR="${node_log_dir:-$data_dir}"
     export CONFIG_DIR="$config_dir"
     export GENESIS_PATH="$genesis_path"
     export BINARY_PATH="$binary_path"
@@ -604,7 +604,7 @@ configure_vfn() {
     export NODE_ID="$node_id"
     export DATA_DIR="$data_dir"
     export STORAGE_DIR="${node_storage_dir:-$data_dir/data}"
-    export LOG_DIR="${node_log_dir:-$STORAGE_DIR}"
+    export LOG_DIR="${node_log_dir:-$data_dir}"
     export CONFIG_DIR="$config_dir"
     export GENESIS_PATH="$genesis_path"
     export BINARY_PATH="$binary_path"
@@ -976,7 +976,7 @@ main() {
 
         # Prepare dirs
         local storage_dir="${node_storage_dir:-$data_dir/data}"
-        local log_dir="${node_log_dir:-$storage_dir}"
+        local log_dir="${node_log_dir:-$data_dir}"
         mkdir -p "$data_dir"/{bin,config,logs,script}
         mkdir -p "$storage_dir"
         mkdir -p "$log_dir"/{execution_logs,consensus_log}

--- a/gravity_e2e/cluster_test_cases/four_validator/test_latency.py
+++ b/gravity_e2e/cluster_test_cases/four_validator/test_latency.py
@@ -54,7 +54,7 @@ async def measure_latencies(w3, account, num_txs: int, interval: float, recipien
     """
     latencies = []
     chain_id = w3.eth.chain_id
-    gas_price = w3.to_wei('2', 'gwei')
+    gas_price = w3.to_wei('100', 'gwei')
     
     LOG.info(f"Measuring latency for {num_txs} transactions...")
     start_batch = time.time()

--- a/gravity_e2e/cluster_test_cases/four_validator/test_single_address_stress.py
+++ b/gravity_e2e/cluster_test_cases/four_validator/test_single_address_stress.py
@@ -37,7 +37,7 @@ MIN_SUCCESS_RATE = 0.80        # Minimum acceptable confirmation rate (80%)
 STABILIZE_WAIT_SEC = 10        # Seconds to wait for cluster stabilization
 VALUE_PER_TX = 0               # Wei per transaction (0 = gas-only stress)
 GAS_LIMIT = 21000              # Simple transfer gas
-GAS_PRICE_GWEI = 2             # Gas price in gwei
+GAS_PRICE_GWEI = 100           # Gas price in gwei (must be ≥ 50 to clear Gravity's protocol min base fee)
 
 
 # =====================================================================

--- a/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/test_pfn_vfn_shadow.py
+++ b/gravity_e2e/cluster_test_cases/pfn_vfn_shadow/test_pfn_vfn_shadow.py
@@ -76,7 +76,7 @@ class TxSender:
     async def _send_loop(self):
         w3 = self._w3
         chain_id = await asyncio.to_thread(lambda: w3.eth.chain_id)
-        gas_price = Web3.to_wei("2", "gwei")
+        gas_price = Web3.to_wei("100", "gwei")
         nonce = await asyncio.to_thread(
             lambda: w3.eth.get_transaction_count(self.faucet.address, "pending")
         )

--- a/gravity_e2e/cluster_test_cases/rolling_upgrade/test_rolling_upgrade.py
+++ b/gravity_e2e/cluster_test_cases/rolling_upgrade/test_rolling_upgrade.py
@@ -116,7 +116,7 @@ class TxSender:
     async def _send_loop(self):
         """Main send loop running in background."""
         chain_id = await asyncio.to_thread(lambda: self._current_w3.eth.chain_id)
-        gas_price = Web3.to_wei("2", "gwei")
+        gas_price = Web3.to_wei("100", "gwei")
         nonce = await asyncio.to_thread(
             lambda: self._current_w3.eth.get_transaction_count(
                 self.faucet.address, "pending"

--- a/gravity_e2e/cluster_test_cases/single_node/staking/test_gas_distribution.py
+++ b/gravity_e2e/cluster_test_cases/single_node/staking/test_gas_distribution.py
@@ -288,7 +288,7 @@ async def test_withdraw_rewards_to_account(cluster: Cluster):
     withdraw_result = await staker_tb.build_and_send_tx(
         to=coinbase,
         data=pool.encode_abi("withdrawRewards", [recipient.address]),
-        options=TransactionOptions(gas_limit=200_000, max_priority_fee_per_gas=0, max_fee_per_gas=10**10),
+        options=TransactionOptions(gas_limit=200_000, max_priority_fee_per_gas=0, max_fee_per_gas=10**11),
     )
     assert withdraw_result.success, f"withdrawRewards failed: {withdraw_result.error}"
 

--- a/gravity_e2e/cluster_test_cases/vfn_shadow/test_vfn_shadow.py
+++ b/gravity_e2e/cluster_test_cases/vfn_shadow/test_vfn_shadow.py
@@ -69,7 +69,7 @@ class TxSender:
     async def _send_loop(self):
         w3 = self._w3
         chain_id = await asyncio.to_thread(lambda: w3.eth.chain_id)
-        gas_price = Web3.to_wei("2", "gwei")
+        gas_price = Web3.to_wei("100", "gwei")
         nonce = await asyncio.to_thread(
             lambda: w3.eth.get_transaction_count(self.faucet.address, "pending")
         )


### PR DESCRIPTION
## Summary
- The E2E job in #688 ran 2h then was cancelled. Two independent regressions, both surfaced by that PR's gravity-reth/STORAGE_DIR bumps:
  - **Gas pricing**: gravity-reth#335 enforces a 50 Gwei minimum base fee. Several E2E tests still sign txns with `gas_price = 2 Gwei` or `max_fee_per_gas = 10**10`. reth rejects them as `transaction underpriced`, the test/bench retries forever, the suite hangs.
  - **LOG_DIR default**: #688 changed `LOG_DIR`'s default from `$data_dir` to `$data_dir/data`, so consensus logs moved from `<node>/consensus_log/` to `<node>/data/consensus_log/`. `test_vfn_shadow` reads from the old path and asserts on `Batch retrieval task starts`; with logs missing it fails as "consumer-only path is not wired".

## Changes
- `cluster/deploy.sh`: default `LOG_DIR` back to `$data_dir`. The `cluster.log_dir` override in `cluster.toml` still routes logs elsewhere; this only restores the unset-default placement.
- 6 test files: bump hardcoded `2 Gwei` / `10**10` gas params to `100 Gwei` / `10**11` (still ≥ 50 Gwei min).

## Bench side (already merged)
The matching gravity_bench fix is `Galxe/gravity_bench#46` (commit `9be05b8` on `main`) — bumps `BENCH_MAX_FEE_PER_GAS` to 100 Gwei across faucet/transfer/swap/approve builders. `cluster/faucet.sh` re-pulls bench main on every run, so no sdk-side change is needed for that.

## Test plan
Verified locally — all 10 CI suites pass:
- [x] bridge
- [x] distinct_roles
- [x] distinct_roles_3nodes
- [x] four_validator
- [x] gov_consensus_config_test
- [x] gov_validator_whitelist_test
- [x] pfn_vfn_shadow
- [x] single_node
- [x] vfn
- [x] vfn_shadow

## Out of scope
`fuzzy_cluster` and `rolling_upgrade` are excluded by `e2e-docker.yml` for PR-review runs; the gas-price bump is also applied to `test_rolling_upgrade.py` for completeness so it doesn't break when the nightly job picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)