### PR TITLE
fix(consensus): reject stale reconfig payloads to prevent epoch lock-in

### DIFF
--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -565,8 +565,25 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     async fn initiate_new_epoch(&mut self, proof: EpochChangeProof) -> anyhow::Result<()> {
         let ledger_info =
             proof.verify(self.epoch_state()).context("[EpochManager] Invalid EpochChangeProof")?;
+        // The proof's last LedgerInfo carries the new epoch's `next_epoch_state`; that target
+        // epoch is the smallest epoch we can legitimately advance to from this proof.
+        let target_epoch = ledger_info.ledger_info().next_block_epoch();
+        let current_epoch = self.epoch();
+        if target_epoch <= current_epoch {
+            // The proof is at-or-behind us. Skip rather than tearing down the current epoch's
+            // processors and re-running setup with stale state.
+            warn!(
+                current_epoch = current_epoch,
+                target_epoch = target_epoch,
+                "Skipping EpochChangeProof: target epoch is not ahead of current epoch",
+            );
+            counters::EPOCH_MANAGER_ISSUES_DETAILS
+                .with_label_values(&["initiate_new_epoch_target_not_ahead"])
+                .inc();
+            return Ok(());
+        }
         info!(
-            LogSchema::new(LogEvent::NewEpoch).epoch(ledger_info.ledger_info().next_block_epoch()),
+            LogSchema::new(LogEvent::NewEpoch).epoch(target_epoch),
             "Received verified epoch change",
         );
 
@@ -581,9 +598,36 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             .await
             .context(format!("[EpochManager] State sync to new epoch {}", ledger_info))
             .expect("Failed to sync to new epoch");
-        let reconfig_notification = monitor!("reconfig", self.await_reconfig_notification().await);
-        monitor!("reconfig", self.start_new_epoch(reconfig_notification.on_chain_configs).await);
-        Ok(())
+
+        // Wait for a reconfig notification that matches the proof's target epoch.
+        //
+        // Why the loop: `reconfig_events` may have stale notifications buffered from earlier
+        // in this process's lifetime (e.g. replayed by the event subscription on bootstrap).
+        // A stale payload with `epoch <= current_epoch` would otherwise re-initialize the
+        // current epoch's state machine -- the failure mode that locked Private Mainnet core-3
+        // at epoch 70 for 19h on 2026-05-05 (PR #701 mitigation context). Discard such
+        // payloads and keep awaiting the genuine notification for the target epoch.
+        loop {
+            let reconfig_notification =
+                monitor!("reconfig", self.await_reconfig_notification().await);
+            let payload_epoch = reconfig_notification.on_chain_configs.epoch();
+            if payload_epoch >= target_epoch {
+                monitor!(
+                    "reconfig",
+                    self.start_new_epoch(reconfig_notification.on_chain_configs).await
+                );
+                return Ok(());
+            }
+            warn!(
+                payload_epoch = payload_epoch,
+                target_epoch = target_epoch,
+                "Discarding stale reconfig notification while initiating new epoch; \
+                 continuing to wait for target_epoch or beyond",
+            );
+            counters::EPOCH_MANAGER_ISSUES_DETAILS
+                .with_label_values(&["stale_reconfig_during_initiate"])
+                .inc();
+        }
     }
 
     fn spawn_block_retrieval_task(
@@ -1127,7 +1171,30 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     }
 
     async fn start_new_epoch(&mut self, payload: OnChainConfigPayload<P>) {
-        info!("start to start new epoch for epoch: {:?}", payload.epoch());
+        let new_epoch = payload.epoch();
+
+        // Monotonic-epoch guard. `start_new_epoch` must only ever advance forward; reaccepting
+        // a payload for the current or an earlier epoch would re-initialize the local state
+        // machine for an epoch that was already left behind, which manifests on a stuck node
+        // as zombie RoundManager re-creation while EPOCH metric never advances.
+        //
+        // The bootstrap path enters here with `epoch_state = None`; let it pass.
+        // Otherwise, drop any payload whose epoch is not strictly greater than the current.
+        if let Some(ref current) = self.epoch_state {
+            if new_epoch <= current.epoch {
+                warn!(
+                    current_epoch = current.epoch,
+                    new_epoch = new_epoch,
+                    "Rejecting stale reconfig payload (new_epoch <= current_epoch)",
+                );
+                counters::EPOCH_MANAGER_ISSUES_DETAILS
+                    .with_label_values(&["start_new_epoch_stale_payload"])
+                    .inc();
+                return;
+            }
+        }
+
+        info!("start to start new epoch for epoch: {:?}", new_epoch);
         let validator_set: ValidatorSet =
             payload.get().expect("failed to get ValidatorSet from payload");
         info!("validator_set read from config storage is : {:?}", validator_set);


### PR DESCRIPTION
## Summary

A node whose reth EL stops advancing (e.g. just after recovering from the PR #645 cache_full bug while sitting on an epoch boundary) can permanently lock itself in epoch N, despite repeatedly receiving and \"successfully\" processing `EpochChangeProof` messages from peers.

This was observed on **Private Mainnet `core-3` on 2026-05-05**: stuck at `epoch=70` for 19 hours while the rest of the network advanced to `epoch=73`. Process did not panic, did not hang.

## Forensic evidence

```
process_epoch_proof_count          = 7    # initiate_new_epoch ran 7 times
consensus_duration_count{reconfig} = 14   # both await + start each ran 7 times
sync_to_count                      = 1    # short-circuit hit thereafter
aptos_state_sync_synced_version    = 0    # state-sync notifier no-op
aptos_consensus_epoch              = 70   # never advanced
```

7 EpochChangeProofs entered `initiate_new_epoch` and ran the whole pipeline (`shutdown_current_processor` → `sync_to` → `await_reconfig_notification` → `start_new_epoch`) but the EPOCH metric never moved.

## Root cause

Three independently-correct behaviors interact pathologically when a node is stuck:

**(1) `ExecutionProxy::sync_to`** ([state_computer.rs:660](https://github.com/Galxe/gravity-sdk/blob/main/aptos-core/consensus/src/state_computer.rs)) updates `latest_logical_time` to the sync target unconditionally after the state-sync notifier returns. With reth EL stuck and the aptos state-sync component effectively a no-op (`aptos_state_sync_synced_version=0`), subsequent `sync_to` calls short-circuit at the cache check without ever advancing the chain.

**(2) `await_reconfig_notification`** ([epoch_manager.rs:1911](https://github.com/Galxe/gravity-sdk/blob/main/aptos-core/consensus/src/epoch_manager.rs)) returns the next item in the `reconfig_events` channel without checking its epoch. With no fresh on-chain reconfig events arriving from the stuck reth EL, only stale ones (replayed during process bootstrap and never consumed) remain, all carrying `epoch <= current_epoch`.

**(3) `start_new_epoch`** ([epoch_manager.rs:1108](https://github.com/Galxe/gravity-sdk/blob/main/aptos-core/consensus/src/epoch_manager.rs)) accepts any payload and re-initializes the local state machine for whatever epoch the payload carries, with no monotonic check.

The result is a self-perpetuating loop on every EpochChangeProof received:

```
shutdown_current_processor (kills RoundManager + BufferManager)
  -> sync_to (no-op via short-circuit)
    -> await_reconfig_notification (returns stale epoch=N payload)
      -> start_new_epoch (re-initializes epoch N from scratch)
```

RoundManager is recreated for an epoch the network left long ago, EPOCH metric never moves, and `core-3` stays stuck.

## Fix

This patch addresses items **(2)** and **(3)**. Item (1) is a deeper change to `ExecutionProxy` and is left for a separate follow-up.

### `start_new_epoch` monotonic guard

Rejects payloads whose epoch is not strictly greater than `epoch_state.epoch`. The bootstrap path (`epoch_state = None`) is unaffected. A new metric label `start_new_epoch_stale_payload` and a warn log make the rejection observable.

### `initiate_new_epoch` target-aware retry loop

Derives `target_epoch` from the verified proof's last LedgerInfo (`next_block_epoch`). Returns early without shutting down processors if `target_epoch <= current_epoch` (new metric `initiate_new_epoch_target_not_ahead`). After `sync_to`, loops on `await_reconfig_notification`, discarding payloads with `epoch < target_epoch` (new metric `stale_reconfig_during_initiate`), until it receives a payload that advances the node.

## Behavior change for healthy nodes

**None.** `target_epoch > current_epoch` always holds during real epoch transitions, the loop exits on the first iteration, and the rejection guard never fires. The fix only changes behavior on stuck nodes (which today silently corrupt their state) and on nodes racing against buffered stale events.

## Verification

- [x] `cargo check -p aptos-consensus` clean
- [x] `cargo clippy -p aptos-consensus --no-deps` clean (no new warnings on the changed file)
- [ ] Build fix binary, deploy to a stuck Private Mainnet validator (or simulate a stuck state on a single-node test cluster).
- [ ] Confirm stuck node receiving EpochChangeProof advances correctly when reth EL produces fresh reconfig events for the target epoch.
- [ ] Confirm stuck node where reth never advances stays safely blocked inside `initiate_new_epoch`'s loop with `stale_reconfig_during_initiate` counter incrementing — strictly better than the current invisible re-initialization loop.

## Out of scope (separate follow-ups)

1. **`ExecutionProxy::sync_to` / state-sync notifier wiring** — `latest_logical_time` should only advance after the state-sync notifier confirms the underlying chain advanced. Today it advances unconditionally, enabling the short-circuit to mask a stuck reth EL.
2. **Commit-vote re-broadcast or pull-on-demand** in PR #701's description — orthogonal but related (PR #645 cache_full bug exposed this code path).

## Production context

PR #701 (cache_full mitigation) is currently deployed on Private Mainnet. `core-3` was the residual stuck node from before that deploy. This patch closes the recovery hole that prevented `core-3` from self-recovering after the fix binary was deployed; it should be considered a hard requirement before mainnet launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)