### PR TITLE
fix(consensus): prevent panic on empty ledger_infos in fast_forward_sync_by_epoch

### DIFF
--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -381,6 +381,14 @@ impl BlockStore {
             .filter(|((block, _, _), _)| block.round() > hcc_round)
             .unzip();
 
+        if blocks.is_empty() {
+            info!(
+                "[Fast_Forward_sync] all fetched blocks at or below local HCC round {}, nothing to sync",
+                hcc_round
+            );
+            return Ok(());
+        }
+
         for (i, (block, _, _)) in blocks.iter().enumerate() {
             assert_eq!(block.id(), quorum_certs[i].certified_block().id());
             if let Some(payload) = block.payload() {
@@ -397,18 +405,6 @@ impl BlockStore {
             quorum_certs,
             block_numbers,
         )?;
-        if !ledger_infos.is_empty() {
-            ledger_infos.reverse();
-            let mut ledger_info_batch = SchemaBatch::new();
-            for ledger_info in &ledger_infos {
-                storage
-                    .consensus_db()
-                    .ledger_db
-                    .metadata_db()
-                    .put_ledger_info(ledger_info, &mut ledger_info_batch)?;
-            }
-            storage.consensus_db().ledger_db.metadata_db().write_schemas(ledger_info_batch)?;
-        }
         storage.consensus_db().put_randomness(
             &blocks
                 .iter()
@@ -418,6 +414,25 @@ impl BlockStore {
                 })
                 .collect(),
         )?;
+
+        if ledger_infos.is_empty() {
+            info!(
+                "[Fast_Forward_sync] no ledger_infos returned, skipping rebuild (epoch {})",
+                epoch
+            );
+            return Ok(());
+        }
+
+        ledger_infos.reverse();
+        let mut ledger_info_batch = SchemaBatch::new();
+        for ledger_info in &ledger_infos {
+            storage
+                .consensus_db()
+                .ledger_db
+                .metadata_db()
+                .put_ledger_info(ledger_info, &mut ledger_info_batch)?;
+        }
+        storage.consensus_db().ledger_db.metadata_db().write_schemas(ledger_info_batch)?;
 
         let (root, blocks, quorum_certs) =
             match storage.start(false, ledger_infos.last().unwrap().ledger_info().epoch()).await {
@@ -429,7 +444,7 @@ impl BlockStore {
 
         self.rebuild(root, blocks, quorum_certs).await;
 
-        if !ledger_infos.is_empty() && ledger_infos.last().unwrap().ledger_info().ends_epoch() {
+        if ledger_infos.last().unwrap().ledger_info().ends_epoch() {
             retriever
                 .network
                 .send_epoch_change(EpochChangeProof::new(


### PR DESCRIPTION

Two early-return guards:
1. When all fetched blocks are at or below the local HCC round, nothing to sync.
2. When ledger_infos is empty (no commit proofs), skip rebuild and epoch-change notification — the unwrap on ledger_infos.last() was the direct cause of the panic at sync_manager.rs:423.

