### PR TITLE
feat: add genesis-alloc-audit agent skill

### DIFF
--- a/.agents/security/audit_genesis.py
+++ b/.agents/security/audit_genesis.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Audit a Reth/geth-style genesis.json for dev/test credential leaks.
+
+Outputs a Markdown report to stdout. Exit code 1 on any FAIL, 0 otherwise
+(PASS or WARN-only).
+
+Usage:
+    python audit_genesis.py <genesis.json> [--expected-chain-id N]
+
+What it checks:
+  - chainId is not a known dev value (1337, 31337) and matches the
+    optional --expected-chain-id.
+  - alloc does not contain any address derived from the public Anvil /
+    Hardhat / Foundry test mnemonic ("test test test ... junk").
+  - The raw file text does not embed the well-known anvil default
+    private key or the test mnemonic anywhere (defends against stray
+    comments, metadata fields, leftover fixtures).
+  - No individual alloc balance is implausibly large (>= 2^160 wei),
+    which usually indicates a dev "infinite money" preset.
+
+Extending: edit the constants at the top of this file.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Anvil / Hardhat / Foundry default mnemonic:
+#   "test test test test test test test test test test test junk"
+# All ten accounts derived from this mnemonic have publicly-known private
+# keys. None of these addresses must ever appear in a mainnet alloc.
+DEV_ADDRESSES: dict[str, str] = {
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266": "anvil-mnemonic-#0",
+    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8": "anvil-mnemonic-#1",
+    "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC": "anvil-mnemonic-#2",
+    "0x90F79bf6EB2c4f870365E785982E1f101E93b906": "anvil-mnemonic-#3",
+    "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65": "anvil-mnemonic-#4",
+    "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc": "anvil-mnemonic-#5",
+    "0x976EA74026E726554dB657fA54763abd0C3a0aa9": "anvil-mnemonic-#6",
+    "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955": "anvil-mnemonic-#7",
+    "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f": "anvil-mnemonic-#8",
+    "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720": "anvil-mnemonic-#9",
+}
+
+# Strings that should never appear literally in a mainnet genesis file.
+DEV_LITERAL_STRINGS: list[tuple[str, str]] = [
+    (
+        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "anvil-default-privkey-#0",
+    ),
+    (
+        "test test test test test test test test test test test junk",
+        "anvil-foundry-test-mnemonic",
+    ),
+]
+
+DEV_CHAIN_IDS: set[int] = {1337, 31337}
+
+# 2^160 wei ~= 1.46e+30 ETH. Any per-account allocation at or above this
+# threshold is implausible for a real mainnet and almost always means a
+# dev-style "infinite money" preset. Reported as WARN (not FAIL) because
+# a system contract acting as the token mint may be intentionally large
+# and should be confirmed by a human, not auto-rejected.
+SUSPICIOUS_BALANCE_THRESHOLD_BITS = 160
+
+
+def parse_balance(b) -> int | None:
+    if b is None:
+        return None
+    if isinstance(b, int):
+        return b
+    s = str(b).strip()
+    try:
+        if s.lower().startswith("0x"):
+            return int(s, 16)
+        return int(s, 10)
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Audit a Reth/geth-style genesis.json for dev/test credential leaks."
+    )
+    ap.add_argument("genesis_path", type=Path)
+    ap.add_argument(
+        "--expected-chain-id",
+        type=int,
+        default=None,
+        help="Require chainId to equal this value (in addition to the dev-id blocklist).",
+    )
+    args = ap.parse_args()
+
+    raw = args.genesis_path.read_text()
+    g = json.loads(raw)
+
+    findings: list[tuple[str, str, str]] = []  # (severity, label, detail)
+
+    # --- chainId ---
+    chain_id = g.get("config", {}).get("chainId")
+    if chain_id in DEV_CHAIN_IDS:
+        findings.append(
+            ("FAIL", "Dev chainId", f"chainId={chain_id} is a known dev value")
+        )
+    if args.expected_chain_id is not None and chain_id != args.expected_chain_id:
+        findings.append(
+            (
+                "FAIL",
+                "ChainId mismatch",
+                f"expected {args.expected_chain_id}, got {chain_id}",
+            )
+        )
+
+    # --- alloc address blocklist ---
+    alloc = g.get("alloc", {}) or {}
+    alloc_lc = {a.lower(): a for a in alloc.keys()}
+    for dev_addr, source in DEV_ADDRESSES.items():
+        if dev_addr.lower() in alloc_lc:
+            real_key = alloc_lc[dev_addr.lower()]
+            bal = alloc[real_key].get("balance", "0x0")
+            findings.append(
+                (
+                    "FAIL",
+                    f"Dev address in alloc ({source})",
+                    f"{real_key} balance={bal}",
+                )
+            )
+
+    # --- literal string blocklist on raw file text ---
+    raw_lc = raw.lower()
+    for s, source in DEV_LITERAL_STRINGS:
+        if s.lower() in raw_lc:
+            findings.append(
+                (
+                    "FAIL",
+                    f"Dev secret literal in genesis ({source})",
+                    f"matched: {s[:48]}{'...' if len(s) > 48 else ''}",
+                )
+            )
+
+    # --- suspicious balance heuristic ---
+    threshold = 1 << SUSPICIOUS_BALANCE_THRESHOLD_BITS
+    for addr, entry in alloc.items():
+        bal = parse_balance(entry.get("balance"))
+        if bal is None:
+            continue
+        if bal >= threshold:
+            findings.append(
+                (
+                    "WARN",
+                    "Oversized balance (possible dev-style 'infinite money')",
+                    f"{addr} balance={entry.get('balance')} (~2^{bal.bit_length()} wei)",
+                )
+            )
+
+    # ---------- report ----------
+    print(f"## Genesis audit: `{args.genesis_path}`")
+    print()
+    print(f"- **chainId**: `{chain_id}`")
+    print(f"- **alloc entries**: {len(alloc)}")
+    print()
+    print("### alloc entries")
+    print()
+    print("| Address | Balance |")
+    print("|---|---|")
+    for addr in sorted(alloc.keys(), key=str.lower):
+        bal = alloc[addr].get("balance", "0x0")
+        print(f"| `{addr}` | `{bal}` |")
+    print()
+    print("### Findings")
+    print()
+
+    if not findings:
+        print("PASS - no blocklist hits, no suspicious balances.")
+        return 0
+
+    sev_order = {"FAIL": 0, "WARN": 1}
+    findings.sort(key=lambda f: sev_order.get(f[0], 99))
+
+    for sev, label, detail in findings:
+        print(f"- **{sev}** - {label}: {detail}")
+
+    fails = sum(1 for s, _, _ in findings if s == "FAIL")
+    warns = sum(1 for s, _, _ in findings if s == "WARN")
+    if fails:
+        verdict = "FAIL"
+    elif warns:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+    print()
+    print(f"**Verdict**: {verdict} ({fails} FAIL, {warns} WARN)")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/security/genesis-alloc-audit.md
+++ b/.agents/security/genesis-alloc-audit.md
@@ -1,0 +1,58 @@
+---
+description: How to audit a Reth/geth-style genesis.json for dev/test credential leaks (Anvil mnemonic addresses in alloc, dev chainId, suspicious "infinite money" balances) before publishing it as a mainnet artifact
+---
+
+# Genesis Alloc Audit
+
+Run a deterministic, blocklist-based audit of an EL `genesis.json` before publishing it as a mainnet artifact. The goal is to catch the most common ways a genesis leaks dev credentials:
+
+- An Anvil/Hardhat-derived account in `alloc` (those private keys are globally known).
+- `chainId` left at the dev default (`1337`, `31337`).
+- The public test mnemonic or privkey embedded literally as a string in the file.
+- An "infinite money" balance preset that is implausible for any real allocation.
+
+This skill is the EL-side check only. CL waypoint, validator BLS keys, PoP, and onchain config (`epoch_interval_micros`, etc.) live in different files and are out of scope — call those out as not-covered when reporting.
+
+The companion script is `audit_genesis.py` in this directory.
+
+## How to run
+
+```bash
+python3 .agents/security/audit_genesis.py <path-to-genesis.json> [--expected-chain-id N]
+```
+
+Exit code is `1` if any **FAIL** finding is produced (CI-friendly), `0` otherwise (PASS or WARN-only).
+
+The script writes a Markdown report to stdout with:
+
+1. **Header** — genesis path, chainId, alloc entry count.
+2. **alloc table** — every address + balance, sorted by lower-case address. The script cannot know which custom addresses are legitimate; the human reviewer does. List them so the reviewer can scan.
+3. **Findings** — every blocklist hit, sorted FAIL-then-WARN, plus a final verdict line.
+
+## What it checks (and why)
+
+| Check | Why it matters |
+|---|---|
+| `chainId in {1337, 31337}` | Defaults from the `genesis-tool` template and Anvil. A "mainnet" artifact with a dev chainId is an immediate sign that the ceremony input was wrong. |
+| `chainId == --expected-chain-id` (optional) | Belt-and-suspenders if the team has agreed on a specific mainnet chainId in advance. Pass it on the CLI to enforce. |
+| Anvil/Hardhat default first-10 addresses present in `alloc` | The seed mnemonic `test test test ... junk` is public. Any address derived from it has a globally known privkey — funding it on mainnet is equivalent to setting fire to the tokens AND letting the burner spam transactions from a pre-funded account. |
+| Anvil default privkey or test mnemonic appearing as a raw string anywhere in the file | Catches sneaky cases like leftover comments, metadata fields, or stray test fixtures stuck inside the JSON blob. |
+| Balance >= 2^160 wei | Legitimate per-account allocations top out near total token supply (typically << 2^100 wei). Beyond 2^160 wei (~10^30 ETH) almost always indicates a dev "infinite money" preset. WARN, not FAIL — a system contract that acts as the token mint may be intentionally large, and a human reviewer should sign off rather than the script auto-rejecting. |
+
+## Updating the blocklist
+
+Constants live at the top of `audit_genesis.py`:
+
+- `DEV_ADDRESSES` — dict of `address -> source-tag`. To add a new dev mnemonic family, derive its first ~10 accounts and append, with a `source` tag pointing at where the mnemonic originates (e.g. `foundry-default-#3`, `hardhat-mnemonic-#0`). The `source` tag shows up in finding output and dramatically speeds up triage.
+- `DEV_LITERAL_STRINGS` — list of `(string, source-tag)`. Any literal that should never appear in a mainnet genesis (mnemonics, privkeys, well-known test-vector strings).
+- `DEV_CHAIN_IDS` — set of integer chain IDs known to be dev/test.
+- `SUSPICIOUS_BALANCE_THRESHOLD_BITS` — bitsize cutoff for the oversized-balance WARN.
+
+Inline constants (rather than a separate JSON data file) keep this a single self-contained script with no extra moving parts. If the blocklist ever grows past a couple of dozen entries, splitting it out is reasonable.
+
+## What this skill does NOT do
+
+- Not a static analyzer for predeployed bytecode. If `alloc[X].code` is custom contract code, this script won't audit the contract; that needs a separate review.
+- Not a CL audit. Validator BLS keys, PoP, onchain configs are out of scope.
+- Not a tokenomics / balance-sum checker. Only flags absurd *individual* balances.
+- Doesn't validate EIP-55 checksumming (alloc keys often arrive lower-cased after `jq`-style processing, and EIP-55 is not a security concern here).


### PR DESCRIPTION
## Summary

- New agent skill at `.agents/security/genesis-alloc-audit.md` + `audit_genesis.py`: a deterministic, blocklist-based audit of an EL `genesis.json` to catch the most common ways a "mainnet" artifact leaks dev credentials.
- Checks: Anvil/Hardhat mnemonic-derived addresses in `alloc`, dev `chainId` (1337/31337), public test mnemonic / privkey embedded as a raw string, and implausible "infinite money" balances (`>= 2^160 wei`).
- CLI: `python3 .agents/security/audit_genesis.py <genesis.json> [--expected-chain-id N]`. Exit `1` on any FAIL (CI-friendly), `0` otherwise.

Scope is intentionally narrow: **EL only**. CL waypoint, validator BLS keys / PoP, and onchain configs (`epoch_interval_micros`, etc.) are out of scope and called out as not-covered in the doc.

Format follows the existing `.agents/` convention (`description`-only YAML frontmatter, `.md` doc + sibling helper script — same shape as `.agents/benchmark/` and `.agents/workflows/`).

## Test plan

- [x] Ran against a known-positive genesis containing Anvil default account #0 — produced `FAIL` on `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` with source tag `anvil-mnemonic-#0`, plus `WARN` on the oversized `~2^254 wei` balance, exit code `1`.
- [x] Verified the script also flags the `0x0000…01625f0000` system-contract pre-allocation (`~2^253 wei`) as `WARN` (not `FAIL`) — intentional, since legitimate token-mint placeholders may be large and need human sign-off rather than auto-rejection.
- [ ] Reviewer: run the script against `genesis/testnet/genesis.json` to confirm no false positives on a real (clean) artifact.