### PR TITLE
Persist fetched quorum store batches to DB

### DIFF
--- a/aptos-core/consensus/src/quorum_store/batch_store.rs
+++ b/aptos-core/consensus/src/quorum_store/batch_store.rs
@@ -322,6 +322,29 @@ impl BatchStore {
         }
     }
 
+    pub(crate) fn save_fetched_batch_to_db(
+        &self,
+        persist_request: PersistedValue,
+    ) -> anyhow::Result<()> {
+        let batch_info = persist_request.batch_info().clone();
+        self.db.save_batch(persist_request).map_err(|e| {
+            anyhow::anyhow!(
+                "Could not persist fetched batch to DB: epoch={}, digest={}, expiration={}, error={:?}",
+                batch_info.epoch(),
+                batch_info.digest(),
+                batch_info.expiration(),
+                e,
+            )
+        })?;
+        debug!(
+            "QS: persisted fetched batch to DB: epoch={}, digest={}, expiration={}",
+            batch_info.epoch(),
+            batch_info.digest(),
+            batch_info.expiration(),
+        );
+        Ok(())
+    }
+
     pub fn update_certified_timestamp(&self, certified_time: u64) {
         trace!("QS: batch reader updating time {:?}", certified_time);
         let prev_time = self.last_certified_time.fetch_max(certified_time, Ordering::SeqCst);
@@ -485,6 +508,18 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchReader for Batch
                 if let Some((batch_info, payload)) =
                     batch_requester.request_batch(key, expiration, signers, tx, subscriber_rx).await
                 {
+                    if let Err(e) = batch_store.save_fetched_batch_to_db(PersistedValue::new(
+                        batch_info.clone(),
+                        Some(payload.clone()),
+                    )) {
+                        error!(
+                            "QS: failed to persist fetched remote batch to DB: epoch={}, digest={}, expiration={}, error={:?}",
+                            batch_info.epoch(),
+                            batch_info.digest(),
+                            batch_info.expiration(),
+                            e,
+                        );
+                    }
                     batch_store.persist(vec![PersistedValue::new(batch_info, Some(payload))]);
                 }
             }


### PR DESCRIPTION
## Summary

Persist QuorumStore batches that are fetched from remote peers directly into the local QS DB before continuing through the existing `BatchStore::persist` flow.

This keeps the normal live QS cache/signing semantics unchanged, while ensuring batches obtained during block sync / recovery are retained locally and can later be served to downstream fullnodes.

## Context

We observed a case where validators still had the required QS batch payloads, but both VFNs were missing them locally. Since the RPC node only requests batches from its VFN peers, it could not recover even though validators still had the data.

The existing remote fetch path called `BatchStore::persist(...)`, which may skip DB persistence when cache insertion returns `false` or when the live QS expiration/cache path rejects the batch. That is fine for live QS semantics, but not enough for recovery/fullnode serving: if a node successfully fetched the batch payload, it should keep a DB copy.

## Changes

- Add `save_fetched_batch_to_db(...)` for remote-fetched batches.
- Call it from `BatchReaderImpl::get_batch()` when `BatchRequester::request_batch()` returns a batch.
- Keep the existing `BatchStore::persist(...)` call afterwards so cache/sign/notify behavior remains unchanged.
- Log an error if the forced DB persistence fails.

## Validation

- `cargo +nightly fmt`
- `RUSTFLAGS='--cfg tokio_unstable' cargo +nightly check -p aptos-consensus`
