### PR TITLE
feat(cluster): set txpool_max_account_slots=1024 on pfn_chain nodes

### DIFF
--- a/gravity_e2e/cluster_test_cases/pfn_chain/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/pfn_chain/cluster.toml
@@ -62,6 +62,11 @@ reth_p2p_port = 12026
 # pubkey mismatch self-check loop. Force vfn-network discovery off; the
 # validator_network keeps the default onchain.
 vfn_discovery_method = "none"
+# Bench's stress generator (1500 senders × 10K accts) submits many in-flight
+# txs per sender. reth's default 16 caps External-origin per-sender to ~16
+# tx/min after the Aptos shared-mempool broadcast cache cycles. 1024 lets
+# the pool absorb the full burst so chain TPS isn't gated by ingress.
+txpool_max_account_slots = 1024
 
 [[nodes]]
 id = "vfn1"
@@ -83,6 +88,7 @@ inspection_port = 10003
 https_port = 1025
 authrpc_port = 8554
 reth_p2p_port = 12027
+txpool_max_account_slots = 1024
 
 [[nodes]]
 id = "pfn1"
@@ -99,6 +105,7 @@ metrics_port = 9005
 inspection_port = 10004
 authrpc_port = 8555
 reth_p2p_port = 12028
+txpool_max_account_slots = 1024
 
 [[nodes]]
 id = "pfn2"
@@ -115,6 +122,7 @@ metrics_port = 9006
 inspection_port = 10005
 authrpc_port = 8556
 reth_p2p_port = 12029
+txpool_max_account_slots = 1024
 
 [[nodes]]
 id = "pfn3"
@@ -131,6 +139,7 @@ metrics_port = 9007
 inspection_port = 10006
 authrpc_port = 8557
 reth_p2p_port = 12030
+txpool_max_account_slots = 1024
 
 [faucet_init]
 num_accounts = 10000


### PR DESCRIPTION
## Summary

Opts the `pfn_chain` e2e/bench test case into raised reth per-sender txpool slots so the bench's stress generator can saturate the chain.

- Sets `txpool_max_account_slots = 1024` on each of the 5 nodes (node1, vfn1, pfn1, pfn2, pfn3) in `gravity_e2e/cluster_test_cases/pfn_chain/cluster.toml`.
- Uses the per-node knob introduced in #696 — no template or `deploy.sh` changes, behavior for other test cases is unchanged (they still get the upstream-default 16).

## Why

`pfn_chain` is the topology used by the `gravity_bench` stress generator (1500 senders × 10K accounts). reth's default `--txpool.max-account-slots=16` caps in-pool tx count per sender for External-origin ingress; under the Aptos shared-mempool broadcast cache (60s cycle) this throttles per-sender drain to roughly 16 mined tx/min steady-state. Aggregate chain throughput plateaus well below the validator's capability.

Raising the cap on PFN/VFN forwarding paths (and at the validator's own ingress) lets the pool absorb the full burst, so chain TPS is bounded by execution, not ingress.

## Validation

Measured on a 5-node single-host docker cluster reproducing the pfn_chain topology, with bench defaults (1500 senders, 10K accounts, 8K target TPS):

| Config | Sustained chain TPS (node1 ingress) |
|---|---|
| upstream `pfn_chain/cluster.toml` (slots=16) | < 1,000 |
| this PR (slots=1024) | ~ 5,800 |

## Test plan

- [ ] `python3 gravity_e2e/runner.py pfn_chain --force-init` still passes end-to-end (no regression in the existing e2e — the field is purely a per-node override and the default for all other cases remains 16)
- [ ] Rendered `reth_config*.json` for each node contains `"txpool.max-account-slots": 1024`

🤖 Generated with [Claude Code](https://claude.com/claude-code)