### PR TITLE
chore: gitignore Claude Code harness local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ Temporary Items
 # VSCode settings
 .vscode/
 
+# Claude Code harness local state
+.claude/
+
 # Typescript
 # *.env  — moved to .env/ specific rule below
 node_modules


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so harness local state (`scheduled_tasks.lock`, `skills/`, `worktrees/`, `settings.local.json`) stops showing up in `git status`.
- The tracked `.claude/commands/` entries are unaffected — already-tracked files are not re-ignored.

## Test plan
- [x] `git status` no longer lists `.claude/*` untracked entries on a working tree where the harness has run.
- [x] `git ls-files .claude/` still shows `commands/build-and-test.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)