### PR TITLE
ci(nightly): drop `environment: default` from e2e-docker-nightly

### DIFF
--- a/.github/workflows/e2e-docker-nightly.yml
+++ b/.github/workflows/e2e-docker-nightly.yml
@@ -16,7 +16,6 @@ jobs:
     name: E2E Nightly - fuzzy_cluster
     runs-on: [self-hosted, linux]
     timeout-minutes: 120
-    environment: default
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## Summary

The `fuzzy_cluster` nightly does not reference any environment-scoped
secrets, reviewers or URLs — declaring `environment: default` only
causes GitHub Actions to register a `Deployment` record for every run.
Because the suite has been failing every night for ~2 weeks, the repo's
[Deployments tab](https://github.com/Galxe/gravity-sdk/deployments) is
now filled with red `default` entries that have nothing to do with an
actual deployment.

Removing the line stops the bogus Deployment records without touching
the run itself. The underlying nightly failure (`Failed to find PoolCreated event`) is unrelated and tracked separately.

## Test plan

- [x] `actionlint` clean (single-line deletion in `.github/workflows/e2e-docker-nightly.yml`)
- [ ] After merge: confirm next nightly run does **not** create a new entry under `Deployments`
- [ ] After merge: existing failed `default` Deployment records can be cleaned up via the GitHub API or left to decay