### PR TITLE
fix(consensus): harden fast-forward recovery pipeline

### DIFF
--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -208,7 +208,23 @@ impl BlockStore {
         if let Some(tc) = sync_info.highest_2chain_timeout_cert() {
             self.insert_2chain_timeout_certificate(Arc::new(tc.clone()))?;
         }
+        self.replay_ordered_path_if_needed().await?;
         BLOCK_SYNC_GAUGE.set_with(&[], 0);
+        Ok(())
+    }
+
+    async fn replay_ordered_path_if_needed(&self) -> anyhow::Result<()> {
+        let ordered_root_round = self.ordered_root().round();
+        let highest_ordered_cert = self.highest_ordered_cert().as_ref().clone();
+        let highest_ordered_round = highest_ordered_cert.commit_info().round();
+        if ordered_root_round < highest_ordered_round {
+            info!(
+                "[BlockStore] replay ordered path after adding certs: ordered_root_round={}, highest_ordered_round={}",
+                ordered_root_round,
+                highest_ordered_round,
+            );
+            self.send_for_execution(highest_ordered_cert, false, None).await?;
+        }
         Ok(())
     }
 

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -83,6 +83,44 @@ pub enum NeedFetchResult {
 }
 
 impl BlockStore {
+    fn is_epoch_change_li_boundary_locally_committed(&self, li: &LedgerInfoWithSignatures) -> bool {
+        let commit_root = self.commit_root();
+        // For non-blocking epoch changes, the epoch-change LI may commit a suffix block after the
+        // actual epoch boundary. Recovery intentionally filters out those suffix blocks and only
+        // commits up to `epoch_block_info`, so checking against `li.commit_info()` would prevent us
+        // from sending the epoch-change proof and leave execution waiting for the first suffix
+        // block.
+        let epoch_block_info = li.commit_info().epoch_block_info();
+        let committed = if let Some(epoch_info) = epoch_block_info {
+            match commit_root.block().block_number() {
+                Some(root_number) if root_number > epoch_info.block_number => true,
+                Some(root_number) if root_number == epoch_info.block_number => {
+                    commit_root.id() == epoch_info.block_id
+                }
+                _ => false,
+            }
+        } else {
+            commit_root.id() == li.commit_info().id()
+        };
+
+        if !committed {
+            warn!(
+                "[FastForwardSync] skip epoch change proof because local commit root has not reached \
+                 epoch-change boundary: boundary_block_id={}, boundary_block_number={:?}, \
+                 local_root_id={}, local_root_block_number={:?}, local_root_round={}",
+                epoch_block_info
+                    .map(|info| info.block_id)
+                    .unwrap_or_else(|| li.commit_info().id()),
+                epoch_block_info.map(|info| info.block_number),
+                commit_root.id(),
+                commit_root.block().block_number(),
+                commit_root.round(),
+            );
+        }
+
+        committed
+    }
+
     /// Check if we're far away from this ledger info and need to sync.
     /// This ensures that the block referred by the ledger info is not in buffer manager.
     pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
@@ -423,11 +461,14 @@ impl BlockStore {
 
         self.rebuild(root, blocks, quorum_certs).await;
 
-        if ledger_infos.last().unwrap().ledger_info().ends_epoch() {
+        let latest_li = ledger_infos.last().unwrap();
+        if latest_li.ledger_info().ends_epoch() &&
+            self.is_epoch_change_li_boundary_locally_committed(latest_li)
+        {
             retriever
                 .network
                 .send_epoch_change(EpochChangeProof::new(
-                    vec![ledger_infos.last().unwrap().clone()],
+                    vec![latest_li.clone()],
                     /* more = */ false,
                 ))
                 .await;
@@ -532,6 +573,14 @@ impl BlockStore {
         if !self.is_validator {
             self.append_blocks_for_sync(blocks, quorum_certs).await;
         } else {
+            let target = highest_commit_cert.ledger_info();
+            info!(
+                "[FastForwardSync] validator reset and rebuild to commit round {}, block {}",
+                target.commit_info().round(),
+                target.commit_info().id(),
+            );
+            self.execution_client.reset(target).await?;
+
             let (root, blocks, quorum_certs) = match self
                 .storage
                 .start(false, ledger_infos.last().unwrap().ledger_info().epoch())
@@ -545,46 +594,18 @@ impl BlockStore {
 
             self.rebuild(root, blocks, quorum_certs).await;
         }
-        if ledger_infos.last().unwrap().ledger_info().ends_epoch() {
+        let latest_li = ledger_infos.last().unwrap();
+        if latest_li.ledger_info().ends_epoch() &&
+            self.is_epoch_change_li_boundary_locally_committed(latest_li)
+        {
             retriever
                 .network
                 .send_epoch_change(EpochChangeProof::new(
-                    vec![ledger_infos.last().unwrap().clone()],
+                    vec![latest_li.clone()],
                     /* more = */ false,
                 ))
                 .await;
         }
-        Ok(())
-    }
-
-    async fn apply_fast_forward_sync(
-        &self,
-        target_commit_cert: &WrappedLedgerInfo,
-        blocks: Vec<(Block, Option<u64>, Option<Vec<u8>>)>,
-        quorum_certs: Vec<QuorumCert>,
-    ) -> anyhow::Result<()> {
-        if !self.is_validator {
-            self.append_blocks_for_sync(blocks, quorum_certs).await;
-            return Ok(());
-        }
-
-        let target = target_commit_cert.ledger_info();
-        info!(
-            "apply_fast_forward_sync: validator reset and rebuild to commit round {}, block {}",
-            target.commit_info().round(),
-            target.commit_info().id(),
-        );
-        self.execution_client.reset(target).await?;
-
-        let (root, blocks, quorum_certs) =
-            match self.storage.start(false, target.ledger_info().epoch()).await {
-                LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
-                _ => panic!("Failed to construct recovery data after fast forward sync"),
-            }
-            .take();
-
-        self.storage.consensus_db().ledger_db.metadata_db().update_latest_ledger_info();
-        self.rebuild(root, blocks, quorum_certs).await;
         Ok(())
     }
 
@@ -897,22 +918,22 @@ impl BlockStore {
             id = parent_id;
         }
 
-        // Step 3: Collect ledger infos for the retrieved blocks
-        // Calculate the block number range to fetch ledger infos
-        let mut lower = 0;
-        let mut upper = 0;
-        for (block, _, _) in &blocks {
-            if let Some(block_number) = block.block_number() {
-                // Set upper to the first block number + 1 (exclusive range)
-                if upper == 0 {
-                    upper = block_number + 1;
-                }
-                // Update lower to the smallest block number
-                lower = block_number;
-            }
-        }
+        // Step 3: Collect ledger infos for the range covered by the returned QCs.
+        // Block retrieval walks from a block to its parents and returns each block's own QC.
+        // The first returned block's QC usually commits its parent, not the first block itself,
+        // so returning LIs up to the first block can make the consumer observe an epoch-change
+        // LI before it has enough QCs to recover that epoch-change block.
+        let block_numbers_by_id = blocks
+            .iter()
+            .filter_map(|(block, _, _)| block.block_number().map(|num| (block.id(), num)))
+            .collect::<std::collections::HashMap<_, _>>();
+        let committed_block_numbers = quorum_certs
+            .iter()
+            .filter_map(|qc| block_numbers_by_id.get(&qc.commit_info().id()).copied());
+        let lower = committed_block_numbers.clone().min().unwrap_or(0);
+        let upper = committed_block_numbers.max().map(|num| num + 1).unwrap_or(0);
 
-        // Fetch ledger infos for the block number range
+        // Fetch ledger infos only for blocks that this response's QCs can commit.
         let mut ledger_infos = vec![];
         if upper != 0 {
             ledger_infos = self

--- a/aptos-core/consensus/src/gravity_state_computer.rs
+++ b/aptos-core/consensus/src/gravity_state_computer.rs
@@ -104,7 +104,7 @@ impl BlockExecutorTrait for GravityBlockExecutor {
             }
             let epoch = ledger_info_with_sigs.ledger_info().epoch();
             self.runtime.block_on(async move {
-                let mut persist_notifiers = get_block_buffer_manager()
+                let persist_notifiers = get_block_buffer_manager()
                     .set_commit_blocks(
                         block_ids
                             .into_iter()
@@ -122,8 +122,14 @@ impl BlockExecutorTrait for GravityBlockExecutor {
                             .collect(),
                         epoch,
                     )
-                    .await
-                    .expect("Failed to set commit blocks in BlockBufferManager");
+                    .await;
+                let mut persist_notifiers = match persist_notifiers {
+                    Ok(persist_notifiers) => persist_notifiers,
+                    Err(e) => {
+                        error!("Failed to set commit blocks in BlockBufferManager: {:?}", e);
+                        return;
+                    }
+                };
                 for notifier in persist_notifiers.iter_mut() {
                     if notifier.recv().await.is_none() {
                         warn!("persist_notifier channel closed in commit_blocks");
@@ -179,7 +185,7 @@ impl BlockExecutorTrait for GravityBlockExecutor {
         }
 
         self.runtime.block_on(async move {
-            let mut persist_notifiers = get_block_buffer_manager()
+            let persist_notifiers = get_block_buffer_manager()
                 .set_commit_blocks(
                     block_ids
                         .into_iter()
@@ -196,8 +202,14 @@ impl BlockExecutorTrait for GravityBlockExecutor {
                         .collect(),
                     epoch,
                 )
-                .await
-                .expect("Failed to set commit blocks in BlockBufferManager");
+                .await;
+            let mut persist_notifiers = match persist_notifiers {
+                Ok(persist_notifiers) => persist_notifiers,
+                Err(e) => {
+                    error!("Failed to set commit blocks in BlockBufferManager: {:?}", e);
+                    return;
+                }
+            };
             for notifier in persist_notifiers.iter_mut() {
                 if notifier.recv().await.is_none() {
                     warn!("persist_notifier channel closed in commit_ledger");

--- a/aptos-core/consensus/src/gravity_state_computer.rs
+++ b/aptos-core/consensus/src/gravity_state_computer.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_executor::block_executor::BlockExecutor;
-use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResult};
+use aptos_executor_types::{BlockExecutorTrait, ExecutorError, ExecutorResult, StateComputeResult};
 use block_buffer_manager::{block_buffer_manager::BlockHashRef, get_block_buffer_manager};
 use gaptos::{
     api_types::u256_define::BlockId,
@@ -104,7 +104,7 @@ impl BlockExecutorTrait for GravityBlockExecutor {
             }
             let epoch = ledger_info_with_sigs.ledger_info().epoch();
             self.runtime.block_on(async move {
-                let persist_notifiers = get_block_buffer_manager()
+                let mut persist_notifiers = get_block_buffer_manager()
                     .set_commit_blocks(
                         block_ids
                             .into_iter()
@@ -122,20 +122,19 @@ impl BlockExecutorTrait for GravityBlockExecutor {
                             .collect(),
                         epoch,
                     )
-                    .await;
-                let mut persist_notifiers = match persist_notifiers {
-                    Ok(persist_notifiers) => persist_notifiers,
-                    Err(e) => {
-                        error!("Failed to set commit blocks in BlockBufferManager: {:?}", e);
-                        return;
-                    }
-                };
+                    .await
+                    .map_err(|e| {
+                        ExecutorError::internal_err(format!(
+                            "Failed to set commit blocks in BlockBufferManager: {e:?}"
+                        ))
+                    })?;
                 for notifier in persist_notifiers.iter_mut() {
                     if notifier.recv().await.is_none() {
                         warn!("persist_notifier channel closed in commit_blocks");
                     }
                 }
-            });
+                Ok::<(), ExecutorError>(())
+            })?;
         }
         Ok(())
     }
@@ -185,7 +184,7 @@ impl BlockExecutorTrait for GravityBlockExecutor {
         }
 
         self.runtime.block_on(async move {
-            let persist_notifiers = get_block_buffer_manager()
+            let mut persist_notifiers = get_block_buffer_manager()
                 .set_commit_blocks(
                     block_ids
                         .into_iter()
@@ -202,14 +201,12 @@ impl BlockExecutorTrait for GravityBlockExecutor {
                         .collect(),
                     epoch,
                 )
-                .await;
-            let mut persist_notifiers = match persist_notifiers {
-                Ok(persist_notifiers) => persist_notifiers,
-                Err(e) => {
-                    error!("Failed to set commit blocks in BlockBufferManager: {:?}", e);
-                    return;
-                }
-            };
+                .await
+                .map_err(|e| {
+                    ExecutorError::internal_err(format!(
+                        "Failed to set commit blocks in BlockBufferManager: {e:?}"
+                    ))
+                })?;
             for notifier in persist_notifiers.iter_mut() {
                 if notifier.recv().await.is_none() {
                     warn!("persist_notifier channel closed in commit_ledger");
@@ -220,7 +217,8 @@ impl BlockExecutorTrait for GravityBlockExecutor {
             {
                 error!("Failed to save_transactions in commit_ledger: {:?}", e);
             }
-        });
+            Ok::<(), ExecutorError>(())
+        })?;
         Ok(())
     }
 }

--- a/aptos-core/consensus/src/persistent_liveness_storage.rs
+++ b/aptos-core/consensus/src/persistent_liveness_storage.rs
@@ -471,8 +471,15 @@ impl PersistentLivenessStorage for StorageWriteProxy {
                 Err(_) => false,
             };
 
-        // Get ledger_info based on the check result
-        let latest_ledger_info = if is_last_block_of_prev_epoch {
+        // Recovery root must match the execution layer's committed height. If execution has not
+        // committed any block yet, the ledger root must be genesis even if metadata DB has newer
+        // LI.
+        let latest_ledger_info = if latest_block_number == 0 {
+            LedgerInfoWithSignatures::genesis(
+                *ACCUMULATOR_PLACEHOLDER_HASH,
+                self.db.validator_set(),
+            )
+        } else if is_last_block_of_prev_epoch {
             // If it's the last block of previous epoch, get ledger_info from LedgerInfoSchema
             match (&*ledger_db_arc).get::<LedgerInfoSchema>(&latest_block_number) {
                 Ok(Some(ledger_info)) => {
@@ -482,9 +489,18 @@ impl PersistentLivenessStorage for StorageWriteProxy {
                     );
                     ledger_info
                 }
-                Ok(None) | Err(_) => {
-                    // Fallback to original method if not found in schema
-                    warn!("LedgerInfo not found in LedgerInfoSchema for block {}, falling back to aptos_db", latest_block_number);
+                Ok(None) => {
+                    warn!(
+                        "LedgerInfo not found in LedgerInfoSchema for block {}, falling back to aptos_db",
+                        latest_block_number
+                    );
+                    self.aptos_db.get_latest_ledger_info().unwrap()
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to read LedgerInfoSchema for block {}: {:?}, falling back to aptos_db",
+                        latest_block_number, e
+                    );
                     self.aptos_db.get_latest_ledger_info().unwrap()
                 }
             }

--- a/aptos-core/consensus/src/pipeline/execution_client.rs
+++ b/aptos-core/consensus/src/pipeline/execution_client.rs
@@ -30,7 +30,7 @@ use aptos_consensus_types::{
     common::{Author, Round},
     pipelined_block::PipelinedBlock,
 };
-use aptos_executor_types::ExecutorResult;
+use aptos_executor_types::{ExecutorError, ExecutorResult};
 use fail::fail_point;
 use futures::{
     channel::{mpsc::UnboundedSender, oneshot},
@@ -361,8 +361,10 @@ impl TExecutionClient for ExecutionProxyClient {
         let mut execute_tx = match self.handle.read().execute_tx.clone() {
             Some(tx) => tx,
             None => {
-                debug!("Failed to send to buffer manager, maybe epoch ends");
-                return Ok(());
+                warn!("Failed to send to buffer manager, execute channel is missing");
+                return Err(ExecutorError::internal_err(
+                    "Failed to send to buffer manager, execute channel is missing",
+                ));
             }
         };
 
@@ -382,7 +384,10 @@ impl TExecutionClient for ExecutionProxyClient {
             .await
             .is_err()
         {
-            debug!("Failed to send to buffer manager, maybe epoch ends");
+            warn!("Failed to send to buffer manager, execute channel is closed");
+            return Err(ExecutorError::internal_err(
+                "Failed to send to buffer manager, execute channel is closed",
+            ));
         }
         Ok(())
     }

--- a/aptos-core/consensus/src/pipeline/execution_client.rs
+++ b/aptos-core/consensus/src/pipeline/execution_client.rs
@@ -30,7 +30,7 @@ use aptos_consensus_types::{
     common::{Author, Round},
     pipelined_block::PipelinedBlock,
 };
-use aptos_executor_types::{ExecutorError, ExecutorResult};
+use aptos_executor_types::ExecutorResult;
 use fail::fail_point;
 use futures::{
     channel::{mpsc::UnboundedSender, oneshot},
@@ -362,9 +362,7 @@ impl TExecutionClient for ExecutionProxyClient {
             Some(tx) => tx,
             None => {
                 warn!("Failed to send to buffer manager, execute channel is missing");
-                return Err(ExecutorError::internal_err(
-                    "Failed to send to buffer manager, execute channel is missing",
-                ));
+                return Ok(());
             }
         };
 
@@ -385,9 +383,7 @@ impl TExecutionClient for ExecutionProxyClient {
             .is_err()
         {
             warn!("Failed to send to buffer manager, execute channel is closed");
-            return Err(ExecutorError::internal_err(
-                "Failed to send to buffer manager, execute channel is closed",
-            ));
+            return Ok(());
         }
         Ok(())
     }

--- a/aptos-core/consensus/src/rand/rand_gen/block_queue.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/block_queue.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use aptos_consensus_types::{common::Round, pipelined_block::PipelinedBlock};
 use gaptos::{
-    aptos_logger::warn,
+    aptos_logger::error,
     aptos_reliable_broadcast::DropGuard,
     aptos_types::randomness::{FullRandMetadata, Randomness},
 };
@@ -106,7 +106,7 @@ impl BlockQueue {
             .highest_dequeued_round
             .is_some_and(|highest_dequeued_round| first_round <= highest_dequeued_round)
         {
-            warn!(
+            error!(
                 "Dropping stale ordered blocks pushed to rand manager: first_round={}, last_round={}, highest_dequeued_round={}",
                 first_round,
                 last_round,

--- a/aptos-core/consensus/src/rand/rand_gen/block_queue.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/block_queue.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use aptos_consensus_types::{common::Round, pipelined_block::PipelinedBlock};
 use gaptos::{
+    aptos_logger::warn,
     aptos_reliable_broadcast::DropGuard,
     aptos_types::randomness::{FullRandMetadata, Randomness},
 };
@@ -43,6 +44,11 @@ impl QueueItem {
     #[allow(clippy::unwrap_used)]
     pub fn first_round(&self) -> u64 {
         self.blocks().first().unwrap().block().round()
+    }
+
+    #[allow(clippy::unwrap_used)]
+    pub fn last_round(&self) -> u64 {
+        self.blocks().last().unwrap().block().round()
     }
 
     pub fn offset(&self, round: Round) -> usize {
@@ -82,10 +88,11 @@ impl QueueItem {
 /// Maintain ordered blocks that have pending randomness
 pub struct BlockQueue {
     queue: BTreeMap<Round, QueueItem>,
+    highest_dequeued_round: Option<Round>,
 }
 impl BlockQueue {
     pub fn new() -> Self {
-        Self { queue: BTreeMap::new() }
+        Self { queue: BTreeMap::new(), highest_dequeued_round: None }
     }
 
     pub fn queue(&self) -> &BTreeMap<Round, QueueItem> {
@@ -93,10 +100,25 @@ impl BlockQueue {
     }
 
     pub fn push_back(&mut self, item: QueueItem) {
+        let first_round = item.first_round();
+        let last_round = item.last_round();
+        if self
+            .highest_dequeued_round
+            .is_some_and(|highest_dequeued_round| first_round <= highest_dequeued_round)
+        {
+            warn!(
+                "Dropping stale ordered blocks pushed to rand manager: first_round={}, last_round={}, highest_dequeued_round={}",
+                first_round,
+                last_round,
+                self.highest_dequeued_round.unwrap_or_default(),
+            );
+            return;
+        }
+
         for block in item.blocks() {
             observe_block(block.timestamp_usecs(), BlockStage::RAND_ENTER);
         }
-        assert!(self.queue.insert(item.first_round(), item).is_none());
+        assert!(self.queue.insert(first_round, item).is_none());
     }
 
     /// Dequeue all ordered blocks prefix that have randomness
@@ -110,6 +132,10 @@ impl BlockQueue {
                 for block in item.blocks() {
                     observe_block(block.timestamp_usecs(), BlockStage::RAND_READY);
                 }
+                self.highest_dequeued_round = Some(
+                    self.highest_dequeued_round
+                        .map_or(item.last_round(), |round| round.max(item.last_round())),
+                );
                 let QueueItem { ordered_blocks, .. } = item;
                 debug_assert!(ordered_blocks
                     .ordered_blocks
@@ -217,5 +243,24 @@ mod tests {
         assert_eq!(queue.dequeue_rand_ready_prefix().len(), 2);
 
         assert_eq!(queue.queue.len(), 1);
+    }
+
+    #[test]
+    fn test_block_queue_drops_stale_dequeued_round() {
+        let mut queue = BlockQueue::new();
+        queue.push_back(QueueItem::new(create_ordered_blocks(vec![1]), None));
+        assert_eq!(queue.queue.len(), 1);
+
+        assert!(queue.set_randomness(1, Randomness::default()));
+        assert_eq!(queue.dequeue_rand_ready_prefix().len(), 1);
+        assert_eq!(queue.queue.len(), 0);
+
+        queue.push_back(QueueItem::new(create_ordered_blocks(vec![1]), None));
+        assert_eq!(queue.queue.len(), 0);
+
+        queue.push_back(QueueItem::new(create_ordered_blocks(vec![2]), None));
+        assert_eq!(queue.queue.len(), 1);
+        assert!(queue.set_randomness(2, Randomness::default()));
+        assert_eq!(queue.dequeue_rand_ready_prefix().len(), 1);
     }
 }

--- a/aptos-core/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/rand_manager.rs
@@ -191,7 +191,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
             ResetSignal::TargetRound(round) => round,
         };
         self.block_queue = BlockQueue::new();
-        self.rand_store.lock().update_highest_known_round(target_round);
+        self.rand_store.lock().reset_to_round(target_round);
         self.stop = matches!(signal, ResetSignal::Stop);
         let _ = tx.send(ResetAck::default());
     }

--- a/aptos-core/consensus/src/rand/rand_gen/rand_store.rs
+++ b/aptos-core/consensus/src/rand/rand_gen/rand_store.rs
@@ -222,6 +222,14 @@ impl<S: TShare> RandStore<S> {
         self.highest_known_round = std::cmp::max(self.highest_known_round, round);
     }
 
+    pub fn reset_to_round(&mut self, target_round: Round) {
+        self.rand_map.retain(|round, _| *round <= target_round);
+        if let Some(fast_rand_map) = self.fast_rand_map.as_mut() {
+            fast_rand_map.retain(|round, _| *round <= target_round);
+        }
+        self.update_highest_known_round(target_round);
+    }
+
     pub fn add_rand_metadata(&mut self, rand_metadata: FullRandMetadata) {
         let rand_item = self
             .rand_map
@@ -506,6 +514,42 @@ mod tests {
         for share in ctxt.authors[1..6]
             .iter()
             .map(|author| create_share(metadata_2[0].metadata.clone(), *author))
+        {
+            rand_store.add_share(share, PathType::Slow).unwrap();
+        }
+        assert!(decision_rx.next().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_rand_store_reset_to_round_allows_reaggregation() {
+        let ctxt = TestContext::new(vec![100; 7], 0);
+        let (decision_tx, mut decision_rx) = unbounded();
+        let mut rand_store = RandStore::new(
+            ctxt.target_epoch,
+            ctxt.authors[0],
+            ctxt.rand_config.clone(),
+            None,
+            decision_tx,
+        );
+        let metadata = FullRandMetadata::new(ctxt.target_epoch, 2, HashValue::zero(), 1700000000);
+
+        for share in
+            ctxt.authors[0..5].iter().map(|author| create_share(metadata.metadata.clone(), *author))
+        {
+            rand_store.add_share(share, PathType::Slow).unwrap();
+        }
+        rand_store.add_rand_metadata(metadata.clone());
+        assert!(decision_rx.next().await.is_some());
+        assert!(rand_store.get_all_shares_authors(metadata.round()).is_none());
+
+        rand_store.reset_to_round(1);
+        rand_store.add_rand_metadata(metadata.clone());
+        assert!(rand_store
+            .get_all_shares_authors(metadata.round())
+            .is_some_and(|authors| authors.is_empty()));
+
+        for share in
+            ctxt.authors[0..5].iter().map(|author| create_share(metadata.metadata.clone(), *author))
         {
             rand_store.add_share(share, PathType::Slow).unwrap();
         }

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -194,6 +194,15 @@ impl BlockStateMachine {
             .is_some_and(|cache| block_num > cache.epoch_block_info.block_number)
     }
 
+    /// Returns true when a commit notification belongs to an old in-flight block that
+    /// was intentionally dropped during epoch-change cleanup.
+    fn is_stale_commit_after_epoch_change(&self, epoch: u64, block_num: u64) -> bool {
+        epoch < self.current_epoch ||
+            self.epoch_change_block_info.as_ref().is_some_and(|cache| {
+                epoch == self.current_epoch && block_num > cache.epoch_block_info.block_number
+            })
+    }
+
     /// Record a profile measurement for the given block key.
     fn record_profile(&mut self, key: BlockKey, f: impl FnOnce(&mut BlockProfile)) {
         f(self.profile.entry(key).or_default());
@@ -1086,6 +1095,18 @@ impl BlockBufferManager {
                     }
                 }
             } else {
+                if block_state_machine
+                    .is_stale_commit_after_epoch_change(epoch, block_id_num_hash.num)
+                {
+                    warn!(
+                        "Discard stale commit block after epoch change id {:?} num {} commit_epoch {} current_epoch {}",
+                        block_id_num_hash.block_id,
+                        block_id_num_hash.num,
+                        epoch,
+                        block_state_machine.current_epoch,
+                    );
+                    continue;
+                }
                 return Err(anyhow::anyhow!(
                     "There is no Block but try to push commit block for block {:?} num {}",
                     block_id_num_hash.block_id,


### PR DESCRIPTION
## Summary

This PR now covers the private-mainnet recovery / fast-forward-sync failure modes found during the 2055785 stall investigation.

Main changes:

- Align consensus recovery root with execution when execution is still at block 0.
  - If `latest_block_number == 0`, recover from genesis LI instead of a newer metadata DB LI.
  - Preserve the existing `is_last_block_of_prev_epoch` branch for epoch-boundary recovery.
- Harden fast-forward sync around non-blocking epoch changes.
  - Only return ledger infos for blocks that the returned QCs can actually commit.
  - Only send `EpochChangeProof` after the local commit root reaches the epoch-change boundary.
  - Reset validator rand/buffer pipeline before FFsync rebuild to avoid BlockStore/pipeline state divergence.
- Make rand manager ordered-block intake idempotent for stale/dequeued rounds.
  - Track the highest dequeued round and drop stale ordered blocks that are pushed again.
  - This covers the core-4 duplicate-send case where round 28843 was pushed again and blocked round 28844.
- Replay ordered path after `add_certs`.
  - After SyncInfo certs are inserted, if `highest_ordered_cert` is ahead of `ordered_root`, call `send_for_execution` once to replay the missing ordered path into rand/buffer.
  - This covers the richard-1 case where FFsync/rebuild had 28844..28851 in BlockStore but the pipeline never received them.
- Surface broken execution channel sends as errors instead of silently returning `Ok(())`.

## Incident Notes

Two different symptoms were observed:

- **core-4 duplicate send**: round 28843 / block `84fb855d` was sent to execution twice. The second push created a stale rand queue entry ahead of round 28844, so randomness for 28844 was decided but never reached BufferManager.
- **richard-1 missing replay**: FFsync pulled blocks/QCs through round 28851, but recovery only executed up to the latest committed LI at round 28843. The node then advanced current round from SyncInfo and treated old 28844/28845 proposals as stale, leaving the ordered path present in BlockStore but not replayed into the pipeline.

The fixes are intentionally split:

- reset before validator FFsync rebuild prevents stale pipeline state from surviving a BlockStore rebuild;
- rand queue stale-drop is the safety net for duplicate ordered-block pushes;
- add-certs ordered-path replay fills the gap when BlockStore already has a higher ordered cert than the local pipeline root.

## Validation

```bash
cargo +nightly fmt
RUSTFLAGS='--cfg tokio_unstable' cargo +nightly check -p 'path+file:///Users/lightman/repos/gravity-sdk/aptos-core/consensus#aptos-consensus@0.1.0'
RUSTFLAGS='--cfg tokio_unstable' cargo +nightly test -p 'path+file:///Users/lightman/repos/gravity-sdk/aptos-core/consensus#aptos-consensus@0.1.0' rand::rand_gen::block_queue --lib
```

All passed locally.
