### PR TITLE
ci(release): runner-native release workflow + actionlint

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,26 @@
+name: Lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: lint-workflows-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.7
+          ./actionlint --version
+
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -23,4 +23,8 @@ jobs:
           ./actionlint --version
 
       - name: Run actionlint
-        run: ./actionlint -color
+        # Skip shellcheck integration: pre-existing inline scripts in
+        # gate.yml / rust-ci.yml have SC2086 / SC2053 noise that is out of
+        # scope for this workflow's purpose (yaml + expression validation).
+        # Re-enable by dropping `-shellcheck=` once those are cleaned up.
+        run: ./actionlint -color -shellcheck=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,8 @@ jobs:
             gh --version
             exit 0
           fi
-          GH_VERSION="2.62.0"
-          curl -fsSL "https://github.com/cli/gh/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+          GH_VERSION="2.92.0"
+          curl -fsSL --retry 3 "https://github.com/cli/gh/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /tmp
           install -m0755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
           gh --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 on:
   push:
-    tags: ['gravity-mainnet-*']
+    tags:
+      - 'gravity-mainnet-*'
+      - 'gravity-testnet-*'
   pull_request:
     paths:
       - '.github/workflows/release.yml'
@@ -106,8 +108,8 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF##refs/tags/}"
           case "$TAG" in
-            gravity-mainnet-*) ;;
-            *) echo "tag must start with gravity-mainnet-: $TAG" >&2; exit 1 ;;
+            gravity-mainnet-*|gravity-testnet-*) ;;
+            *) echo "tag must start with gravity-mainnet- or gravity-testnet-: $TAG" >&2; exit 1 ;;
           esac
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install build dependencies
+        # Mirrors gravity_e2e/build_docker.sh apt list (the working
+        # in-container build env), minus the python/test bits we don't need.
+        # libclang-dev added explicitly: on bullseye the `clang` package does
+        # not ship the unversioned libclang.so symlink that bindgen searches
+        # for, unlike bookworm where it's pulled in transitively.
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+            clang llvm libclang-dev \
+            build-essential pkg-config \
+            libssl-dev libudev-dev \
+            procps git jq curl ca-certificates
+
       - name: Assert rustc matches rust-toolchain.toml
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             exit 0
           fi
           GH_VERSION="2.92.0"
-          curl -fsSL --retry 3 "https://github.com/cli/gh/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+          curl -fsSL --retry 3 "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
             | tar -xz -C /tmp
           install -m0755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
           gh --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+on:
+  push:
+    tags: ['gravity-mainnet-*']
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+
+concurrency:
+  group: release-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build and release
+    runs-on: [self-hosted, linux]
+    # Image pins glibc + rust toolchain for forward-compatible binaries.
+    # Override per-repo via Settings → Variables → Actions → RELEASE_BUILD_IMAGE.
+    # Default targets Debian 11 (glibc 2.31) to match current staging/mainnet OS.
+    container:
+      image: ${{ vars.RELEASE_BUILD_IMAGE || 'rust:1.93.0-bullseye' }}
+    timeout-minutes: 180
+    env:
+      RUSTFLAGS: "--cfg tokio_unstable"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assert rustc matches rust-toolchain.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected=$(grep -E '^channel[[:space:]]*=' rust-toolchain.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          actual=$(rustc --version | awk '{print $2}')
+          echo "expected: $expected"
+          echo "actual:   $actual"
+          if [ "$expected" != "$actual" ]; then
+            echo "rustc in container image does not match rust-toolchain.toml." >&2
+            echo "bump vars.RELEASE_BUILD_IMAGE to rust:${expected}-<codename>, or update rust-toolchain.toml." >&2
+            exit 1
+          fi
+
+      - name: Install gh CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            gh --version
+            exit 0
+          fi
+          GH_VERSION="2.62.0"
+          curl -fsSL "https://github.com/cli/gh/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /tmp
+          install -m0755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+          gh --version
+
+      - name: Build gravity_node and gravity_cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --profile quick-release --bin gravity_node --bin gravity_cli
+
+      - name: Stage release assets and compute sha256
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="${RUNNER_TEMP}/release-assets"
+          rm -rf "$OUT" && mkdir -p "$OUT"
+          for bin in gravity_node gravity_cli; do
+            src="target/quick-release/$bin"
+            if [ ! -x "$src" ]; then
+              echo "$src not built or not executable" >&2
+              exit 1
+            fi
+            cp "$src" "$OUT/$bin"
+            ( cd "$OUT" && sha256sum "$bin" > "$bin.sha256" )
+          done
+          ls -lh "$OUT"
+          echo "--- sha256 ---"
+          cat "$OUT"/*.sha256
+          echo "dir=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload PR dry-run artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dryrun-${{ github.sha }}
+          path: ${{ steps.stage.outputs.dir }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Resolve tag
+        id: tag
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF##refs/tags/}"
+          case "$TAG" in
+            gravity-mainnet-*) ;;
+            *) echo "tag must start with gravity-mainnet-: $TAG" >&2; exit 1 ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Upload assets to GitHub release
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          ASSETS_DIR: ${{ steps.stage.outputs.dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG does not exist." >&2
+            echo "create it first via GitHub UI (Releases → Draft a new release) with notes, then publish — that will push the tag and re-trigger this workflow." >&2
+            exit 1
+          fi
+          gh release upload "$TAG" \
+            "$ASSETS_DIR/gravity_node" \
+            "$ASSETS_DIR/gravity_node.sha256" \
+            "$ASSETS_DIR/gravity_cli" \
+            "$ASSETS_DIR/gravity_cli.sha256" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,17 @@ jobs:
   build-and-release:
     name: Build and release
     runs-on: [self-hosted, linux]
-    # Image pins glibc + rust toolchain for forward-compatible binaries.
-    # Override per-repo via Settings → Variables → Actions → RELEASE_BUILD_IMAGE.
-    # Default targets Debian 11 (glibc 2.31) to match current staging/mainnet OS.
-    container:
-      image: ${{ vars.RELEASE_BUILD_IMAGE || 'rust:1.93.0-bullseye' }}
+    # Native build on the runner — no container.
+    # Invariant: runner OS must match production node OS, otherwise the
+    # binary's required glibc may exceed what target nodes provide and
+    # they'll fail to start with `GLIBC_X.YY not found`. Verify before
+    # changing the runner: `cat /etc/os-release && ldd --version`
+    # on both runner and target should agree (or runner glibc ≤ target).
+    # Runner must have these installed once:
+    #   - rust toolchain matching rust-toolchain.toml (rustup default <ver>)
+    #   - gh CLI (`apt install gh` via cli.github.com apt repo)
+    #   - build deps: clang llvm libclang-dev build-essential pkg-config
+    #                 libssl-dev libudev-dev
     timeout-minutes: 180
     env:
       RUSTFLAGS: "--cfg tokio_unstable"
@@ -31,22 +37,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install build dependencies
-        # Mirrors gravity_e2e/build_docker.sh apt list (the working
-        # in-container build env), minus the python/test bits we don't need.
-        # libclang-dev added explicitly: on bullseye the `clang` package does
-        # not ship the unversioned libclang.so symlink that bindgen searches
-        # for, unlike bookworm where it's pulled in transitively.
+      - name: Show build environment
+        # Logs runner OS / glibc / rustc so any future divergence from
+        # production OS is visible in the release run record.
         shell: bash
         run: |
           set -euo pipefail
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get update -qq
-          apt-get install -y --no-install-recommends \
-            clang llvm libclang-dev \
-            build-essential pkg-config \
-            libssl-dev libudev-dev \
-            procps git jq curl ca-certificates
+          grep -E '^(NAME|VERSION|VERSION_CODENAME)=' /etc/os-release
+          ldd --version | head -1
+          rustc --version
+          cargo --version
 
       - name: Assert rustc matches rust-toolchain.toml
         shell: bash
@@ -57,24 +57,10 @@ jobs:
           echo "expected: $expected"
           echo "actual:   $actual"
           if [ "$expected" != "$actual" ]; then
-            echo "rustc in container image does not match rust-toolchain.toml." >&2
-            echo "bump vars.RELEASE_BUILD_IMAGE to rust:${expected}-<codename>, or update rust-toolchain.toml." >&2
+            echo "rustc on runner does not match rust-toolchain.toml." >&2
+            echo "update the runner toolchain (rustup install $expected && rustup default $expected) or update rust-toolchain.toml." >&2
             exit 1
           fi
-
-      - name: Install gh CLI
-        shell: bash
-        run: |
-          set -euo pipefail
-          if command -v gh >/dev/null 2>&1; then
-            gh --version
-            exit 0
-          fi
-          GH_VERSION="2.92.0"
-          curl -fsSL --retry 3 "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /tmp
-          install -m0755 "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
-          gh --version
 
       - name: Build gravity_node and gravity_cli
         shell: bash


### PR DESCRIPTION
## Summary

New `.github/workflows/release.yml` for shipping `gravity_node` / `gravity_cli` binaries when a `gravity-mainnet-*` or `gravity-testnet-*` tag is pushed. Workflow runs natively on the self-hosted Ubuntu 24.04 runner — no container.

**Decision: align production node OS with the runner OS, not the other way around.** Runner is already Ubuntu 24.04 (glibc 2.39); the planned production-VM Packer image is being moved to `ubuntu-2404-lts-amd64` to match. Native runner build keeps the workflow simple (no per-run apt-install, `target/` cache reuse) at the cost of requiring runner state stays in sync.

The earlier containerized direction (`rust:1.93.0-bullseye`) is preserved in git history (`abf88dd1..af3e3711`) and can be brought back with `git revert d75fc1f2` if the OS migration slips.

## Changes

### `.github/workflows/release.yml`

- Native build on `[self-hosted, linux]` — no `container:` field.
- Trigger: `push: tags: ['gravity-mainnet-*', 'gravity-testnet-*']` and `pull_request: paths: ['.github/workflows/release.yml']`.
- `Show build environment` step logs `/etc/os-release`, `ldd --version`, `rustc --version`, `cargo --version` every run, so runner OS drift surfaces in the run record.
- `Assert rustc matches rust-toolchain.toml` so toolchain drift fails fast with a clear remediation message.
- PR-trigger path uploads the binary as a 7-day `release-dryrun-<sha>` artifact for reviewer inspection; real GH-release upload is skipped on PR events.
- Tag-push path requires the GitHub Release to already exist (created via UI with human-authored notes); workflow only attaches binaries via `gh release upload --clobber`. No auto-create.
- `Resolve tag` step rejects any tag that doesn't match `gravity-{mainnet,testnet}-*`.

### `.github/workflows/lint-workflows.yml`

- `actionlint@1.7.7` on PRs touching `.github/workflows/**`. Shellcheck integration disabled (`-shellcheck=`) — pre-existing SC2086 / SC2053 noise in `gate.yml` / `rust-ci.yml` is out of scope; re-enable after a separate cleanup PR.

## Runner prerequisites (install once on the runner host)

- Rust toolchain matching `rust-toolchain.toml` (currently 1.93.0)
- `gh` CLI (via `cli.github.com` apt repo) — uses workflow-injected `GH_TOKEN`, no `gh auth login` needed
- Build deps: `clang llvm libclang-dev build-essential pkg-config libssl-dev libudev-dev`

These are installed on `gravity-grafana-20250806-070307`.

## Test plan

- [x] `Lint workflows / actionlint` green
- [x] `Release / Build and release` dry-run green (run [25787189549](https://github.com/Galxe/gravity-sdk/actions/runs/25787189549), attempt 2, 10m57s)
- [x] Dry-run artifact verified:
  - `objdump -T gravity_node | grep GLIBC_` → max `GLIBC_2.39` (matches Ubuntu 24.04)
  - `sha256sum -c` matches workflow output
  - `./gravity_node --version` on runner shows non-empty `build_commit_hash` and `build_time` (read by shadow_rs at compile time from the checkout; PR path shows merge sha, tag-push path will show tag commit)
- [ ] Pending Packer image rollout: do not push a real `gravity-mainnet-*` tag until staging-mainnet VMs are running Ubuntu 24.04.

## Follow-ups (separate PRs)

- **Production-VM Packer image migration** (`ubuntu-os-cloud/ubuntu-2404-lts-amd64`). Runner-native binaries depend on `GLIBC_2.39`; older OS targets will refuse to start.
- **Shellcheck cleanup** in `gate.yml` / `rust-ci.yml`, then drop `-shellcheck=` from `lint-workflows.yml`.

## Notes for reviewers

- The `build-info` crate has a runtime `std::env::var(\"GIT_SHA\")` override path (`crates/build-info/src/lib.rs:84-101`). It looks like it could be wired to GitHub Actions context to populate `build_branch` / `build_commit_hash` from the env, but the override is **runtime-only** — production `systemd` units won't set those env vars, so it's a no-op for shipped binaries. Compile-time `shadow_rs` already fills `build_commit_hash` and `build_tag` correctly on tag-push builds; `build_branch` is empty under detached-HEAD checkout (acceptable for tag releases). Fixing `build_branch` properly is a crate change (`option_env!` + `cargo:rerun-if-env-changed`), tracked separately.
- An earlier attempt added these env vars to the workflow (commit `03fcff29`, since reset) before this was understood; the commit has been dropped via force-push.