### PR TITLE
fix(mempool): honor sender_bucket / timeline_id / count / before in read_timeline

### DIFF
--- a/aptos-core/mempool/src/core_mempool/mempool.rs
+++ b/aptos-core/mempool/src/core_mempool/mempool.rs
@@ -24,62 +24,64 @@ use gaptos::{
     },
 };
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::{Arc, Mutex},
+    collections::{BTreeMap, HashMap},
+    ops::Bound,
+    sync::Mutex,
     time::{Duration, Instant},
 };
 
 use super::transaction::VerifiedTxn;
 use block_buffer_manager::TxPool;
 
-/// Broadcast deduplication cache. Suppresses re-emission of the same txn hash
-/// across consecutive `read_timeline` ticks. Single-generation: when capacity
-/// or TTL is exceeded, the whole set is cleared. The worst-case effect of a
-/// clear is one extra broadcast of an in-flight txn, which the gossip layer
-/// will dedupe.
-pub struct TxnCache {
-    cache: HashSet<TxnHash>,
-    size: usize,
-    last_clear: Instant,
-    ttl: Duration,
+/// Per-txn metadata maintained for broadcast scheduling.
+struct TxnMeta {
+    sender_bucket: MempoolSenderBucket,
+    timeline_id: u64,
+    insertion_time: Instant,
 }
 
-impl TxnCache {
-    fn new(size: usize) -> Self {
-        let ttl_secs = std::env::var("MEMPOOL_BROADCAST_CACHE_TTL_SECS")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(60);
+/// In-memory index that mirrors the upstream reth pool's broadcastable set,
+/// adding the per-(sender_bucket) ordering that the Aptos broadcast loop
+/// expects. Each new txn is assigned a monotonic `timeline_id` within its
+/// `sender_bucket` on first observation; entries are GC'd when the txn
+/// disappears from the pool.
+///
+/// This replaces the previous global `TxnCache` (single-generation TTL
+/// HashSet), which ignored sender_bucket / count / before / timeline_id and
+/// caused one peer to drain the entire pool per tick.
+struct BroadcastIndex {
+    /// `timelines[sender_bucket]: BTreeMap<timeline_id, TxnHash>`
+    timelines: Vec<BTreeMap<u64, TxnHash>>,
+    /// Reverse index: txn hash -> metadata. Used for failover-delay lookup
+    /// and for GC when the pool drops a txn.
+    by_hash: HashMap<TxnHash, TxnMeta>,
+    /// Next `timeline_id` to assign per sender_bucket. Starts at 1 so that
+    /// the initial state of `id_per_bucket: vec![0; ..]` excludes nothing.
+    next_ids: Vec<u64>,
+}
+
+impl BroadcastIndex {
+    fn new(num_sender_buckets: usize) -> Self {
         Self {
-            cache: HashSet::new(),
-            size,
-            last_clear: Instant::now(),
-            ttl: Duration::from_secs(ttl_secs),
+            timelines: vec![BTreeMap::new(); num_sender_buckets],
+            by_hash: HashMap::new(),
+            next_ids: vec![1; num_sender_buckets],
         }
-    }
-
-    fn maybe_clear(&mut self) {
-        if self.cache.len() > self.size || self.last_clear.elapsed() > self.ttl {
-            self.cache.clear();
-            self.last_clear = Instant::now();
-        }
-    }
-
-    fn insert(&mut self, txn_hash: TxnHash) {
-        self.maybe_clear();
-        self.cache.insert(txn_hash);
-    }
-
-    pub fn is_contains(&mut self, txn_hash: &TxnHash) -> bool {
-        self.maybe_clear();
-        self.cache.contains(txn_hash)
     }
 }
 
 pub struct Mempool {
-    // Stores the metadata of all transactions in mempool (of all states).
     pool: Box<dyn TxPool>,
-    txn_cache: Arc<Mutex<TxnCache>>,
+    index: Mutex<BroadcastIndex>,
+    num_sender_buckets: MempoolSenderBucket,
+}
+
+/// Map a sender address to its `sender_bucket`, matching upstream Aptos
+/// (`transaction_store.rs::sender_bucket`): the last byte of the address
+/// modulo `num_sender_buckets`.
+fn sender_bucket_of(sender: &ExternalAccountAddress, num_sender_buckets: MempoolSenderBucket) -> MempoolSenderBucket {
+    let bytes = sender.bytes();
+    bytes[bytes.len() - 1] % num_sender_buckets
 }
 
 impl CoreMempoolTrait for Mempool {
@@ -106,28 +108,138 @@ impl CoreMempoolTrait for Mempool {
         vec![]
     }
 
+    /// Honors all four routing parameters from upstream Aptos:
+    /// - `sender_bucket`: only return txns whose sender hashes into this bucket.
+    /// - `timeline_id`: resume from the per-peer cursor (max position taken
+    ///   as the single id; we don't subdivide by fee bucket).
+    /// - `count`: cap on the returned batch.
+    /// - `before`: failover-delay gate; skip txns first observed after this
+    ///   instant. Breaks the scan since `timeline_id` is monotonic with
+    ///   observation time.
+    ///
+    /// `priority_of_receiver` is unused — the caller selects `before` based
+    /// on it. The returned `MultiBucketTimelineIndexIds` length matches the
+    /// input length (so `state.timelines[sender_bucket]` stays well-formed);
+    /// we write the single resume id into every position.
     fn read_timeline(
         &self,
-        _sender_bucket: MempoolSenderBucket,
-        _timeline_id: &MultiBucketTimelineIndexIds,
-        _count: usize,
-        _before: Option<Instant>,
+        sender_bucket: MempoolSenderBucket,
+        timeline_id: &MultiBucketTimelineIndexIds,
+        count: usize,
+        before: Option<Instant>,
         _priority_of_receiver: BroadcastPeerPriority,
     ) -> (Vec<(SignedTransaction, u64)>, MultiBucketTimelineIndexIds) {
-        let visited = self.txn_cache.clone();
-        let filter = Box::new(move |txn: (ExternalAccountAddress, u64, TxnHash)| {
-            !visited.lock().unwrap().is_contains(&txn.2)
-        });
-        let iter = self.pool.get_broadcast_txns(Some(filter));
-        let mut broacasted_txns = vec![];
-        let mut visited_cache = self.txn_cache.lock().unwrap();
-        for txn in iter {
-            visited_cache.insert(TxnHash::from_bytes(txn.committed_hash().as_slice()));
-            broacasted_txns.push((VerifiedTxn::from(txn).into(), 0));
+        let num_fee_buckets = timeline_id.id_per_bucket.len();
+        if num_fee_buckets == 0 || count == 0 {
+            return (vec![], timeline_id.clone());
         }
-        let len = broacasted_txns.len();
+        let bucket_idx = sender_bucket as usize;
+        if bucket_idx >= self.num_sender_buckets as usize {
+            return (
+                vec![],
+                MultiBucketTimelineIndexIds { id_per_bucket: vec![0; num_fee_buckets] },
+            );
+        }
 
-        (broacasted_txns, MultiBucketTimelineIndexIds { id_per_bucket: vec![0; len] })
+        // Snapshot the reth pool's broadcastable set. We pass `None` for the
+        // filter so we see every pending txn and can keep our index in sync.
+        let snapshot: Vec<gaptos::api_types::VerifiedTxn> =
+            self.pool.get_broadcast_txns(None).collect();
+
+        // Build a hash -> txn lookup once for the snapshot, used both for GC
+        // detection and for materializing the output.
+        let mut snapshot_by_hash: HashMap<TxnHash, gaptos::api_types::VerifiedTxn> =
+            HashMap::with_capacity(snapshot.len());
+        for txn in snapshot {
+            let hash = TxnHash::from_bytes(txn.committed_hash().as_slice());
+            snapshot_by_hash.insert(hash, txn);
+        }
+
+        let now = Instant::now();
+        let num_sender_buckets = self.num_sender_buckets;
+        let mut idx = self.index.lock().unwrap();
+
+        // GC entries whose txns are no longer in the pool (committed,
+        // expired, or evicted upstream).
+        let stale: Vec<TxnHash> = idx
+            .by_hash
+            .keys()
+            .filter(|h| !snapshot_by_hash.contains_key(*h))
+            .copied()
+            .collect();
+        for h in &stale {
+            if let Some(meta) = idx.by_hash.remove(h) {
+                if let Some(tl) = idx.timelines.get_mut(meta.sender_bucket as usize) {
+                    tl.remove(&meta.timeline_id);
+                }
+            }
+        }
+
+        // Assign a timeline_id to txns we've never seen, regardless of which
+        // sender_bucket this call targets — other ticks will ask about the
+        // remaining buckets.
+        for (hash, txn) in &snapshot_by_hash {
+            if idx.by_hash.contains_key(hash) {
+                continue;
+            }
+            let sb = sender_bucket_of(txn.sender(), num_sender_buckets);
+            let sb_idx = sb as usize;
+            if sb_idx >= idx.timelines.len() {
+                // Defensive: skip if config indicates more buckets than we
+                // allocated. Should not happen since both come from the same
+                // config at Mempool construction time.
+                continue;
+            }
+            let tid = idx.next_ids[sb_idx];
+            idx.next_ids[sb_idx] = idx.next_ids[sb_idx].saturating_add(1);
+            idx.timelines[sb_idx].insert(tid, *hash);
+            idx.by_hash.insert(
+                *hash,
+                TxnMeta { sender_bucket: sb, timeline_id: tid, insertion_time: now },
+            );
+        }
+
+        // Resume from the max position in the input. We don't subdivide by
+        // fee bucket internally, so all positions encode the same id; taking
+        // max is robust even if a caller hands us heterogenous values.
+        let resume_id = *timeline_id.id_per_bucket.iter().max().unwrap_or(&0);
+        let mut last_seen_id = resume_id;
+        let mut output_txns: Vec<(SignedTransaction, u64)> = Vec::new();
+
+        for (&tid, hash) in idx.timelines[bucket_idx]
+            .range((Bound::Excluded(resume_id), Bound::Unbounded))
+        {
+            if output_txns.len() >= count {
+                break;
+            }
+            let meta = match idx.by_hash.get(hash) {
+                Some(m) => m,
+                None => continue,
+            };
+            if let Some(before) = before {
+                if meta.insertion_time >= before {
+                    // timeline_id is monotonic with insertion_time, so every
+                    // subsequent entry is also too fresh; bail out.
+                    break;
+                }
+            }
+            let verified_gaptos = match snapshot_by_hash.get(hash) {
+                Some(t) => t,
+                None => continue,
+            };
+            let local: VerifiedTxn = verified_gaptos.clone().into();
+            let signed: SignedTransaction = local.into();
+            // ready_time (second tuple element) is left as 0, matching the
+            // previous behavior. Wiring it to the txn's real insertion time
+            // is a follow-up — needs SystemTime tracking, not just Instant.
+            output_txns.push((signed, 0));
+            last_seen_id = tid;
+        }
+
+        let new_ids = MultiBucketTimelineIndexIds {
+            id_per_bucket: vec![last_seen_id; num_fee_buckets],
+        };
+        (output_txns, new_ids)
     }
 
     fn gc(&mut self) {
@@ -208,8 +320,13 @@ impl CoreMempoolTrait for Mempool {
 }
 
 impl Mempool {
-    pub fn new(_config: &NodeConfig, pool: Box<dyn TxPool>) -> Self {
-        Self { pool, txn_cache: Arc::new(Mutex::new(TxnCache::new(100000))) }
+    pub fn new(config: &NodeConfig, pool: Box<dyn TxPool>) -> Self {
+        let num_sender_buckets = config.mempool.num_sender_buckets.max(1);
+        Self {
+            pool,
+            index: Mutex::new(BroadcastIndex::new(num_sender_buckets as usize)),
+            num_sender_buckets,
+        }
     }
 
     /// This function will be called once the transaction has been stored.
@@ -287,55 +404,94 @@ impl Mempool {
 
 #[cfg(test)]
 mod tests {
+    //! Tests for the broadcast index. They exercise `BroadcastIndex` directly
+    //! rather than going through `Mempool::read_timeline`, because the latter
+    //! needs a `TxPool` (which requires the full reth pool wiring). The end-
+    //! to-end behavior is covered by integration tests in the broadcast loop.
+
     use super::*;
 
-    fn mock_txn_hash(id: u64) -> TxnHash {
-        TxnHash::from_bytes(&[id as u8; 32])
+    fn hash_of(id: u8) -> TxnHash {
+        TxnHash::from_bytes(&[id; 32])
     }
 
     #[test]
-    fn test_txn_cache_size_clear() {
-        let cache_size = 2;
-        let mut cache = TxnCache::new(cache_size);
-
-        let h1 = mock_txn_hash(1);
-        let h2 = mock_txn_hash(2);
-        let h3 = mock_txn_hash(3);
-        let h4 = mock_txn_hash(4);
-
-        // Fill past capacity. maybe_clear runs *before* each op, so the third
-        // insert still goes through (len=2 is not > 2 yet) and lands in the set.
-        cache.insert(h1);
-        cache.insert(h2);
-        cache.insert(h3);
-        assert_eq!(cache.cache.len(), 3); // direct field read avoids triggering maybe_clear
-
-        // Next op sees len=3 > size=2 and clears. Then h4 is inserted.
-        cache.insert(h4);
-        assert_eq!(cache.cache.len(), 1);
-        assert!(cache.is_contains(&h4));
-        assert!(!cache.is_contains(&h1));
-        assert!(!cache.is_contains(&h2));
-        assert!(!cache.is_contains(&h3));
+    fn sender_bucket_takes_last_byte_mod_n() {
+        let mut addr = [0u8; 32];
+        addr[31] = 7;
+        let a = ExternalAccountAddress::new(addr);
+        assert_eq!(sender_bucket_of(&a, 4), 3);
+        assert_eq!(sender_bucket_of(&a, 8), 7);
+        assert_eq!(sender_bucket_of(&a, 1), 0);
     }
 
     #[test]
-    fn test_txn_cache_ttl_clear() {
-        let cache_size = 100_000; // large enough that only TTL triggers clear
-        let mut cache = TxnCache::new(cache_size);
-        cache.ttl = Duration::from_millis(50);
+    fn broadcast_index_partitions_by_sender_bucket() {
+        // Two txns landing in different sender buckets should advance
+        // independent timeline_ids.
+        let mut idx = BroadcastIndex::new(4);
+        let now = Instant::now();
+        let h1 = hash_of(1);
+        let h2 = hash_of(2);
+        idx.timelines[0].insert(1, h1);
+        idx.by_hash.insert(h1, TxnMeta { sender_bucket: 0, timeline_id: 1, insertion_time: now });
+        idx.next_ids[0] = 2;
+        idx.timelines[2].insert(1, h2);
+        idx.by_hash.insert(h2, TxnMeta { sender_bucket: 2, timeline_id: 1, insertion_time: now });
+        idx.next_ids[2] = 2;
 
-        let h1 = mock_txn_hash(1);
-        let h2 = mock_txn_hash(2);
+        assert_eq!(idx.timelines[0].len(), 1);
+        assert_eq!(idx.timelines[1].len(), 0);
+        assert_eq!(idx.timelines[2].len(), 1);
+        assert_eq!(idx.timelines[3].len(), 0);
+    }
 
-        cache.insert(h1);
-        assert!(cache.is_contains(&h1));
+    #[test]
+    fn range_query_respects_resume_id() {
+        // BTreeMap::range with Excluded lower-bound is what makes the resume
+        // semantics work — guard against accidental Bound::Included changes.
+        let mut idx = BroadcastIndex::new(1);
+        let now = Instant::now();
+        for i in 1u64..=5 {
+            let h = hash_of(i as u8);
+            idx.timelines[0].insert(i, h);
+            idx.by_hash.insert(h, TxnMeta { sender_bucket: 0, timeline_id: i, insertion_time: now });
+        }
+        let after_two: Vec<u64> = idx.timelines[0]
+            .range((Bound::Excluded(2u64), Bound::Unbounded))
+            .map(|(&k, _)| k)
+            .collect();
+        assert_eq!(after_two, vec![3, 4, 5]);
+    }
 
-        std::thread::sleep(Duration::from_millis(60));
+    #[test]
+    fn failover_before_filter_breaks_scan() {
+        // Once we hit a txn that's too fresh, the whole tail is too fresh
+        // (timeline_ids are assigned in arrival order). The scan must break,
+        // not continue — otherwise `last_seen_id` would advance past txns
+        // that should still be re-presented on the next tick.
+        let mut idx = BroadcastIndex::new(1);
+        let t0 = Instant::now() - Duration::from_secs(10);
+        let t_recent = Instant::now();
+        idx.timelines[0].insert(1, hash_of(1));
+        idx.by_hash.insert(hash_of(1), TxnMeta { sender_bucket: 0, timeline_id: 1, insertion_time: t0 });
+        idx.timelines[0].insert(2, hash_of(2));
+        idx.by_hash.insert(hash_of(2), TxnMeta { sender_bucket: 0, timeline_id: 2, insertion_time: t_recent });
+        idx.timelines[0].insert(3, hash_of(3));
+        idx.by_hash.insert(hash_of(3), TxnMeta { sender_bucket: 0, timeline_id: 3, insertion_time: t_recent });
 
-        // Next op triggers clear; h1 is gone, h2 stays.
-        cache.insert(h2);
-        assert!(!cache.is_contains(&h1));
-        assert!(cache.is_contains(&h2));
+        let before = Instant::now() - Duration::from_secs(1);
+        let mut last_seen = 0u64;
+        let mut out = vec![];
+        for (&tid, _h) in idx.timelines[0].range((Bound::Excluded(0u64), Bound::Unbounded)) {
+            let meta = idx.by_hash.get(&hash_of(tid as u8)).unwrap();
+            if meta.insertion_time >= before {
+                break;
+            }
+            out.push(tid);
+            last_seen = tid;
+        }
+        assert_eq!(out, vec![1]);
+        assert_eq!(last_seen, 1);
     }
 }


### PR DESCRIPTION
## Summary

`CoreMempool::read_timeline` was ignoring every routing parameter (`sender_bucket`, `timeline_id`, `count`, `before`, `priority_of_receiver`) and using a single global `TxnCache` to dedup across consecutive ticks. The result: the first call of any tick drained every broadcastable txn from the reth pool into one batch, and every subsequent call (other buckets, Failover priority, even other peers) returned empty until the cache's TTL/capacity expired ~60s later.

### Observable bugs

- **sender_bucket fan-out across PFNs collapsed.** Whichever peer the broadcast loop iterated first this tick swallowed the entire pool; the other PFN got nothing for ~60s.
- **Failover delay (`shared_mempool_failover_delay_ms`) bypassed.** `before` was ignored, so Failover peers received txns with the same timing as Primary.
- **`shared_mempool_batch_size` cap bypassed.** A single broadcast batch could contain the entire pool.
- **Peer-side resume state broken.** The returned `MultiBucketTimelineIndexIds.id_per_bucket` had length equal to the txn count rather than the number of fee buckets, so `PeerSyncState::timelines` never advanced meaningfully.

### Fix

Replace `TxnCache` with a `BroadcastIndex` that lazily mirrors the reth pool's broadcastable set, assigning each txn a monotonic `timeline_id` within its `sender_bucket` on first observation. `read_timeline` now:

- Filters by `sender_bucket` (last-byte-mod-N, matching `transaction_store::sender_bucket` in upstream Aptos).
- Resumes after the input `timeline_id` (max across positions; this PR does not subdivide by fee bucket internally — see follow-ups).
- Caps at `count`.
- Skips txns first observed after `before` and breaks the scan on the first too-fresh entry (timeline_id is monotonic with insertion time, so the tail is also too fresh).
- Returns a `MultiBucketTimelineIndexIds` whose length matches the caller's input so `PeerSyncState` stays well-formed.

GC: entries are dropped when their txn no longer appears in the snapshot from the upstream pool (committed, expired, or evicted).

### Follow-ups (intentionally out of scope)

- **Per-(sender_bucket, fee_bucket) subdivision.** Requires exposing gas price from `TxPool::get_broadcast_txns`. Current PR collapses all fee buckets into one timeline, which loses high-fee-first ordering within a broadcast batch but matches the reth pool's natural ordering.
- **Accurate `ready_time` emission.** Needs `SystemTime` tracking in addition to `Instant`. Left at `0` to match prior behavior.
- **`timeline_range` retransmit path.** Still returns empty (unchanged from before); orthogonal to this fix.

## Test plan

- [x] `cargo check -p aptos-mempool` — passes
- [x] `cargo test -p aptos-mempool --lib` — 4 new unit tests pass:
  - `sender_bucket_takes_last_byte_mod_n` (sender_bucket arithmetic)
  - `broadcast_index_partitions_by_sender_bucket` (bucket partitioning)
  - `range_query_respects_resume_id` (`BTreeMap::range` resume semantics)
  - `failover_before_filter_breaks_scan` (`before`-driven scan break)
- [ ] Validator/PFN broadcast smoke: confirm both PFNs receive a balanced share of new txns under load
- [ ] Confirm `shared_mempool_failover_delay_ms` is honored on Failover peers (Failover broadcasts strictly lag Primary by configured delay)
- [ ] Watch for regressions in the per-peer distribution of the broadcast metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)