### PR TITLE
feat(cluster): per-node txpool slots and vfn-discovery overrides

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -867,6 +867,11 @@ main() {
         export HTTPS_PORT=$(echo "$node" | jq -r '.https_port // "null"')
         export AUTHRPC_PORT=$(echo "$node" | jq -r '.authrpc_port')
         export P2P_PORT_RETH=$(echo "$node" | jq -r '.reth_p2p_port')
+        # reth pool per-sender cap. Default = 16 (matches reth upstream default).
+        # Under Aptos-mempool-driven External-origin ingress this triggers the cap=16 stall
+        # documented in _local/wiki/private-mainnet/handoff.md. Set to a larger value
+        # (e.g. 10000) in cluster.toml to opt into the fix.
+        export TXPOOL_MAX_ACCOUNT_SLOTS=$(echo "$node" | jq -r '.txpool_max_account_slots // 16')
 
         role=$(echo "$node" | jq -r '.role // empty')
 

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -937,7 +937,20 @@ main() {
         # Resolve discovery_method. Per-node override wins; otherwise the
         # default is role-driven — validator/vfn use onchain, pfn emits nothing
         # (seed-only). Valid values: onchain | none. Omit to take the default.
+        #
+        # On a validator node the template emits TWO discovery blocks:
+        # validator_network (controlled by `discovery_method`) and the secondary
+        # full_node_networks/vfn block. The latter has its own per-node override
+        # `vfn_discovery_method`, which falls back to `discovery_method` for
+        # backward compat. Setting `vfn_discovery_method = "none"` on a validator
+        # whose genesis registers `shadow_fullnode` is REQUIRED — otherwise the
+        # validator's vfn-network onchain discovery resolves to the shadow VFN's
+        # registered identity, producing a "Onchain pubkey mismatch" self-check
+        # error every cycle. On VFN/PFN role nodes there is only one network
+        # block, so vfn_discovery_method is effectively an alias for
+        # discovery_method (and is treated as such here).
         discovery_method=$(echo "$node" | jq -r '.discovery_method // empty')
+        vfn_discovery_method=$(echo "$node" | jq -r '.vfn_discovery_method // empty')
         if [ -z "$discovery_method" ]; then
             case "$role" in
                 genesis|validator|vfn) discovery_method="onchain" ;;
@@ -945,13 +958,19 @@ main() {
                 *)                     discovery_method="" ;;
             esac
         fi
+        if [ -z "$vfn_discovery_method" ]; then
+            vfn_discovery_method="$discovery_method"
+        fi
         if [ -n "$discovery_method" ]; then
             export DISCOVERY_METHOD_NETWORK_BLOCK="  discovery_method:
     ${discovery_method}"
-            export DISCOVERY_METHOD_FULLNODE_BLOCK="    discovery_method:
-      ${discovery_method}"
         else
             export DISCOVERY_METHOD_NETWORK_BLOCK=""
+        fi
+        if [ -n "$vfn_discovery_method" ]; then
+            export DISCOVERY_METHOD_FULLNODE_BLOCK="    discovery_method:
+      ${vfn_discovery_method}"
+        else
             export DISCOVERY_METHOD_FULLNODE_BLOCK=""
         fi
 

--- a/cluster/templates/reth_config.json.tpl
+++ b/cluster/templates/reth_config.json.tpl
@@ -28,6 +28,7 @@
         "txpool.basefee-max-size": 17592186044415,
         "txpool.queued-max-count": 17592186044415,
         "txpool.queued-max-size": 17592186044415,
+        "txpool.max-account-slots": ${TXPOOL_MAX_ACCOUNT_SLOTS},
         "ipcdisable": ""
     },
     "env_vars": {

--- a/cluster/templates/reth_config_pfn.json.tpl
+++ b/cluster/templates/reth_config_pfn.json.tpl
@@ -27,6 +27,7 @@
         "txpool.basefee-max-size": 17592186044415,
         "txpool.queued-max-count": 17592186044415,
         "txpool.queued-max-size": 17592186044415,
+        "txpool.max-account-slots": ${TXPOOL_MAX_ACCOUNT_SLOTS},
         "ipcdisable": ""
     },
     "env_vars": {

--- a/cluster/templates/reth_config_vfn.json.tpl
+++ b/cluster/templates/reth_config_vfn.json.tpl
@@ -27,6 +27,7 @@
         "txpool.basefee-max-size": 17592186044415,
         "txpool.queued-max-count": 17592186044415,
         "txpool.queued-max-size": 17592186044415,
+        "txpool.max-account-slots": ${TXPOOL_MAX_ACCOUNT_SLOTS},
         "ipcdisable": ""
     },
     "env_vars": {

--- a/gravity_e2e/cluster_test_cases/pfn_chain/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/pfn_chain/cluster.toml
@@ -57,6 +57,11 @@ inspection_port = 10002
 https_port = 1024
 authrpc_port = 8553
 reth_p2p_port = 12026
+# genesis registers shadow_fullnode = "vfn1" (see genesis.toml). validator's
+# own vfn-network onchain discovery would resolve to vfn1's identity → noise
+# pubkey mismatch self-check loop. Force vfn-network discovery off; the
+# validator_network keeps the default onchain.
+vfn_discovery_method = "none"
 
 [[nodes]]
 id = "vfn1"

--- a/gravity_e2e/cluster_test_cases/vfn_shadow/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/vfn_shadow/cluster.toml
@@ -24,6 +24,11 @@ inspection_port = 10002
 https_port = 1024
 authrpc_port = 8553
 reth_p2p_port = 12026
+# genesis registers shadow_fullnode = "vfn-alpha" (see genesis.toml). validator's
+# own vfn-network onchain discovery would resolve to vfn-alpha's identity → noise
+# pubkey mismatch self-check loop. Force vfn-network discovery off; the
+# validator_network keeps the default onchain.
+vfn_discovery_method = "none"
 
 [[nodes]]
 id = "vfn-alpha"


### PR DESCRIPTION
## Summary

- **`txpool_max_account_slots` field** (per-node, default 16): renders as `--txpool.max-account-slots=N` in reth_config.json. The upstream reth default of 16 caps each sender's in-pool tx count for External-origin ingress; under Aptos shared mempool propagation this throttles per-sender drain to roughly one cycle of the 60s broadcast cache (~16 mined tx/min steady-state). Default kept at 16 to preserve existing e2e/cluster behavior; deployments needing the fix opt in via e.g. `txpool_max_account_slots = 10000`.
- **`vfn_discovery_method` field** (per-node, falls back to `discovery_method`): independent control over the validator's secondary `full_node_networks/vfn` discovery block. Required when genesis registers `shadow_fullnode` — without it, the validator's vfn-network onchain discovery resolves to the shadow VFN's identity, triggering a noise pubkey mismatch self-check loop every cycle. Applied to e2e `pfn_chain` and `vfn_shadow` (the only two cases using shadow_fullnode in `genesis.toml`).

## Test plan

- [ ] `python3 gravity_e2e/runner.py pfn_chain --force-init`
- [ ] `python3 gravity_e2e/runner.py vfn_shadow --force-init`
- [ ] Default deploy renders `--txpool.max-account-slots=16`; setting `txpool_max_account_slots = 10000` per node renders the override
- [ ] On a validator with `vfn_discovery_method = "none"`, rendered `validator.yaml` shows `validator_network: discovery_method: onchain` and `full_node_networks/vfn: discovery_method: none`
- [ ] On a VFN/PFN node, behavior is unchanged from before this PR