### PR TITLE
fix(consensus): use block_number limit in recover_blocks to prevent skipping epoch change

### DIFF
--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -249,15 +249,14 @@ impl BlockStore {
 
         // When a non-blocking epoch change was in progress, determine the epoch change
         // block_number so that recovery does not commit suffix blocks past it.
-        let epoch_change_block_number =
-            last_ledger_info.as_ref().and_then(|li| {
-                let info = li.ledger_info().commit_info().epoch_block_info()?;
-                info!(
-                    "recover_blocks: epoch change detected at block_id={}, block_number={}",
-                    info.block_id, info.block_number,
-                );
-                Some(info.block_number)
-            });
+        let epoch_change_block_number = last_ledger_info.as_ref().and_then(|li| {
+            let info = li.ledger_info().commit_info().epoch_block_info()?;
+            info!(
+                "recover_blocks: epoch change detected at block_id={}, block_number={}",
+                info.block_id, info.block_number,
+            );
+            Some(info.block_number)
+        });
 
         certs.sort_unstable_by_key(|qc| qc.commit_info().round());
 
@@ -280,11 +279,10 @@ impl BlockStore {
                 commit_round,
                 self.commit_root().round(),
             );
-            if let Err(e) = self.send_for_execution(
-                qc.into_wrapped_ledger_info(),
-                true,
-                epoch_change_block_number,
-            ).await {
+            if let Err(e) = self
+                .send_for_execution(qc.into_wrapped_ledger_info(), true, epoch_change_block_number)
+                .await
+            {
                 error!("recover_blocks: failed to commit blocks: {e}");
                 break;
             }
@@ -562,18 +560,23 @@ impl BlockStore {
         // blocks.
         self.init_block_number(&blocks_to_commit);
         if recovery {
-            // Recovery mode: process blocks directly without going through execution pipeline
+            // Recovery mode: process blocks directly without going through execution pipeline.
+            // Filter out suffix blocks past the epoch change boundary before execution.
+            let blocks_to_commit: Vec<_> = if let Some(limit) = recover_epoch_change_block_number {
+                let filtered: Vec<_> = blocks_to_commit
+                    .into_iter()
+                    .filter(|b| !b.block().block_number().is_some_and(|bn| bn > limit))
+                    .collect();
+                info!(
+                    "send_for_execution(recovery): filtered to {} blocks (epoch change limit={})",
+                    filtered.len(),
+                    limit,
+                );
+                filtered
+            } else {
+                blocks_to_commit
+            };
             for p_block in &blocks_to_commit {
-                // Stop before committing blocks past the epoch change boundary.
-                if let Some(limit) = recover_epoch_change_block_number {
-                    if p_block.block().block_number().is_some_and(|bn| bn > limit) {
-                        info!(
-                            "send_for_execution(recovery): stopping at block_number={} (epoch change limit={})",
-                            p_block.block().block_number().unwrap_or(0), limit,
-                        );
-                        break;
-                    }
-                }
                 let mut txns = vec![];
                 loop {
                     match self.payload_manager.get_transactions(p_block.block()).await {
@@ -1219,7 +1222,8 @@ impl BlockStore {
     pub async fn insert_block_with_qc(&self, block: Block) -> anyhow::Result<Arc<PipelinedBlock>> {
         self.insert_single_quorum_cert(block.quorum_cert().clone(), false)?;
         if self.ordered_root().round() < block.quorum_cert().commit_info().round() {
-            self.send_for_execution(block.quorum_cert().into_wrapped_ledger_info(), false, None).await?;
+            self.send_for_execution(block.quorum_cert().into_wrapped_ledger_info(), false, None)
+                .await?;
         }
         self.insert_block(block, false).await
     }

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -709,6 +709,7 @@ impl BlockStore {
             );
             self.inner.write().update_ordered_root(block_to_commit.id());
             self.inner.write().insert_ordered_cert(finality_proof_clone.clone());
+            update_counters_for_ordered_blocks(&blocks_to_commit);
         } else {
             // `BATCH_COMMIT_SIZE` env var: when set and the accumulated path is still
             // small, defer sending so the execution layer can process blocks in larger
@@ -788,9 +789,9 @@ impl BlockStore {
                 self.inner.write().update_ordered_root(block.id());
                 self.inner.write().insert_ordered_cert(proof);
             }
+            update_counters_for_ordered_blocks(&blocks_to_commit);
         }
 
-        update_counters_for_ordered_blocks(&blocks_to_commit);
         Ok(())
     }
 

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -247,17 +247,16 @@ impl BlockStore {
             self.storage.consensus_db().ledger_db.metadata_db().get_latest_ledger_info();
         info!("recover_blocks: last_ledger_info={:?}", last_ledger_info);
 
-        // Determine the upper-bound round for recovery when a non-blocking epoch change
-        // was in progress. Blocks after this round are suffix blocks that reth will discard.
-        let epoch_change_limit_round =
+        // When a non-blocking epoch change was in progress, determine the epoch change
+        // block_number so that recovery does not commit suffix blocks past it.
+        let epoch_change_block_number =
             last_ledger_info.as_ref().and_then(|li| {
                 let info = li.ledger_info().commit_info().epoch_block_info()?;
-                let block = self.get_block(info.block_id)?;
                 info!(
-                "recover_blocks: epoch change detected at block_id={}, block_number={}, round={}",
-                info.block_id, info.block_number, block.round(),
-            );
-                Some(block.round())
+                    "recover_blocks: epoch change detected at block_id={}, block_number={}",
+                    info.block_id, info.block_number,
+                );
+                Some(info.block_number)
             });
 
         certs.sort_unstable_by_key(|qc| qc.commit_info().round());
@@ -267,12 +266,6 @@ impl BlockStore {
 
             if commit_round <= self.commit_root().round() {
                 continue;
-            }
-
-            // Stop once we pass the epoch change boundary.
-            if epoch_change_limit_round.is_some_and(|ec| commit_round > ec) {
-                info!("recover_blocks: stopping before round {commit_round} (epoch change limit)");
-                break;
             }
 
             let Some(last_li) = &last_ledger_info else { continue };
@@ -287,7 +280,11 @@ impl BlockStore {
                 commit_round,
                 self.commit_root().round(),
             );
-            if let Err(e) = self.send_for_execution(qc.into_wrapped_ledger_info(), true).await {
+            if let Err(e) = self.send_for_execution(
+                qc.into_wrapped_ledger_info(),
+                true,
+                epoch_change_block_number,
+            ).await {
                 error!("recover_blocks: failed to commit blocks: {e}");
                 break;
             }
@@ -532,6 +529,7 @@ impl BlockStore {
         &self,
         finality_proof: WrappedLedgerInfo,
         recovery: bool,
+        recover_epoch_change_block_number: Option<u64>,
     ) -> anyhow::Result<()> {
         let block_id_to_commit = finality_proof.commit_info().id();
         // Idempotent short-circuits for concurrent send_for_execution races
@@ -566,6 +564,16 @@ impl BlockStore {
         if recovery {
             // Recovery mode: process blocks directly without going through execution pipeline
             for p_block in &blocks_to_commit {
+                // Stop before committing blocks past the epoch change boundary.
+                if let Some(limit) = recover_epoch_change_block_number {
+                    if p_block.block().block_number().is_some_and(|bn| bn > limit) {
+                        info!(
+                            "send_for_execution(recovery): stopping at block_number={} (epoch change limit={})",
+                            p_block.block().block_number().unwrap_or(0), limit,
+                        );
+                        break;
+                    }
+                }
                 let mut txns = vec![];
                 loop {
                     match self.payload_manager.get_transactions(p_block.block()).await {
@@ -1211,7 +1219,7 @@ impl BlockStore {
     pub async fn insert_block_with_qc(&self, block: Block) -> anyhow::Result<Arc<PipelinedBlock>> {
         self.insert_single_quorum_cert(block.quorum_cert().clone(), false)?;
         if self.ordered_root().round() < block.quorum_cert().commit_info().round() {
-            self.send_for_execution(block.quorum_cert().into_wrapped_ledger_info(), false).await?;
+            self.send_for_execution(block.quorum_cert().into_wrapped_ledger_info(), false, None).await?;
         }
         self.insert_block(block, false).await
     }

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -572,6 +572,12 @@ impl BlockStore {
                     filtered.len(),
                     limit,
                 );
+                if filtered.is_empty() {
+                    info!(
+                        "send_for_execution(recovery): all blocks filtered out by epoch change limit, skipping",
+                    );
+                    return Ok(());
+                }
                 filtered
             } else {
                 blocks_to_commit

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -187,7 +187,7 @@ impl BlockStore {
         }
         if self.ordered_root().round() < qc.commit_info().round() {
             SUCCESSFUL_EXECUTED_WITH_REGULAR_QC.inc();
-            self.send_for_execution(qc.into_wrapped_ledger_info(), false).await?;
+            self.send_for_execution(qc.into_wrapped_ledger_info(), false, None).await?;
             if qc.ends_epoch() {
                 retriever
                     .network
@@ -214,7 +214,7 @@ impl BlockStore {
                     observe_block(ordered_block.block().timestamp_usecs(), BlockStage::OC_ADDED);
                 }
                 SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC.inc();
-                self.send_for_execution(ordered_cert.clone(), false).await?;
+                self.send_for_execution(ordered_cert.clone(), false, None).await?;
             } else {
                 bail!("Ordered block not found in block store when inserting ordered cert");
             }

--- a/aptos-core/consensus/src/persistent_liveness_storage.rs
+++ b/aptos-core/consensus/src/persistent_liveness_storage.rs
@@ -18,12 +18,20 @@ use aptos_consensus_types::{
 use async_trait::async_trait;
 use block_buffer_manager::get_block_buffer_manager;
 use gaptos::{
-    aptos_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue},
+    aptos_crypto::{
+        hash::{CryptoHash, ACCUMULATOR_PLACEHOLDER_HASH},
+        HashValue,
+    },
     aptos_logger::prelude::*,
     aptos_storage_interface::DbReader,
     aptos_types::{
-        block_info::Round, epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures,
-        on_chain_config::ValidatorSet, proof::TransactionAccumulatorSummary, transaction::Version,
+        aggregate_signature::AggregateSignature,
+        block_info::{BlockInfo, Round},
+        epoch_change::EpochChangeProof,
+        ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+        on_chain_config::ValidatorSet,
+        proof::TransactionAccumulatorSummary,
+        transaction::Version,
     },
 };
 use itertools::Itertools;
@@ -222,6 +230,16 @@ pub struct RecoveryData {
 }
 
 impl RecoveryData {
+    fn make_placeholder_commit_cert(root_block: &Block) -> WrappedLedgerInfo {
+        let commit_info = root_block.gen_block_info(*ACCUMULATOR_PLACEHOLDER_HASH, 0, None);
+        let vote_data = VoteData::new(commit_info.clone(), commit_info.clone());
+        let li = LedgerInfo::new(commit_info, vote_data.hash());
+        WrappedLedgerInfo::new(
+            vote_data,
+            LedgerInfoWithSignatures::new(li, AggregateSignature::empty()),
+        )
+    }
+
     pub fn find_root_by_block_number(
         execution_latest_block_num: u64,
         blocks: &mut Vec<Block>,
@@ -246,24 +264,33 @@ impl RecoveryData {
             .ok_or_else(|| format_err!("No QC found for root: {}", root_block.id()))?
             .clone();
         let (root_ordered_cert, root_commit_cert) = if order_vote_enabled {
-            // We are setting ordered_root same as commit_root. As every committed block is also
-            // ordered, this is fine. As the block store inserts all the fetched blocks
-            // and quorum certs and execute the blocks, the block store
-            // updates highest_ordered_cert accordingly.
             let root_ordered_cert =
                 WrappedLedgerInfo::new(VoteData::dummy(), root_quorum_cert.ledger_info().clone());
             (root_ordered_cert.clone(), root_ordered_cert)
         } else {
-            let root_ordered_cert = quorum_certs
-                .iter()
-                .find(|qc| qc.commit_info().id() == root_block.id())
-                .ok_or_else(|| format_err!("No LI found for root: {}", root_block.id()))?
-                .clone()
-                .into_wrapped_ledger_info();
-            let root_commit_cert = root_ordered_cert
-                .create_merged_with_executed_state(root_ordered_cert.ledger_info().clone())
-                .expect("Inconsistent commit proof and evaluation decision, cannot commit block");
-            (root_ordered_cert, root_commit_cert)
+            match quorum_certs.iter().find(|qc| qc.commit_info().id() == root_block.id()) {
+                Some(qc) => {
+                    let root_ordered_cert = qc.clone().into_wrapped_ledger_info();
+                    let root_commit_cert = root_ordered_cert
+                        .create_merged_with_executed_state(
+                            root_ordered_cert.ledger_info().clone(),
+                        )
+                        .expect(
+                            "Inconsistent commit proof and evaluation decision, cannot commit block",
+                        );
+                    (root_ordered_cert, root_commit_cert)
+                }
+                None => {
+                    warn!(
+                        "No explicit commit LI for root {} (block_number={}), \
+                         constructing placeholder commit cert",
+                        root_block.id(),
+                        execution_latest_block_num,
+                    );
+                    let placeholder = Self::make_placeholder_commit_cert(&root_block);
+                    (placeholder.clone(), placeholder)
+                }
+            }
         };
         info!("Consensus root block is {}", root_block);
         Ok(RootInfo(Box::new(root_block), root_quorum_cert, root_ordered_cert, root_commit_cert))


### PR DESCRIPTION
## Summary

Fix two recovery panics that prevent nodes from restarting after crashes:

**1. recover_blocks skips epoch change block (commits 541e93eb, 5d9fc047, fd685e7d)**

The round-based `epoch_change_limit_round` check in `recover_blocks` would break before processing the only QC that can commit the epoch change block, because that QC's `commit_round` exceeds the epoch change round. Replace with a `block_number`-based limit passed into `send_for_execution`, so the epoch change block is committed while suffix blocks are skipped.

**2. "No LI found for root" panic on implicit-only commit (commit a28eeaa4)**

When reth lags behind aptos_db (e.g. crash between aptos commit and reth persist), the recovery root block may have been committed implicitly as an ancestor via the 3-chain rule, with no explicit commit LI in consensus DB (e.g. due to consecutive timeouts after the root round). This caused `find_root_by_block_number` to panic. Fix: construct a placeholder `WrappedLedgerInfo` with the root block's `BlockInfo` to pass `BlockTree::new`'s assert, then let `recover_blocks()` replay the real commit proofs via `commit_callback` and overwrite it.

## Test plan

- [ ] Verify node recovers from crash where reth block_number < aptos_db block_number
- [ ] Verify node recovers across epoch change boundaries
- [ ] Verify normal restart (with explicit commit LI) still works unchanged