### PR TITLE
build: hoist RUSTFLAGS=--cfg tokio_unstable into workspace cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,31 @@
+# Workspace-level cargo config.
+#
+# The aptos-core fork that gravity_node and gravity_cli depend on uses several
+# tokio APIs gated behind `#[cfg(tokio_unstable)]`:
+#
+#   - `tokio::runtime::RuntimeMetrics`     — runtime task / worker metrics
+#   - `tokio_console` integration          — task introspection over tokio-console
+#   - `task::Builder::name(...)`           — named tasks in tracing output
+#
+# Without this cfg flag, dozens of files in the dependency graph fail to
+# compile with `unresolved import: this item is gated behind a
+# cfg(tokio_unstable) flag`.
+#
+# Previously every build entry point (Makefile targets, GitHub Actions
+# workflows, cluster/deploy.sh, .agents/* docs) had to remember to set
+# `RUSTFLAGS="--cfg tokio_unstable"`. Forgetting the flag silently broke
+# the build — see `cluster/deploy.sh`, `Makefile`, `.github/workflows/*.yml`
+# for the per-entry repetition this config replaces.
+#
+# Putting it here means any `cargo build / test / check / clippy` invocation,
+# inside or outside CI, picks the flag up automatically. The duplicate
+# `RUSTFLAGS=...` declarations in the entry points are now redundant but
+# kept for now to avoid touching every workflow file in the same PR — they
+# can be cleaned up incrementally.
+#
+# Note: an explicit `RUSTFLAGS` env var still takes precedence over this
+# config (cargo's documented merge order), so any caller that sets it
+# already continues to work unchanged.
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]


### PR DESCRIPTION
## Summary

The aptos-core fork that gravity_node and gravity_cli depend on uses several tokio APIs gated behind \`#[cfg(tokio_unstable)]\` — \`RuntimeMetrics\`, tokio-console integration, named tasks. Dozens of files reference these. Without the cfg flag the build fails with \`unresolved import: this item is gated behind a cfg(tokio_unstable) flag\`.

Until now the flag has been repeated at every build entry point:

| Where | How |
|---|---|
| \`.github/workflows/release.yml\` | \`env: RUSTFLAGS:\` |
| \`.github/workflows/rust-ci.yml\` | \`env: RUSTFLAGS:\` |
| \`.github/workflows/unit-test.yml\` | \`env: RUSTFLAGS:\` |
| \`Makefile\` | two targets ahead of the line, **two missing it** |
| \`cluster/deploy.sh\` | inline per-cargo-build call |
| \`.agents/*\` docs / \`cluster/docs/gcp-secret-manager.md\` / \`bin/gravity_cli/README.md\` | manual one-liner reminder |

## Why this matters now

This sprawl bit two operators in the past week:

1. **A team member building gravity_cli manually forgot the flag.** The build failed, but a `| tail` in their wrapper masked cargo's non-zero exit (bash default behavior; you'd need \`set -o pipefail\` to catch it). They saw "looks fine" output and proceeded with a binary that wasn't actually built. Took a while to notice.

2. **The Makefile is internally inconsistent.** The \`bench\` and \`kvstore\` targets transitively depend on \`gaptos.workspace\` and \`aptos-*\`, so they DO need \`tokio_unstable\`. But their Makefile lines don't set \`RUSTFLAGS\`. Anyone running \`make bench\` from a clean checkout today gets a compile failure. Existing local Makefile runs probably work only because the operator had \`RUSTFLAGS\` in their shell already.

## Fix

Workspace-level \`.cargo/config.toml\` with:

\`\`\`toml
[build]
rustflags = ["--cfg", "tokio_unstable"]
\`\`\`

Any \`cargo build / test / check / clippy\` invocation, in CI or on a fresh checkout, picks the flag up automatically.

## Compatibility

Cargo's documented merge order: an explicit \`RUSTFLAGS\` env var **takes precedence** over the config file. So the existing per-workflow \`RUSTFLAGS\` declarations keep working unchanged — they're now belt-and-suspenders rather than the only line of defense. **No CI behavior changes.**

## Scope

This PR is intentionally minimal: add the config, don't touch the duplicate \`RUSTFLAGS\` sites. Cleanup of the redundant lines can land in a follow-up once this config has soaked through a few CI runs and is proven to be the source of truth.

## Test plan

- [ ] CI green on this PR (existing workflows still build)
- [ ] \`unset RUSTFLAGS && cargo build -p gravity_node\` succeeds on a fresh clone (was failing before)
- [ ] \`make bench\` succeeds without the operator having to set RUSTFLAGS in their shell (was implicitly broken before)
- [ ] No change in output binary for gravity_node / gravity_cli (only the entry-point env handling differs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)