### PR TITLE
fix(consensus): bound commit_vote_cache by round window + reset validator pipeline after FFsync

### DIFF
--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -665,10 +665,17 @@ impl BlockStore {
                     match p_block.randomness() {
                         Some(r) => Some(Random::from_bytes(r.randomness())),
                         None => {
-                            return Err(anyhow::anyhow!(
-                                "Randomness is required but not found in block {}",
-                                p_block.block().id()
-                            ));
+                            self.try_set_randomness_from_db(&p_block, p_block.block());
+                            match p_block.randomness() {
+                                Some(r) => Some(Random::from_bytes(r.randomness())),
+                                None => {
+                                    return Err(anyhow::anyhow!(
+                                        "Randomness is required but not found in block {}, block_number={}",
+                                        p_block.block().id(),
+                                        block_number,
+                                    ));
+                                }
+                            }
                         }
                     }
                 } else {

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -475,17 +475,26 @@ impl BlockStore {
             if block.round() <= root_round && block.id() != root_id {
                 continue;
             }
-            block_store.insert_block(block, true).await.unwrap_or_else(|e| {
-                panic!("[BlockStore] failed to insert block during build {:?}", e)
-            });
+            if let Err(e) = block_store.insert_block(block.clone(), true).await {
+                warn!(
+                    "[BlockStore] skipping block during build: block={}, parent={}, error={:?}",
+                    block.id(),
+                    block.parent_id(),
+                    e
+                );
+            }
         }
         for qc in quorum_certs {
             if qc.certified_block().round() < root_round {
                 continue;
             }
-            block_store.insert_single_quorum_cert(qc, true).unwrap_or_else(|e| {
-                panic!("[BlockStore] failed to insert quorum during build{:?}", e)
-            });
+            if let Err(e) = block_store.insert_single_quorum_cert(qc.clone(), true) {
+                warn!(
+                    "[BlockStore] skipping quorum during build: certified_block={}, error={:?}",
+                    qc.certified_block().id(),
+                    e
+                );
+            }
         }
 
         counters::LAST_COMMITTED_ROUND.set(block_store.ordered_root().round() as i64);

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -538,6 +538,10 @@ impl BlockStore {
         recovery: bool,
         recover_epoch_change_block_number: Option<u64>,
     ) -> anyhow::Result<()> {
+        if !self.is_validator && !recovery {
+            debug!("send_for_execution: skip live ordered execution for non-validator");
+            return Ok(());
+        }
         let block_id_to_commit = finality_proof.commit_info().id();
         // Idempotent short-circuits for concurrent send_for_execution races
         // (e.g. recover_blocks vs. live consensus both advancing ordered_root).

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -546,10 +546,28 @@ impl BlockStore {
         let block_to_commit = self
             .get_block(block_id_to_commit)
             .ok_or_else(|| format_err!("Committed block id not found"))?;
-        ensure!(
-            block_to_commit.round() > self.ordered_root().round(),
-            "Committed block round lower than root"
-        );
+        let ordered_root = self.ordered_root();
+        let commit_root = self.commit_root();
+        if block_to_commit.round() <= ordered_root.round() {
+            warn!(
+                "send_for_execution: committed block round lower than ordered root: \
+                block_to_commit_id={}, block_to_commit_round={}, \
+                ordered_root_id={}, ordered_root_round={}, \
+                commit_root_id={}, commit_root_round={}, recovery={}",
+                block_to_commit.id(),
+                block_to_commit.round(),
+                ordered_root.id(),
+                ordered_root.round(),
+                commit_root.id(),
+                commit_root.round(),
+                recovery,
+            );
+            return Err(format_err!(
+                "Committed block round lower than root: block_to_commit_round={}, ordered_root_round={}",
+                block_to_commit.round(),
+                ordered_root.round(),
+            ));
+        }
         let blocks_to_commit = self.path_from_ordered_root(block_id_to_commit).unwrap_or_default();
         if blocks_to_commit.is_empty() {
             // Narrow race: ordered_root advanced between the round check above and here.

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -307,28 +307,7 @@ impl BlockStore {
             } else {
                 highest_commit_cert.clone()
             };
-        let (blocks, quorum_certs) = Self::fast_forward_sync(
-            &highest_quorum_cert,
-            &effective_commit_cert,
-            retriever,
-            self.storage.clone(),
-            self.payload_manager.clone(),
-            self.order_vote_enabled,
-            self.is_validator,
-        )
-        .await?;
-
-        self.apply_fast_forward_sync(&effective_commit_cert, blocks, quorum_certs).await?;
-
-        if highest_commit_cert.ledger_info().ledger_info().ends_epoch() {
-            retriever
-                .network
-                .send_epoch_change(EpochChangeProof::new(
-                    vec![highest_quorum_cert.ledger_info().clone()],
-                    /* more = */ false,
-                ))
-                .await;
-        }
+        self.fast_forward_sync(&highest_quorum_cert, &effective_commit_cert, retriever).await?;
         Ok(())
     }
 
@@ -456,15 +435,12 @@ impl BlockStore {
         Ok(())
     }
 
-    pub async fn fast_forward_sync<'a>(
-        highest_quorum_cert: &'a QuorumCert,
-        highest_commit_cert: &'a WrappedLedgerInfo,
-        retriever: &'a mut BlockRetriever,
-        storage: Arc<dyn PersistentLivenessStorage>,
-        payload_manager: Arc<dyn TPayloadManager>,
-        order_vote_enabled: bool,
-        is_validator: bool,
-    ) -> anyhow::Result<(Vec<(Block, Option<u64>, Option<Vec<u8>>)>, Vec<QuorumCert>)> {
+    pub async fn fast_forward_sync(
+        &self,
+        highest_quorum_cert: &QuorumCert,
+        highest_commit_cert: &WrappedLedgerInfo,
+        retriever: &mut BlockRetriever,
+    ) -> anyhow::Result<()> {
         info!(
             LogSchema::new(LogEvent::StateSync).remote_peer(retriever.preferred_peer),
             "Start block sync to commit cert: {}, quorum cert: {}",
@@ -481,17 +457,17 @@ impl BlockStore {
         assert!(num_blocks < std::usize::MAX as u64);
 
         BLOCKS_FETCHED_FROM_NETWORK_WHILE_FAST_FORWARD_SYNC.inc_by(num_blocks);
-        let (mut blocks, _, ledger_infos) = retriever
+        let (mut blocks, _, mut ledger_infos) = retriever
             .retrieve_blocks_in_range(
                 highest_quorum_cert.certified_block().id(),
                 num_blocks,
                 highest_commit_cert.commit_info().id(),
-                if is_validator {
+                if self.is_validator {
                     highest_quorum_cert.ledger_info().get_voters(&retriever.available_peers)
                 } else {
                     retriever.available_peers.clone()
                 },
-                payload_manager.clone(),
+                self.payload_manager.clone(),
             )
             .await?;
 
@@ -519,12 +495,12 @@ impl BlockStore {
             .filter(|(_, block_number, _)| block_number.is_some())
             .map(|(block, block_number, _)| (block.epoch(), block_number.unwrap(), block.id()))
             .collect::<Vec<(u64, u64, HashValue)>>();
-        storage.save_tree(
+        self.storage.save_tree(
             blocks.iter().map(|(block, _, _)| block.clone()).collect(),
             quorum_certs.clone(),
             block_numbers,
         )?;
-        storage.consensus_db().put_randomness(
+        self.storage.consensus_db().put_randomness(
             &blocks
                 .iter()
                 .filter(|(_, _, randomness)| randomness.is_some())
@@ -533,23 +509,52 @@ impl BlockStore {
                 })
                 .collect(),
         )?;
-        if !ledger_infos.is_empty() {
-            let mut ledger_info_batch = SchemaBatch::new();
-            for ledger_info in ledger_infos {
-                storage
-                    .consensus_db()
-                    .ledger_db
-                    .metadata_db()
-                    .put_ledger_info(&ledger_info, &mut ledger_info_batch);
-            }
-            storage.consensus_db().ledger_db.metadata_db().write_schemas(ledger_info_batch);
+        if ledger_infos.is_empty() {
+            info!("[FastForwardSync] no ledger_infos returned, skipping rebuild");
+            return Ok(());
         }
-        storage.consensus_db().ledger_db.metadata_db().update_latest_ledger_info();
+
+        ledger_infos.reverse();
+        let mut ledger_info_batch = SchemaBatch::new();
+        for ledger_info in &ledger_infos {
+            self.storage
+                .consensus_db()
+                .ledger_db
+                .metadata_db()
+                .put_ledger_info(ledger_info, &mut ledger_info_batch)?;
+        }
+        self.storage.consensus_db().ledger_db.metadata_db().write_schemas(ledger_info_batch)?;
+        self.storage.consensus_db().ledger_db.metadata_db().update_latest_ledger_info();
         // we do not need to update block_tree.highest_commit_decision_ledger_info here
         // because the block_tree is going to rebuild itself.
         blocks.reverse();
         quorum_certs.reverse();
-        Ok((blocks, quorum_certs))
+        if !self.is_validator {
+            self.append_blocks_for_sync(blocks, quorum_certs).await;
+        } else {
+            let (root, blocks, quorum_certs) = match self
+                .storage
+                .start(false, ledger_infos.last().unwrap().ledger_info().epoch())
+                .await
+            {
+                LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
+                _ => panic!("Failed to construct recovery data after fast forward sync"),
+            }
+            .take();
+            self.storage.consensus_db().ledger_db.metadata_db().update_latest_ledger_info();
+
+            self.rebuild(root, blocks, quorum_certs).await;
+        }
+        if ledger_infos.last().unwrap().ledger_info().ends_epoch() {
+            retriever
+                .network
+                .send_epoch_change(EpochChangeProof::new(
+                    vec![ledger_infos.last().unwrap().clone()],
+                    /* more = */ false,
+                ))
+                .await;
+        }
+        Ok(())
     }
 
     async fn apply_fast_forward_sync(
@@ -629,18 +634,8 @@ impl BlockStore {
                 // if the block doesnt exist after ordered root
                 let highest_commit_cert_qc =
                     highest_commit_cert.clone().into_quorum_cert(self.order_vote_enabled).unwrap();
-                let (blocks, quorum_certs) = Self::fast_forward_sync(
-                    &highest_commit_cert_qc,
-                    &sync_from_cert,
-                    retriever,
-                    self.storage.clone(),
-                    self.payload_manager.clone(),
-                    self.order_vote_enabled,
-                    self.is_validator,
-                )
-                .await?;
-
-                self.apply_fast_forward_sync(&highest_commit_cert, blocks, quorum_certs).await?;
+                self.fast_forward_sync(&highest_commit_cert_qc, &highest_commit_cert, retriever)
+                    .await?;
             }
         }
         Ok(())

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -318,7 +318,7 @@ impl BlockStore {
         )
         .await?;
 
-        self.append_blocks_for_sync(blocks, quorum_certs).await;
+        self.apply_fast_forward_sync(&effective_commit_cert, blocks, quorum_certs).await?;
 
         if highest_commit_cert.ledger_info().ledger_info().ends_epoch() {
             retriever
@@ -552,6 +552,37 @@ impl BlockStore {
         Ok((blocks, quorum_certs))
     }
 
+    async fn apply_fast_forward_sync(
+        &self,
+        target_commit_cert: &WrappedLedgerInfo,
+        blocks: Vec<(Block, Option<u64>, Option<Vec<u8>>)>,
+        quorum_certs: Vec<QuorumCert>,
+    ) -> anyhow::Result<()> {
+        if !self.is_validator {
+            self.append_blocks_for_sync(blocks, quorum_certs).await;
+            return Ok(());
+        }
+
+        let target = target_commit_cert.ledger_info();
+        info!(
+            "apply_fast_forward_sync: validator reset and rebuild to commit round {}, block {}",
+            target.commit_info().round(),
+            target.commit_info().id(),
+        );
+        self.execution_client.reset(target).await?;
+
+        let (root, blocks, quorum_certs) =
+            match self.storage.start(false, target.ledger_info().epoch()).await {
+                LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
+                _ => panic!("Failed to construct recovery data after fast forward sync"),
+            }
+            .take();
+
+        self.storage.consensus_db().ledger_db.metadata_db().update_latest_ledger_info();
+        self.rebuild(root, blocks, quorum_certs).await;
+        Ok(())
+    }
+
     /// Fast forward in the decoupled-execution pipeline if the block exists there
     async fn sync_to_highest_commit_cert(
         &self,
@@ -609,7 +640,7 @@ impl BlockStore {
                 )
                 .await?;
 
-                self.append_blocks_for_sync(blocks, quorum_certs).await;
+                self.apply_fast_forward_sync(&highest_commit_cert, blocks, quorum_certs).await?;
             }
         }
         Ok(())

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -634,8 +634,7 @@ impl BlockStore {
                 // if the block doesnt exist after ordered root
                 let highest_commit_cert_qc =
                     highest_commit_cert.clone().into_quorum_cert(self.order_vote_enabled).unwrap();
-                self.fast_forward_sync(&highest_commit_cert_qc, &highest_commit_cert, retriever)
-                    .await?;
+                self.fast_forward_sync(&highest_commit_cert_qc, &sync_from_cert, retriever).await?;
             }
         }
         Ok(())

--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -74,7 +74,7 @@ fn generate_executed_item_from_ordered(
 ) -> BufferItem {
     debug!("{} advance to executed from ordered", commit_info);
     let block = executed_blocks.last().expect("execute_blocks should not be empty!");
-    let new_commit_info = BlockInfo::new(
+    let new_commit_info = BlockInfo::new_with_epoch_block_info(
         commit_info.epoch(),
         commit_info.round(),
         commit_info.id(),
@@ -82,9 +82,10 @@ fn generate_executed_item_from_ordered(
         block.block().block_number().unwrap(),
         block.timestamp_usecs(),
         commit_info.next_epoch_state().cloned(),
+        commit_info.epoch_block_info().cloned(),
     );
     let commit_ledger_info = generate_commit_ledger_info(
-        &commit_info,
+        &new_commit_info,
         &ordered_proof,
         order_vote_enabled,
         block.compute_result().root_hash(),

--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -54,14 +54,44 @@ fn verify_signatures(
     // filters out invalid signature shares much faster when there are only a few of them
     // (e.g., [LM07]: Finding Invalid Signatures in Pairing-Based Batches,
     // by Law, Laurie and Matt, Brian J., in Cryptography and Coding, 2007).
-    PartialSignatures::new(
+    let raw_signature_count = unverified_signatures.signatures().len();
+    let mut failed_authors = vec![];
+    let verified_signatures = PartialSignatures::new(
         unverified_signatures
             .signatures()
             .iter()
-            .filter(|(author, sig)| validator.verify(**author, commit_ledger_info, sig).is_ok())
-            .map(|(author, sig)| (*author, sig.clone()))
+            .filter_map(|(author, sig)| {
+                if validator.verify(*author, commit_ledger_info, sig).is_ok() {
+                    Some((*author, sig.clone()))
+                } else {
+                    failed_authors.push(*author);
+                    None
+                }
+            })
             .collect(),
-    )
+    );
+    let verified_signature_count = verified_signatures.signatures().len();
+    if !failed_authors.is_empty() {
+        warn!(
+            commit_info = ?commit_ledger_info.commit_info(),
+            block_hash = ?commit_ledger_info.block_hash(),
+            block_number = commit_ledger_info.block_number(),
+            raw_signature_count = raw_signature_count,
+            verified_signature_count = verified_signature_count,
+            failed_authors = ?failed_authors,
+            "Commit vote signature verification filtered signatures",
+        );
+    } else {
+        info!(
+            commit_info = ?commit_ledger_info.commit_info(),
+            block_hash = ?commit_ledger_info.block_hash(),
+            block_number = commit_ledger_info.block_number(),
+            raw_signature_count = raw_signature_count,
+            verified_signature_count = verified_signature_count,
+            "Commit vote signature verification completed",
+        );
+    }
+    verified_signatures
 }
 
 fn generate_executed_item_from_ordered(
@@ -237,9 +267,9 @@ impl BufferItem {
                     );
                     let verified_signatures =
                         verify_signatures(unverified_signatures, validator, &commit_ledger_info);
-                    if (validator.check_voting_power(verified_signatures.signatures().keys(), true))
-                        .is_ok()
-                    {
+                    let voting_power_result =
+                        validator.check_voting_power(verified_signatures.signatures().keys(), true);
+                    if voting_power_result.is_ok() {
                         let commit_proof = aggregate_commit_proof(
                             &commit_ledger_info,
                             &verified_signatures,
@@ -252,6 +282,14 @@ impl BufferItem {
                             callback,
                         }))
                     } else {
+                        warn!(
+                            commit_info = ?commit_ledger_info.commit_info(),
+                            block_hash = ?commit_ledger_info.block_hash(),
+                            block_number = commit_ledger_info.block_number(),
+                            verified_signature_count = verified_signatures.signatures().len(),
+                            error = ?voting_power_result.err(),
+                            "Commit vote signatures do not have enough voting power after execution",
+                        );
                         generate_executed_item_from_ordered(
                             commit_info,
                             executed_blocks,
@@ -350,10 +388,9 @@ impl BufferItem {
     pub fn try_advance_to_aggregated(self, validator: &ValidatorVerifier) -> Self {
         match self {
             Self::Signed(signed_item) => {
-                if validator
-                    .check_voting_power(signed_item.partial_commit_proof.signatures().keys(), true)
-                    .is_ok()
-                {
+                let voting_power_result = validator
+                    .check_voting_power(signed_item.partial_commit_proof.signatures().keys(), true);
+                if voting_power_result.is_ok() {
                     let commit_proof = aggregate_commit_proof(
                         signed_item.partial_commit_proof.ledger_info(),
                         signed_item.partial_commit_proof.partial_sigs(),
@@ -366,17 +403,23 @@ impl BufferItem {
                         callback: signed_item.callback,
                     }))
                 } else {
+                    warn!(
+                        commit_info = ?signed_item.partial_commit_proof.commit_info(),
+                        block_hash = ?signed_item.partial_commit_proof.ledger_info().block_hash(),
+                        block_number = signed_item.partial_commit_proof.ledger_info().block_number(),
+                        signature_count = signed_item.partial_commit_proof.signatures().len(),
+                        error = ?voting_power_result.err(),
+                        "Signed buffer item does not have enough commit voting power",
+                    );
                     Self::Signed(signed_item)
                 }
             }
             Self::Executed(executed_item) => {
-                if validator
-                    .check_voting_power(
-                        executed_item.partial_commit_proof.signatures().keys(),
-                        true,
-                    )
-                    .is_ok()
-                {
+                let voting_power_result = validator.check_voting_power(
+                    executed_item.partial_commit_proof.signatures().keys(),
+                    true,
+                );
+                if voting_power_result.is_ok() {
                     Self::Aggregated(Box::new(AggregatedItem {
                         executed_blocks: executed_item.executed_blocks,
                         commit_proof: aggregate_commit_proof(
@@ -387,6 +430,14 @@ impl BufferItem {
                         callback: executed_item.callback,
                     }))
                 } else {
+                    warn!(
+                        commit_info = ?executed_item.partial_commit_proof.commit_info(),
+                        block_hash = ?executed_item.partial_commit_proof.ledger_info().block_hash(),
+                        block_number = executed_item.partial_commit_proof.ledger_info().block_number(),
+                        signature_count = executed_item.partial_commit_proof.signatures().len(),
+                        error = ?voting_power_result.err(),
+                        "Executed buffer item does not have enough commit voting power",
+                    );
                     Self::Executed(executed_item)
                 }
             }

--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -82,7 +82,7 @@ fn verify_signatures(
             "Commit vote signature verification filtered signatures",
         );
     } else {
-        info!(
+        debug!(
             commit_info = ?commit_ledger_info.commit_info(),
             block_hash = ?commit_ledger_info.block_hash(),
             block_number = commit_ledger_info.block_number(),

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -167,6 +167,7 @@ pub struct BufferManager {
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
 
     commit_vote_cache: BTreeMap<Round, HashMap<HashValue, HashMap<HashValue, CommitVote>>>,
+    max_pending_rounds_in_commit_vote_cache: Round,
 
     // Cache for commit proofs that arrive before the block enters the buffer.
     // When a CommitMessage::Decision arrives but the block is not yet in the buffer,
@@ -201,6 +202,7 @@ impl BufferManager {
         highest_committed_round: Round,
         consensus_observer_config: ConsensusObserverConfig,
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
+        max_pending_rounds_in_commit_vote_cache: Round,
     ) -> Self {
         let buffer = Buffer::<BufferItem>::new();
 
@@ -261,6 +263,7 @@ impl BufferManager {
             consensus_observer_config,
             consensus_publisher,
             commit_vote_cache: BTreeMap::new(),
+            max_pending_rounds_in_commit_vote_cache,
             pending_commit_proofs: BTreeMap::new(),
         }
     }
@@ -360,20 +363,28 @@ impl BufferManager {
 
     fn cache_commit_vote(&mut self, vote: CommitVote) -> bool {
         let commit_info = vote.commit_info().clone();
-        if commit_info.round() < self.latest_round {
+        let round = commit_info.round();
+        let max_pending_rounds = self.max_pending_rounds_in_commit_vote_cache;
+        let highest_committed_round = self.highest_committed_round;
+        let max_cached_round = highest_committed_round.saturating_add(max_pending_rounds);
+
+        // Match Aptos' pending commit vote window: only cache votes for rounds ahead
+        // of the current commit root and within the configured pending-round window.
+        self.commit_vote_cache.retain(|cached_round, _| {
+            *cached_round > highest_committed_round && *cached_round < max_cached_round
+        });
+
+        if round <= highest_committed_round || round >= max_cached_round {
+            debug!(
+                round = round,
+                highest_committed_round = highest_committed_round,
+                max_cached_round = max_cached_round,
+                block_id = commit_info.id(),
+                "Received a commit vote outside the pending round window, ignored.",
+            );
             return false;
         }
 
-        // Cap the number of cached rounds to prevent OOM from unverified
-        // future votes. When full, evict the oldest round first — those
-        // votes are the least likely to still be needed.
-        const MAX_COMMIT_VOTE_CACHE_ROUNDS: usize = 100_000;
-        let round = commit_info.round();
-        if self.commit_vote_cache.len() >= MAX_COMMIT_VOTE_CACHE_ROUNDS
-            && !self.commit_vote_cache.contains_key(&round)
-        {
-            self.commit_vote_cache.pop_first();
-        }
         self.commit_vote_cache
             .entry(round)
             .or_default()
@@ -1080,6 +1091,7 @@ impl BufferManager {
                     match result {
                         Ok(round) => {
                             // see where `need_backpressure()` is called.
+                            self.commit_vote_cache.retain(|rnd, _| *rnd > round);
                             self.highest_committed_round = round;
                             counters::FINALIZED_EXECUTED_BLOCK_COUNTER.set(self.highest_committed_round as f64);
                         },

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -358,6 +358,50 @@ impl BufferManager {
         });
     }
 
+    fn cache_commit_vote(&mut self, vote: CommitVote) -> bool {
+        let commit_info = vote.commit_info().clone();
+        if commit_info.round() < self.latest_round {
+            return false;
+        }
+
+        // Cap the number of cached rounds to prevent OOM from unverified
+        // future votes. When full, evict the oldest round first — those
+        // votes are the least likely to still be needed.
+        const MAX_COMMIT_VOTE_CACHE_ROUNDS: usize = 100_000;
+        let round = commit_info.round();
+        if self.commit_vote_cache.len() >= MAX_COMMIT_VOTE_CACHE_ROUNDS
+            && !self.commit_vote_cache.contains_key(&round)
+        {
+            self.commit_vote_cache.pop_first();
+        }
+        self.commit_vote_cache
+            .entry(round)
+            .or_default()
+            .entry(commit_info.id())
+            .or_default()
+            .insert(HashValue::new(*vote.author()), vote);
+        true
+    }
+
+    fn drain_cached_commit_votes(&mut self, round: Round, block_id: &HashValue) -> Vec<CommitVote> {
+        let mut remove_round = false;
+        let votes = if let Some(round_cache) = self.commit_vote_cache.get_mut(&round) {
+            let votes = round_cache
+                .remove(block_id)
+                .map(|votes| votes.into_values().collect())
+                .unwrap_or_default();
+            remove_round = round_cache.is_empty();
+            votes
+        } else {
+            vec![]
+        };
+
+        if remove_round {
+            self.commit_vote_cache.remove(&round);
+        }
+        votes
+    }
+
     /// process incoming ordered blocks
     /// push them into the buffer and update the roots if they are none.
     async fn process_ordered_blocks(&mut self, ordered_blocks: OrderedBlocks) {
@@ -385,7 +429,20 @@ impl BufferManager {
             .await
             .expect("Failed to send execution schedule request");
 
-        let item = BufferItem::new_ordered(ordered_blocks, ordered_proof, callback);
+        let mut item = BufferItem::new_ordered(ordered_blocks, ordered_proof, callback);
+        let target_block_id = item.block_id();
+        let round = item.commit_info().round();
+        for vote in self.drain_cached_commit_votes(round, &target_block_id) {
+            if let Err(error) = item.add_signature_if_matched(vote.clone()) {
+                error!(
+                    commit_info = ?item.commit_info(),
+                    target_block_id = ?target_block_id,
+                    vote = ?vote,
+                    error = ?error,
+                    "Failed to add cached commit vote when ordered block entered buffer",
+                );
+            }
+        }
         self.buffer.push_back(item);
     }
 
@@ -619,8 +676,8 @@ impl BufferManager {
             };
             // For suffix blocks with reconfiguration flag, use the cached epoch end timestamp
             if let Some(timestamp) = self.end_epoch_timestamp.get().cloned() {
-                if block_info.timestamp_usecs() != timestamp &&
-                    last_block.is_reconfiguration_suffix()
+                if block_info.timestamp_usecs() != timestamp
+                    && last_block.is_reconfiguration_suffix()
                 {
                     epoch_info.epoch_start_timestamp_usecs = timestamp;
                 }
@@ -752,22 +809,15 @@ impl BufferManager {
         target_block_id: &HashValue,
         round: Round,
     ) {
-        if let Some(round_cache) = self.commit_vote_cache.get(&round) {
-            if let Some(votes) = round_cache.get(target_block_id) {
-                votes.iter().for_each(|(_, vote)| {
-                    match item.add_signature_if_matched(vote.clone()) {
-                        Ok(_) => {}
-                        Err(e) => {
-                            error!(commit_info = ?item.commit_info(), target_block_id = ?target_block_id, vote = ?vote, "Failed to add commit vote from cache");
-                        }
-                    }
-                });
-            }
-        }
-        if let Some(round_cache) = self.commit_vote_cache.get_mut(&round) {
-            round_cache.remove(target_block_id);
-            if round_cache.is_empty() {
-                self.commit_vote_cache.remove(&round);
+        for vote in self.drain_cached_commit_votes(round, target_block_id) {
+            if let Err(error) = item.add_signature_if_matched(vote.clone()) {
+                error!(
+                    commit_info = ?item.commit_info(),
+                    target_block_id = ?target_block_id,
+                    vote = ?vote,
+                    error = ?error,
+                    "Failed to add commit vote from cache",
+                );
             }
         }
     }
@@ -783,24 +833,6 @@ impl BufferManager {
                 let author = vote.author();
                 let commit_info = vote.commit_info().clone();
                 info!("Receive commit vote {} from {}", commit_info, author);
-                if commit_info.round() >= self.latest_round {
-                    // Cap the number of cached rounds to prevent OOM from unverified
-                    // future votes. When full, evict the oldest round first — those
-                    // votes are the least likely to still be needed.
-                    const MAX_COMMIT_VOTE_CACHE_ROUNDS: usize = 100_000;
-                    let round = commit_info.round();
-                    if self.commit_vote_cache.len() >= MAX_COMMIT_VOTE_CACHE_ROUNDS &&
-                        !self.commit_vote_cache.contains_key(&round)
-                    {
-                        self.commit_vote_cache.pop_first();
-                    }
-                    self.commit_vote_cache
-                        .entry(round)
-                        .or_default()
-                        .entry(commit_info.id())
-                        .or_default()
-                        .insert(HashValue::new(*author), vote.clone());
-                }
                 let target_block_id = vote.commit_info().id();
                 let current_cursor =
                     self.buffer.find_elem_by_key(*self.buffer.head_cursor(), target_block_id);
@@ -837,6 +869,13 @@ impl BufferManager {
                     } else {
                         return None;
                     }
+                } else if self.cache_commit_vote(vote) {
+                    let response = ConsensusMsg::CommitMessage(Box::new(CommitMessage::Ack(())));
+                    if let Ok(bytes) = protocol.to_bytes(&response) {
+                        let _ = response_sender.send(Ok(bytes.into()));
+                    }
+                } else {
+                    reply_nack(protocol, response_sender);
                 }
             }
             CommitMessage::Decision(commit_proof) => {
@@ -880,8 +919,8 @@ impl BufferManager {
     /// this function retries all the items until the signing root
     /// note that there might be other signed items after the signing root
     async fn rebroadcast_commit_votes_if_needed(&mut self) {
-        if self.previous_commit_time.elapsed() <
-            Duration::from_millis(COMMIT_VOTE_BROADCAST_INTERVAL_MS)
+        if self.previous_commit_time.elapsed()
+            < Duration::from_millis(COMMIT_VOTE_BROADCAST_INTERVAL_MS)
         {
             return;
         }
@@ -901,8 +940,8 @@ impl BufferManager {
                     // even after send ack, We'll try to re-initiate the
                     // broadcast after 30s.
                     Some((start_time, _)) => {
-                        start_time.elapsed() >=
-                            Duration::from_millis(COMMIT_VOTE_REBROADCAST_INTERVAL_MS)
+                        start_time.elapsed()
+                            >= Duration::from_millis(COMMIT_VOTE_REBROADCAST_INTERVAL_MS)
                     }
                 };
                 if re_broadcast {

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -789,8 +789,8 @@ impl BufferManager {
                     // votes are the least likely to still be needed.
                     const MAX_COMMIT_VOTE_CACHE_ROUNDS: usize = 100_000;
                     let round = commit_info.round();
-                    if self.commit_vote_cache.len() >= MAX_COMMIT_VOTE_CACHE_ROUNDS
-                        && !self.commit_vote_cache.contains_key(&round)
+                    if self.commit_vote_cache.len() >= MAX_COMMIT_VOTE_CACHE_ROUNDS &&
+                        !self.commit_vote_cache.contains_key(&round)
                     {
                         self.commit_vote_cache.pop_first();
                     }
@@ -806,7 +806,11 @@ impl BufferManager {
                     self.buffer.find_elem_by_key(*self.buffer.head_cursor(), target_block_id);
                 if current_cursor.is_some() {
                     let mut item = self.buffer.take(&current_cursor);
-                    self.add_signature_if_matched_from_cache(&mut item, &target_block_id, commit_info.round());
+                    self.add_signature_if_matched_from_cache(
+                        &mut item,
+                        &target_block_id,
+                        commit_info.round(),
+                    );
                     let new_item = match item.add_signature_if_matched(vote) {
                         Ok(()) => {
                             let response =

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -776,8 +776,30 @@ impl BufferManager {
                 let commit_info = vote.commit_info().clone();
                 info!("Receive commit vote {} from {}", commit_info, author);
                 if commit_info.round() >= self.latest_round {
-                    // Limit the cache size to prevent OOM from unverified future votes
-                    const MAX_COMMIT_VOTE_CACHE_ENTRIES: usize = 1000;
+                    // Limit the cache size to prevent OOM from unverified future votes.
+                    //
+                    // The previous limit of 1000 was too tight: with ~3 rounds/sec
+                    // and 7 validators each sending a commit vote per round, this cap
+                    // could be saturated in seconds whenever a node's commit pipeline
+                    // briefly lagged. Once full, every new vote was silently dropped
+                    // until the next reset (epoch transition), and the dropped votes
+                    // were never re-broadcast — so any block whose votes were dropped
+                    // here could not aggregate a quorum locally, leaving the node
+                    // committing far behind for tens of minutes (observed on
+                    // gravity-sdk staging mainnet on 2026-05-04: core-1 lagged by an
+                    // entire epoch for ~18 minutes; in private mainnet ~76,000
+                    // dropped-vote WARNs accumulated across 3 LA validators in a few
+                    // hours, hidden by BFT 5/7 quorum slack).
+                    //
+                    // Bumping to 100k gives ~67 minutes of cache space at 25 votes/s,
+                    // which comfortably exceeds any realistic commit-pipeline lag,
+                    // while keeping the worst-case memory footprint to ~100 MB
+                    // (each entry: 32-byte block_id + up to ~7 vote entries of
+                    // ~130 bytes each). Combined with the existing reset() clear()
+                    // and pending_commit_proofs eviction, this removes the silent
+                    // drop path that has been the root cause of cluster-wide
+                    // commit-lag stalls.
+                    const MAX_COMMIT_VOTE_CACHE_ENTRIES: usize = 100_000;
                     if self.commit_vote_cache.len() < MAX_COMMIT_VOTE_CACHE_ENTRIES ||
                         self.commit_vote_cache.contains_key(&commit_info.id())
                     {

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -166,7 +166,7 @@ pub struct BufferManager {
     consensus_observer_config: ConsensusObserverConfig,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
 
-    commit_vote_cache: HashMap<HashValue, HashMap<HashValue, CommitVote>>,
+    commit_vote_cache: BTreeMap<Round, HashMap<HashValue, HashMap<HashValue, CommitVote>>>,
 
     // Cache for commit proofs that arrive before the block enters the buffer.
     // When a CommitMessage::Decision arrives but the block is not yet in the buffer,
@@ -260,7 +260,7 @@ impl BufferManager {
 
             consensus_observer_config,
             consensus_publisher,
-            commit_vote_cache: HashMap::new(),
+            commit_vote_cache: BTreeMap::new(),
             pending_commit_proofs: BTreeMap::new(),
         }
     }
@@ -750,17 +750,25 @@ impl BufferManager {
         &mut self,
         item: &mut BufferItem,
         target_block_id: &HashValue,
+        round: Round,
     ) {
-        if let Some(cache) = self.commit_vote_cache.get(target_block_id) {
-            cache.iter().for_each(|(_, vote)| {
-                match item.add_signature_if_matched(vote.clone()) {
-                    Ok(_) => {}
-                    Err(e) => {
-                        error!(commit_info = ?item.commit_info(), target_block_id = ?target_block_id, vote = ?vote, "Failed to add commit vote from cache");
+        if let Some(round_cache) = self.commit_vote_cache.get(&round) {
+            if let Some(votes) = round_cache.get(target_block_id) {
+                votes.iter().for_each(|(_, vote)| {
+                    match item.add_signature_if_matched(vote.clone()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            error!(commit_info = ?item.commit_info(), target_block_id = ?target_block_id, vote = ?vote, "Failed to add commit vote from cache");
+                        }
                     }
-                }
-            });
-            self.commit_vote_cache.remove(target_block_id);
+                });
+            }
+        }
+        if let Some(round_cache) = self.commit_vote_cache.get_mut(&round) {
+            round_cache.remove(target_block_id);
+            if round_cache.is_empty() {
+                self.commit_vote_cache.remove(&round);
+            }
         }
     }
 
@@ -776,50 +784,29 @@ impl BufferManager {
                 let commit_info = vote.commit_info().clone();
                 info!("Receive commit vote {} from {}", commit_info, author);
                 if commit_info.round() >= self.latest_round {
-                    // Limit the cache size to prevent OOM from unverified future votes.
-                    //
-                    // The previous limit of 1000 was too tight: with ~3 rounds/sec
-                    // and 7 validators each sending a commit vote per round, this cap
-                    // could be saturated in seconds whenever a node's commit pipeline
-                    // briefly lagged. Once full, every new vote was silently dropped
-                    // until the next reset (epoch transition), and the dropped votes
-                    // were never re-broadcast — so any block whose votes were dropped
-                    // here could not aggregate a quorum locally, leaving the node
-                    // committing far behind for tens of minutes (observed on
-                    // gravity-sdk staging mainnet on 2026-05-04: core-1 lagged by an
-                    // entire epoch for ~18 minutes; in private mainnet ~76,000
-                    // dropped-vote WARNs accumulated across 3 LA validators in a few
-                    // hours, hidden by BFT 5/7 quorum slack).
-                    //
-                    // Bumping to 100k gives ~67 minutes of cache space at 25 votes/s,
-                    // which comfortably exceeds any realistic commit-pipeline lag,
-                    // while keeping the worst-case memory footprint to ~100 MB
-                    // (each entry: 32-byte block_id + up to ~7 vote entries of
-                    // ~130 bytes each). Combined with the existing reset() clear()
-                    // and pending_commit_proofs eviction, this removes the silent
-                    // drop path that has been the root cause of cluster-wide
-                    // commit-lag stalls.
-                    const MAX_COMMIT_VOTE_CACHE_ENTRIES: usize = 100_000;
-                    if self.commit_vote_cache.len() < MAX_COMMIT_VOTE_CACHE_ENTRIES ||
-                        self.commit_vote_cache.contains_key(&commit_info.id())
+                    // Cap the number of cached rounds to prevent OOM from unverified
+                    // future votes. When full, evict the oldest round first — those
+                    // votes are the least likely to still be needed.
+                    const MAX_COMMIT_VOTE_CACHE_ROUNDS: usize = 100_000;
+                    let round = commit_info.round();
+                    if self.commit_vote_cache.len() >= MAX_COMMIT_VOTE_CACHE_ROUNDS
+                        && !self.commit_vote_cache.contains_key(&round)
                     {
-                        self.commit_vote_cache
-                            .entry(commit_info.id())
-                            .or_default()
-                            .insert(HashValue::new(*author), vote.clone());
-                    } else {
-                        warn!(
-                            "Commit vote cache is full ({}), dropping vote from {}",
-                            MAX_COMMIT_VOTE_CACHE_ENTRIES, author
-                        );
+                        self.commit_vote_cache.pop_first();
                     }
+                    self.commit_vote_cache
+                        .entry(round)
+                        .or_default()
+                        .entry(commit_info.id())
+                        .or_default()
+                        .insert(HashValue::new(*author), vote.clone());
                 }
                 let target_block_id = vote.commit_info().id();
                 let current_cursor =
                     self.buffer.find_elem_by_key(*self.buffer.head_cursor(), target_block_id);
                 if current_cursor.is_some() {
                     let mut item = self.buffer.take(&current_cursor);
-                    self.add_signature_if_matched_from_cache(&mut item, &target_block_id);
+                    self.add_signature_if_matched_from_cache(&mut item, &target_block_id, commit_info.round());
                     let new_item = match item.add_signature_if_matched(vote) {
                         Ok(()) => {
                             let response =

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -687,8 +687,8 @@ impl BufferManager {
             };
             // For suffix blocks with reconfiguration flag, use the cached epoch end timestamp
             if let Some(timestamp) = self.end_epoch_timestamp.get().cloned() {
-                if block_info.timestamp_usecs() != timestamp
-                    && last_block.is_reconfiguration_suffix()
+                if block_info.timestamp_usecs() != timestamp &&
+                    last_block.is_reconfiguration_suffix()
                 {
                     epoch_info.epoch_start_timestamp_usecs = timestamp;
                 }
@@ -930,8 +930,8 @@ impl BufferManager {
     /// this function retries all the items until the signing root
     /// note that there might be other signed items after the signing root
     async fn rebroadcast_commit_votes_if_needed(&mut self) {
-        if self.previous_commit_time.elapsed()
-            < Duration::from_millis(COMMIT_VOTE_BROADCAST_INTERVAL_MS)
+        if self.previous_commit_time.elapsed() <
+            Duration::from_millis(COMMIT_VOTE_BROADCAST_INTERVAL_MS)
         {
             return;
         }
@@ -951,8 +951,8 @@ impl BufferManager {
                     // even after send ack, We'll try to re-initiate the
                     // broadcast after 30s.
                     Some((start_time, _)) => {
-                        start_time.elapsed()
-                            >= Duration::from_millis(COMMIT_VOTE_REBROADCAST_INTERVAL_MS)
+                        start_time.elapsed() >=
+                            Duration::from_millis(COMMIT_VOTE_REBROADCAST_INTERVAL_MS)
                     }
                 };
                 if re_broadcast {

--- a/aptos-core/consensus/src/pipeline/decoupled_execution_utils.rs
+++ b/aptos-core/consensus/src/pipeline/decoupled_execution_utils.rs
@@ -44,6 +44,7 @@ pub fn prepare_phases_and_buffer_manager(
     highest_committed_round: u64,
     consensus_observer_config: ConsensusObserverConfig,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
+    max_pending_rounds_in_commit_vote_cache: u64,
 ) -> (
     PipelinePhase<ExecutionSchedulePhase>,
     PipelinePhase<ExecutionWaitPhase>,
@@ -135,6 +136,7 @@ pub fn prepare_phases_and_buffer_manager(
             highest_committed_round,
             consensus_observer_config,
             consensus_publisher,
+            max_pending_rounds_in_commit_vote_cache,
         ),
     )
 }

--- a/aptos-core/consensus/src/pipeline/execution_client.rs
+++ b/aptos-core/consensus/src/pipeline/execution_client.rs
@@ -284,6 +284,7 @@ impl ExecutionProxyClient {
             highest_committed_round,
             consensus_observer_config,
             consensus_publisher,
+            self.consensus_config.max_pending_rounds_in_commit_vote_cache,
         );
 
         tokio::spawn(execution_schedule_phase.start());

--- a/aptos-core/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/aptos-core/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -162,6 +162,7 @@ pub async fn prepare_buffer_manager(
         0,
         ConsensusObserverConfig::default(),
         None,
+        100,
     );
 
     (

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -22,7 +22,7 @@ use tokio::{
     time::Instant,
 };
 
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use gaptos::api_types::{
     compute_res::{ComputeRes, TxnStatus},
@@ -1248,6 +1248,17 @@ impl BlockBufferManager {
         // Access via block_state_machine instead of separate mutex
         let latest_epoch_change_block_number = block_state_machine.latest_epoch_change_block_number;
         let old_epoch = block_state_machine.current_epoch;
+        let has_pending_epoch_change = latest_epoch_change_block_number != 0 ||
+            block_state_machine.next_epoch.is_some() ||
+            block_state_machine.epoch_change_block_info.is_some();
+
+        if !has_pending_epoch_change {
+            debug!(
+                "release_inflight_blocks: no pending epoch change, skip release. current_epoch: {}",
+                block_state_machine.current_epoch
+            );
+            return;
+        }
 
         // Update current_epoch from next_epoch if it exists
         if let Some(next_epoch) = block_state_machine.next_epoch.take() {


### PR DESCRIPTION
## Summary

Properly fix the staging-mainnet consensus stalls and the latent silent-vote-drop on private mainnet that PR #645 introduced. Replaces the original one-line cache-cap bump with a three-part architectural fix.

| Commit | What it fixes |
|---|---|
| [`4978b4b9`](https://github.com/Galxe/gravity-sdk/pull/701/commits/4978b4b9) **fix consensus commit vote cache draining** | Cache restructure from `block_id → author → vote` to `Round → block_id → author → vote`. Prevents fork-related drain leaks (votes for a sibling `block_id` were not being purged when one was committed). |
| [`a16dabe4`](https://github.com/Galxe/gravity-sdk/pull/701/commits/a16dabe4) **bound commit vote cache by configured round window** | Replaces the count cap (1 000 / 100 000) with a round-window cap `(highest_committed_round, highest_committed_round + max_pending_rounds)`. Adds NACK reply for out-of-window votes, completing the round-trip with the existing `rebroadcast_commit_votes_if_needed` retry path in gaptos. **Eliminates the silent-drop class of bugs** that PR #645 introduced. |
| [`30ab6909`](https://github.com/Galxe/gravity-sdk/pull/701/commits/30ab6909) **reset validator pipeline after fast forward sync** | Validator-only: after `BlockStore::sync_to_highest_commit_cert` fast-forwards, fully reset the execution_client + reload recovery_data + rebuild blockstore. Previously only `append_blocks_for_sync` was called, leaving buffer-manager / pipeline state stale and producing the epoch-stuck symptom we've seen on staging post-recovery. Non-validators retain old behaviour. |

Also bumps gaptos `16ed314 → e9544c8c` (the rev with `Identity::FromGcpSecret`, required by the cache-fix's new `max_pending_rounds_in_commit_vote_cache` config field defined in `aptos-config`).

## Why this replaces the original 1-line fix

The original commit (`f6aa3598`, `MAX_COMMIT_VOTE_CACHE_ENTRIES: 1000 → 100_000`) was a mitigation, not a root fix:
- Silent drop path remained — the cap could still be hit under longer pipeline lag.
- Static count cap is decoupled from consensus pace, so behavior degrades under burst traffic.
- No NACK feedback to senders, so `rebroadcast_commit_votes_if_needed` never fires for cap-evicted votes.
- Cache structure couldn't represent forks correctly (single block_id key), causing drain leaks.

The three commits above replace this with the canonical Aptos pattern: round-window cache + NACK reply + sender rebroadcast loop.

## Behaviour & config

New `ConsensusConfig` field (defined in gaptos `consensus_config.rs`):

```
max_pending_rounds_in_commit_vote_cache: u64
default: 100
```

At staging's ~5 rounds/sec this is a ~20 second cushion ahead of `highest_committed_round`. Votes outside the window get a NACK; the sender's existing `rebroadcast_commit_votes_if_needed` task retries periodically.

Worst-case memory: bounded by `max_pending_rounds × validator_count × forks_per_round × ~150 B` ≈ a few hundred KB. Far smaller than the 1 000 / 100 000 count caps.

## Evidence the original bug exists

Captured 2026-05-04 / 05 with the broken 1 000-cap binary:
- **Staging mainnet**: core-1 stuck `epoch=9 round=22017 last_committed_round=19643` for ~18 min until epoch advanced
- **Private mainnet**: core-1/2/3 accumulated **761 475** dropped-vote WARNs combined; ~81 drops/sec on core-3
- Chain only kept producing because BFT 5/7 quorum slack absorbed the per-vote drops

## Validation status

- ✅ Rust CI / Format / Clippy / Dependency Check on head `30ab6909`
- ⚠️ E2E in Docker — last green was on `24bce8e0` (5-6 15:59 UTC, 2 commits earlier). Has **not** run on the latest 3 commits. Re-trigger before merge.
- ✅ Tests added (`buffer_manager_tests.rs`)
- ❌ No human review approval yet (REVIEW_REQUIRED)

## Risk assessment for merge

| Concern | Mitigation |
|---|---|
| Default `max_pending_rounds = 100` rounds: at slower commit pace (e.g. 1 round/sec under stress), this is only ~100 s of cushion. Sustained pipeline stall longer than that → NACK + retry storms. | Sender already implements rebroadcast, so retries are not lost. Sustained stalls of >100 s are a separate liveness problem unrelated to this cache. Make value tunable via config (already done). |
| gaptos rev jump `16ed314 → e9544c8c` is broader than just the cache fix. main was previously on a *newer* state and got rolled back to `16ed314` for unrelated reasons; re-applying may reintroduce whatever issue caused that rollback. | Need maintainer of gaptos workspace to confirm the rollback rationale before merge, or bisect the gaptos diff. |
| Fast-forward-sync reset (commit 3) is invasive — touches `BlockStore::sync_to_highest_commit_cert` and adds a `storage.consensus_db().ledger_db.metadata_db().update_latest_ledger_info()` call before rebuild. | Validator-only path; non-validators unaffected. Behavior reproduces (and fixes) the staging epoch-stuck symptom. |
| E2E hasn't run on `30ab6909` head | Force a rerun of the E2E workflow before merging. |

## Recommended merge gate

1. Re-run `E2E Test in Docker` on head `30ab6909`. Block merge until green.
2. Get gaptos rev-bump rationale from author, OR diff `16ed314..e9544c8c` for unrelated changes that may regress something.
3. At least one approving review (`Lchangliang`, `AshinGau` reviews are dismissed by force-push).
4. Once merged, tag the new release commit and have SRE rebuild + redeploy to staging using the standard build path (LA rpc-1 + `cargo build -p gravity_node --features gcp-secret-manager --profile quick-release`).

## References

- Original 1-line mitigation discussion: this PR's commit `f6aa3598` (now superseded)
- Staging incident postmortem: see CLAUDE.md ($PR #701 section)
- Bug-introducing PR: #645 (`fix(consensus): improve error handling and remove unreachable panics`)
