### PR TITLE
fix(mempool): drop add_txn cache write; simplify TxnCache to single generation

### DIFF
--- a/aptos-core/mempool/src/core_mempool/mempool.rs
+++ b/aptos-core/mempool/src/core_mempool/mempool.rs
@@ -32,11 +32,15 @@ use std::{
 use super::transaction::VerifiedTxn;
 use block_buffer_manager::TxPool;
 
+/// Broadcast deduplication cache. Suppresses re-emission of the same txn hash
+/// across consecutive `read_timeline` ticks. Single-generation: when capacity
+/// or TTL is exceeded, the whole set is cleared. The worst-case effect of a
+/// clear is one extra broadcast of an in-flight txn, which the gossip layer
+/// will dedupe.
 pub struct TxnCache {
-    old_cache: HashSet<TxnHash>,
     cache: HashSet<TxnHash>,
     size: usize,
-    last_rotation: Instant,
+    last_clear: Instant,
     ttl: Duration,
 }
 
@@ -47,29 +51,28 @@ impl TxnCache {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(60);
         Self {
-            old_cache: HashSet::new(),
             cache: HashSet::new(),
             size,
-            last_rotation: Instant::now(),
+            last_clear: Instant::now(),
             ttl: Duration::from_secs(ttl_secs),
         }
     }
 
-    fn maybe_rotate(&mut self) {
-        if self.cache.len() > self.size || self.last_rotation.elapsed() > self.ttl {
-            self.old_cache = std::mem::take(&mut self.cache);
-            self.last_rotation = Instant::now();
+    fn maybe_clear(&mut self) {
+        if self.cache.len() > self.size || self.last_clear.elapsed() > self.ttl {
+            self.cache.clear();
+            self.last_clear = Instant::now();
         }
     }
 
     fn insert(&mut self, txn_hash: TxnHash) {
-        self.maybe_rotate();
+        self.maybe_clear();
         self.cache.insert(txn_hash);
     }
 
     pub fn is_contains(&mut self, txn_hash: &TxnHash) -> bool {
-        self.maybe_rotate();
-        self.cache.contains(txn_hash) || self.old_cache.contains(txn_hash)
+        self.maybe_clear();
+        self.cache.contains(txn_hash)
     }
 }
 
@@ -153,7 +156,6 @@ impl CoreMempoolTrait for Mempool {
             return MempoolStatus::new(MempoolStatusCode::UnknownStatus);
         }
 
-        self.txn_cache.lock().unwrap().insert(TxnHash::new(*txn.committed_hash()));
         let verfited_txn = crate::core_mempool::transaction::VerifiedTxn::from(txn);
         let res = self.pool.add_external_txn(verfited_txn.into());
         if res {
@@ -292,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn test_txn_cache_size_rotation() {
+    fn test_txn_cache_size_clear() {
         let cache_size = 2;
         let mut cache = TxnCache::new(cache_size);
 
@@ -300,40 +302,28 @@ mod tests {
         let h2 = mock_txn_hash(2);
         let h3 = mock_txn_hash(3);
         let h4 = mock_txn_hash(4);
-        let h5 = mock_txn_hash(5);
 
-        // 1. Insert within capacity — no rotation
+        // Fill past capacity. maybe_clear runs *before* each op, so the third
+        // insert still goes through (len=2 is not > 2 yet) and lands in the set.
         cache.insert(h1);
         cache.insert(h2);
         cache.insert(h3);
-        // cache = {h1, h2, h3}, no rotation yet (maybe_rotate checks before insert)
-        assert!(cache.is_contains(&h1));
-        assert!(cache.is_contains(&h2));
-        assert!(cache.is_contains(&h3));
-        assert_eq!(cache.cache.len(), 3);
-        assert_eq!(cache.old_cache.len(), 0);
+        assert_eq!(cache.cache.len(), 3); // direct field read avoids triggering maybe_clear
 
-        // 2. Next insert triggers rotation (cache.len()=3 > size=2)
+        // Next op sees len=3 > size=2 and clears. Then h4 is inserted.
         cache.insert(h4);
-        // rotation moved {h1,h2,h3} to old_cache, then h4 inserted into cache
-        assert!(cache.is_contains(&h1)); // in old_cache
-        assert!(cache.is_contains(&h4)); // in cache
         assert_eq!(cache.cache.len(), 1);
-        assert_eq!(cache.old_cache.len(), 3);
-
-        // 3. One more rotation evicts old_cache
-        cache.insert(h5);
-        // cache = {h4, h5}, no rotation yet (len=2, not > 2)
         assert!(cache.is_contains(&h4));
-        assert!(cache.is_contains(&h5));
-        assert!(cache.is_contains(&h1)); // still in old_cache
+        assert!(!cache.is_contains(&h1));
+        assert!(!cache.is_contains(&h2));
+        assert!(!cache.is_contains(&h3));
     }
 
     #[test]
-    fn test_txn_cache_ttl_rotation() {
-        let cache_size = 100000; // large size so only TTL triggers rotation
+    fn test_txn_cache_ttl_clear() {
+        let cache_size = 100_000; // large enough that only TTL triggers clear
         let mut cache = TxnCache::new(cache_size);
-        cache.ttl = Duration::from_millis(50); // short TTL for testing
+        cache.ttl = Duration::from_millis(50);
 
         let h1 = mock_txn_hash(1);
         let h2 = mock_txn_hash(2);
@@ -341,19 +331,11 @@ mod tests {
         cache.insert(h1);
         assert!(cache.is_contains(&h1));
 
-        // Wait for TTL to expire
         std::thread::sleep(Duration::from_millis(60));
 
-        // Next operation triggers rotation — h1 moves to old_cache
+        // Next op triggers clear; h1 is gone, h2 stays.
         cache.insert(h2);
-        assert!(cache.is_contains(&h1)); // still in old_cache
+        assert!(!cache.is_contains(&h1));
         assert!(cache.is_contains(&h2));
-
-        // Wait for TTL again
-        std::thread::sleep(Duration::from_millis(60));
-
-        // h1 should now be evicted (old_cache replaced)
-        assert!(!cache.is_contains(&h1)); // evicted!
-        assert!(cache.is_contains(&h2)); // moved to old_cache by the rotation in is_contains
     }
 }


### PR DESCRIPTION
## Summary

Two changes to the broadcast-dedup `TxnCache` in `aptos-core/mempool/src/core_mempool/mempool.rs`:

### 1. Bug fix: `add_txn` no longer writes the cache

`add_txn` was inserting the txn hash into the cache *before* calling `pool.add_external_txn`, regardless of whether the underlying reth pool actually accepted the txn. Two problems:

- **Silent suppression of rejected txns.** When reth rejects a txn (nonce gap, balance, replacement failure, pool full), the hash still occupies the dedup cache for 1×–2× TTL (default 60–120 s). During that window, even if the same txn re-arrives via gossip, this node will not re-broadcast it — yet it never held the txn either. The txn relies entirely on other peers to propagate.
- **Wrong semantic layer.** `TxnCache` exists to suppress re-emission across consecutive `read_timeline` ticks. Recording inbound receipts in it conflates "saw it" with "broadcast it" and lets a locally-rejected txn block its own re-arrival.

Fix: only `read_timeline` writes the cache, on the drain path that is actually about to broadcast.

### 2. Simplification: collapse two-generation rotation to a single set

The previous `old_cache` + `cache` rotation only protected just-inserted hashes from immediate eviction at the rotation boundary. The worst-case loss of that protection is **one** duplicate broadcast of an in-flight txn — which the gossip layer already dedupes.

Trade-offs removed:
- Per-hash lifetime was uneven (1×–2× TTL depending on insertion timing).
- Effective peak memory was ~2× the configured `size` (cache + old_cache both populated).
- `is_contains` had to query two sets under the shared mutex.

New behavior: when `cache.len() > size` *or* TTL elapsed, the whole set is cleared. Single set, predictable footprint.

## Test plan

- [x] `RUSTFLAGS=\"--cfg tokio_unstable\" cargo test -p aptos-mempool --lib core_mempool::mempool::tests:: --profile quick-release` — both updated tests pass (`test_txn_cache_size_clear`, `test_txn_cache_ttl_clear`).
- [x] `RUSTFLAGS=\"--cfg tokio_unstable\" cargo build --bin gravity_node --profile quick-release` — full binary builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)