### PR TITLE
fix(harness): make pfn_chain_stress robust on cross-FS / flaky-net hosts

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -1008,7 +1008,9 @@ main() {
         mkdir -p "$log_dir"/{execution_logs,consensus_log}
         
         # Create hardlink for gravity_node binary in each node's bin dir
-        ln -f "$node_binary" "$data_dir/bin/gravity_node"
+        # Fall back to cp if /tmp and target/ live on different filesystems.
+        ln -f "$node_binary" "$data_dir/bin/gravity_node" 2>/dev/null \
+            || cp -f "$node_binary" "$data_dir/bin/gravity_node"
         
         waypoint_src="$OUTPUT_DIR/waypoint.txt"
 

--- a/cluster/genesis.sh
+++ b/cluster/genesis.sh
@@ -51,14 +51,17 @@ main() {
     log_info "Checking out ref: $GENESIS_REF..."
     (
         cd "$GENESIS_CONTRACT_DIR"
-        git fetch origin
+        # Tolerate transient network failures — local working copy is usually
+        # already at the right ref, and a stale local copy is better than a
+        # hard failure for this stress-test workflow.
+        git fetch origin || log_warn "git fetch origin failed (continuing with local refs)"
         # Discard local modifications from previous runs (e.g. genesis_template.json)
         git checkout -- .
         git checkout "$GENESIS_REF"
         # Pull latest if on a branch (no-op for detached HEAD / commit hash)
         if git symbolic-ref -q HEAD &>/dev/null; then
             log_info "Pulling latest changes for branch $GENESIS_REF..."
-            git pull origin "$GENESIS_REF"
+            git pull origin "$GENESIS_REF" || log_warn "git pull failed (continuing with local refs)"
         fi
         # Fix Python 3.9 compatibility: `str | None` → `Optional[str]`
         python3 -c "

--- a/regression/pfn_chain_stress/run.sh
+++ b/regression/pfn_chain_stress/run.sh
@@ -288,9 +288,12 @@ for id in $(cluster_ids); do
     port="$(rpc_port_for "$id" node1)"
     echo -n "[run] waiting cluster $id node1 (port $port)…"
     while [[ $(date +%s) -lt $deadline ]]; do
-        bn=$(curl -s --noproxy '*' -m 2 -X POST -H 'Content-Type: application/json' \
+        # Tolerate curl exit 7 (connection refused) during startup — without
+        # `|| true` set -e + pipefail would abort the script on the first
+        # missed probe.
+        bn=$( { curl -s --noproxy '*' -m 2 -X POST -H 'Content-Type: application/json' \
             --data '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}' \
-            "http://127.0.0.1:$port" 2>/dev/null \
+            "http://127.0.0.1:$port" 2>/dev/null || true; } \
             | sed -n 's/.*"result":"\(0x[0-9a-fA-F]*\)".*/\1/p')
         if [[ -n "$bn" && "$bn" != "0x0" ]]; then
             echo " block=$bn"


### PR DESCRIPTION
Three small defensive fixes hit while reproducing a mempool issue with the pfn_chain_stress harness on a host where `/tmp` is tmpfs and the repo lives on a separate device, and where GitHub fetches occasionally hiccup. None of these change runtime behavior of the binary under test — they only affect the harness's resilience on developer-machine variations.

## 1. `cluster/deploy.sh` — cross-device hardlink

`gravity_node` is hardlinked into each node's `/tmp/gravity-cluster-pfn-*/<node>/bin/`. When `/tmp` and `target/` are on different filesystems the `ln -f` fails with "Invalid cross-device link" and tears down the whole setup.

Fall back to `cp -f` — matches what the `gravity_cli` path a few lines up already does (and the inline comment claims).

## 2. `cluster/genesis.sh` — flaky-network git fetch

Every run does `git fetch origin` + `git pull origin <ref>` on `external/gravity_chain_core_contracts`. A transient network error there kills the whole stress run.

Demote both to warnings — the local working copy is usually already at the right ref, and a stale local copy is strictly better than a hard failure for this workflow.

## 3. `regression/pfn_chain_stress/run.sh` — wait-for-chain set -e brittleness

The wait-for-chain loop does `bn=$(curl ... | sed ...)` under `set -euo pipefail`. The first probe typically lands while node1's RPC is still starting; curl exits 7, `pipefail` propagates it through the command substitution, and `set -e` kills the script before the chain is even up.

Wrap curl in `{ ... || true; }` so the wait loop actually waits.

## Test plan

- [x] Ran `./run.sh pfn3 --clean` end-to-end on a host where all three failure modes were hit; harness now completes cleanly through bench + TPS analysis.
- [ ] Verify no regression on a 'pristine' host where /tmp and target/ are same FS (no functional change there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)