### PR TITLE
fix(mempool): demote AlreadyImported to info, defer to reth's is_bad_transaction

### DIFF
--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -234,14 +234,28 @@ impl TxPool for Mempool {
                 let address = pool_txn.sender();
                 let to = pool_txn.to();
                 self.runtime.spawn(async move {
-                    let res = pool.add_external_transaction(pool_txn).await;
-                    if let Err(e) = res {
-                        tracing::error!(
-                            "Failed to add transaction: {:?} {:?} {:?}",
-                            address,
-                            to,
-                            e
-                        );
+                    if let Err(e) = pool.add_external_transaction(pool_txn).await {
+                        // Defer to reth's classification: only promote to ERROR for
+                        // pool errors that warrant peer penalization (per
+                        // PoolError::is_bad_transaction). The "not bad" cases are
+                        // dominated by AlreadyImported, which floods on every
+                        // legitimate client retry and on duplicate P2P mempool
+                        // gossip — they're observable but not actionable.
+                        if e.is_bad_transaction() {
+                            tracing::error!(
+                                "Failed to add transaction: {:?} {:?} {:?}",
+                                address,
+                                to,
+                                e
+                            );
+                        } else {
+                            tracing::info!(
+                                "tx not added (recoverable): {:?} {:?} {:?}",
+                                address,
+                                to,
+                                e
+                            );
+                        }
                     }
                 });
                 true

--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -18,8 +18,8 @@ use gaptos::api_types::{
 use greth::{
     reth_primitives::{Recovered, TransactionSigned},
     reth_transaction_pool::{
-        BestTransactions, EthPooledTransaction, PoolTransaction, TransactionPool,
-        ValidPoolTransaction,
+        error::PoolErrorKind, BestTransactions, EthPooledTransaction, PoolTransaction,
+        TransactionPool, ValidPoolTransaction,
     },
 };
 
@@ -235,26 +235,40 @@ impl TxPool for Mempool {
                 let to = pool_txn.to();
                 self.runtime.spawn(async move {
                     if let Err(e) = pool.add_external_transaction(pool_txn).await {
-                        // Defer to reth's classification: only promote to ERROR for
-                        // pool errors that warrant peer penalization (per
-                        // PoolError::is_bad_transaction). The "not bad" cases are
-                        // dominated by AlreadyImported, which floods on every
-                        // legitimate client retry and on duplicate P2P mempool
-                        // gossip — they're observable but not actionable.
-                        if e.is_bad_transaction() {
-                            tracing::error!(
-                                "Failed to add transaction: {:?} {:?} {:?}",
-                                address,
-                                to,
-                                e
-                            );
-                        } else {
-                            tracing::info!(
-                                "tx not added (recoverable): {:?} {:?} {:?}",
-                                address,
-                                to,
-                                e
-                            );
+                        // Three-way classification:
+                        //  * PoolErrorKind::Other(_)        — internal failure (DB/IO). Surface at
+                        //    WARN so operators see it.
+                        //  * is_bad_transaction() == true   — sender produced a malformed /
+                        //    protocol-invalid tx. Node correctly rejected; WARN gives visibility +
+                        //    monitoring signal without paging.
+                        //  * everything else                — recoverable noise (AlreadyImported
+                        //    dedup, ReplacementUnderpriced, nonce gap, low fee, local config).
+                        //    INFO.
+                        match &e.kind {
+                            PoolErrorKind::Other(_) => {
+                                tracing::warn!(
+                                    "Failed to add transaction (internal): {:?} {:?} {:?}",
+                                    address,
+                                    to,
+                                    e
+                                );
+                            }
+                            _ if e.is_bad_transaction() => {
+                                tracing::warn!(
+                                    "rejected malformed tx: {:?} {:?} {:?}",
+                                    address,
+                                    to,
+                                    e
+                                );
+                            }
+                            _ => {
+                                tracing::info!(
+                                    "tx not added (recoverable): {:?} {:?} {:?}",
+                                    address,
+                                    to,
+                                    e
+                                );
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
## Summary

Stop promoting reth pool errors that reth itself classifies as benign (`is_bad_transaction() == false`) to ERROR level. They already include `AlreadyImported`, `ReplacementUnderpriced`, etc. — none of which warrant peer penalization or operator alerts.

## Why

`bin/gravity_node/src/mempool.rs::add_external_txn` is on the receiving end of P2P mempool gossip (`process_transaction_broadcast` → `mempool.add_txn` → this trait impl). When a chain stalls, clients retry the same signed tx, and aptos-mempool gossip re-broadcasts the duplicate between peers. On the broadcast hub validator (the one picked as `BroadcastPeerPriority::Primary` by multiple senders) this currently produces sustained ~1100 ERROR/sec of `Failed to add transaction: ... PoolError { kind: AlreadyImported }`.

Concrete impact observed on private-mainnet during the 2055785 stall:

| node | `debug.log` (5h41m) |
|---|---|
| core-1 / core-2 / core-3 / richard-1 / yxia-1 | 374 B (just startup banner) |
| yxia-2 | 68 KB |
| **core-4** | **6.5 GB** |

All seven validators ran identical `start.sh` / cmdline. The discrepancy is entirely from broadcast peer priority routing, not RPC ingress (the RPC path doesn't even reach this code — `MempoolClientRequest::SubmitTransaction` is dead in gravity-sdk: `crates/api/src/consensus_api.rs:273` constructs `(_mempool_client_sender, _mempool_client_receiver)` and immediately drops the sender, so `process_client_transaction_submission` is never reachable).

The 6.5 GB is benign noise but drowns real ERROR/panic events and complicates post-incident grep.

## Fix

Use reth's existing `PoolError::is_bad_transaction()` classifier (defined in `gravity-reth` `crates/transaction-pool/src/error.rs`):

```rust
if let Err(e) = pool.add_external_transaction(pool_txn).await {
    if e.is_bad_transaction() {
        tracing::error!("Failed to add transaction: {:?} {:?} {:?}", address, to, e);
    } else {
        tracing::info!("tx not added (recoverable): {:?} {:?} {:?}", address, to, e);
    }
}
```

reth marks the following as `is_bad_transaction() == false` (with comments like `"already imported but not bad"`):
- `AlreadyImported`
- `ReplacementUnderpriced`
- `FeeCapBelowMinimumProtocolFeeCap`
- `SpammerExceededCapacity`
- `DiscardedOnInsert`
- `ExistingConflictingTransactionType`
- `Other` (internal)
- `InvalidTransaction(err)` defers to `err.is_bad_transaction()`

The classification comes from upstream reth (which never logs these itself); deferring to it keeps gravity-sdk consistent with reth's own judgment about which pool errors are operator-actionable.

## Test plan

- [ ] `cargo check -p gravity_node` (note: there is a pre-existing `tokio::Builder::disable_lifo_slot` private-field error in the `aptos-runtimes` dep on this branch tip, unrelated to this change — should pass on whatever toolchain CI uses)
- [ ] During next chain stall / heavy retry storm, confirm `debug.log` no longer accumulates GB of `Failed to add transaction` ERROR; equivalent INFO line `"tx not added (recoverable)"` is emitted instead
- [ ] Real pool-failure cases (e.g., `InvalidTransaction` with bad signature) still fire at ERROR