### PR TITLE
chore: drop gcp-secret-manager optional cargo feature, revert #713

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,31 +64,11 @@ jobs:
             exit 1
           fi
 
-      - name: Build gravity_node (with gcp-secret-manager)
-        # gravity_node's `gcp-secret-manager` cargo feature must be enabled or
-        # the binary panics on first startup when any node's identity is
-        # configured as `source = "gcp_secret"` (the production case for
-        # Staging Mainnet / future mainnet):
-        #
-        #   panicked at .../config/network_config.rs:281:25:
-        #   load identity blob for peer_id from GCP secret ...: GCP Secret
-        #   Manager support not compiled in. Rebuild aptos-config with
-        #   `--features gcp-secret-manager` ...
-        #
-        # The feature is declared on bin/gravity_node/Cargo.toml (not on the
-        # workspace), so we must scope cargo with `-p gravity_node` to make
-        # `--features` resolve. gravity_cli is built in a separate step
-        # below because it does not declare the same feature.
+      - name: Build gravity_node and gravity_cli
         shell: bash
         run: |
           set -euo pipefail
-          cargo build --profile quick-release -p gravity_node --bin gravity_node --features gcp-secret-manager
-
-      - name: Build gravity_cli
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build --profile quick-release -p gravity_cli --bin gravity_cli
+          cargo build --profile quick-release --bin gravity_node --bin gravity_cli
 
       - name: Stage release assets and compute sha256
         id: stage

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -13,11 +13,6 @@ rust-version.workspace = true
 [features]
 # Forward feature to gaptos so `-p gravity_node --features randomness_disabled` works
 randomness_disabled = ["gaptos/randomness_disabled"]
-# Forward feature to gaptos/aptos-config so identity blobs can be loaded from
-# GCP Secret Manager at startup. Off by default to keep the HTTP/TLS stack out
-# of the default build graph; enable when cluster.toml configures any node with
-# `identity = { source = "gcp_secret", ... }`.
-gcp-secret-manager = ["gaptos/gcp-secret-manager"]
 default = []
 
 [dependencies]
@@ -47,7 +42,7 @@ alloy-transport-http = "=1.0.37"
 alloy-rpc-types-eth = "=1.0.37"
 async-trait.workspace = true
 api.workspace = true
-gaptos.workspace = true
+gaptos = { workspace = true, features = ["gcp-secret-manager"] }
 block-buffer-manager.workspace = true
 proposer-reth-map.workspace = true
 build-info.workspace = true


### PR DESCRIPTION
## Summary

Removes the optional GCP Secret Manager build mode in `bin/gravity_node` and reverts the workflow split that #713 forced as a band-aid.

- **`bin/gravity_node/Cargo.toml`** — drop the local `gcp-secret-manager` forwarding feature. Instead pull the `gaptos` dep with that feature always enabled (`features = [\"gcp-secret-manager\"]`). `reqwest` + `base64` become a permanent part of every `gravity_node` build.
- **`.github/workflows/release.yml`** — collapse the two-step `gravity_node` / `gravity_cli` build back to the single pre-#713 step. With the feature permanently on at the dep level, the explicit `--features` flag (and the `-p gravity_node` scoping it required) is redundant.

No upstream `gravity-aptos` change: the feature flag on `aptos-config` is left in place; we just unconditionally enable it from this side. `cargo` pin is unchanged at `e9544c8`.

## Why

The feature was a footgun. v1.6.0 shipped with `default = []` and the Staging Mainnet VFNs auto-restart-looped on the panic in `aptos-config/.../network_config.rs:281` because their identity source is `gcp_secret`. #713 patched the workflow but the underlying design — an optional build flag that every production deploy must remember to enable — is what should go.

`reqwest` is already in the workspace via `gravity_cli`'s upload-side `secret_manager.rs`, so making it unconditional in `aptos-config` (via the gaptos feature being always on) does not introduce a new transitive dep at workspace scope.

## Test plan

- [x] Local \`cargo check -p gravity_node --profile=quick-release\` (with `RUSTFLAGS=\"--cfg tokio_unstable\"`) passes — finished in 2m27s. Confirms `gaptos = { features = [\"gcp-secret-manager\"] }` resolves and pulls `reqwest` + `base64` into the build graph.
- [ ] CI release workflow dry-run (PR-trigger) — the workflow attaches \`release-dryrun-<sha>\` artifact when triggered on a PR. Single \`Build gravity_node and gravity_cli\` step should succeed.
- [ ] After merge: cut a new release tag (e.g. \`gravity-mainnet-v1.6.2\`), then verify on a Staging Mainnet VFN that the panic at \`network_config.rs:281\` is gone and \`journalctl -u gravity-vfn-1.service\` advances past the identity-load step.

## References

- #713 — the workflow-level fix this supersedes
- #710 — original release workflow that shipped without the feature
- #688 / #695 — the cluster.toml-side wiring that originally introduced the optional build mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)