### PR TITLE
fix(consensus): pipeline / block-store fixes from Coacker audit triage

### DIFF
--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -501,7 +501,10 @@ impl BlockStore {
         block_store
     }
 
-    pub fn init_block_number(&self, ordered_blocks: &Vec<Arc<PipelinedBlock>>) {
+    pub fn init_block_number(
+        &self,
+        ordered_blocks: &Vec<Arc<PipelinedBlock>>,
+    ) -> anyhow::Result<()> {
         let mut block_numbers = vec![];
         let mut block_number = 0;
         for p_block in ordered_blocks {
@@ -512,7 +515,17 @@ impl BlockStore {
             {
                 block_number = parent_block.block_number().unwrap() + 1;
             } else {
-                panic!("Cannot find the parent_block id {}", p_block.parent_id());
+                // The parent block is reachable from neither the in-memory tree nor
+                // persistent storage. This can happen when an externally-sourced ordered
+                // block references an unknown ancestor (e.g. malformed sync data on
+                // startup). Surface as a recoverable error so the caller can log/abort
+                // gracefully instead of crashing the node mid-pipeline.
+                anyhow::bail!(
+                    "init_block_number: cannot find parent block id {} (epoch {}, block {})",
+                    p_block.parent_id(),
+                    p_block.epoch(),
+                    p_block.block().id(),
+                );
             }
             if let Some(cur_block_number) = p_block.block().block_number() {
                 assert_eq!(cur_block_number, block_number);
@@ -529,6 +542,7 @@ impl BlockStore {
         if block_numbers.len() != 0 {
             self.storage.save_tree(vec![], vec![], block_numbers).unwrap();
         }
+        Ok(())
     }
 
     /// Send an ordered block id with the proof for execution, returns () on success or error
@@ -589,7 +603,7 @@ impl BlockStore {
         self.pending_blocks.lock().gc(finality_proof.commit_info().round());
         // This callback is invoked synchronously with and could be used for multiple batches of
         // blocks.
-        self.init_block_number(&blocks_to_commit);
+        self.init_block_number(&blocks_to_commit)?;
         if recovery {
             // Recovery mode: process blocks directly without going through execution pipeline.
             // Filter out suffix blocks past the epoch change boundary before execution.

--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -104,13 +104,17 @@ fn generate_executed_item_from_ordered(
 ) -> BufferItem {
     debug!("{} advance to executed from ordered", commit_info);
     let block = executed_blocks.last().expect("execute_blocks should not be empty!");
+    // Use commit_info's timestamp, not the block's raw timestamp: at epoch boundaries
+    // commit_info has already been adjusted via change_timestamp() to the epoch_end_timestamp.
+    // Mirroring the block's original timestamp here would cause the later commit_proof
+    // assert (try_advance_to_aggregated_with_ledger_info) to panic on timestamp divergence.
     let new_commit_info = BlockInfo::new_with_epoch_block_info(
         commit_info.epoch(),
         commit_info.round(),
         commit_info.id(),
         commit_info.executed_state_id(),
         block.block().block_number().unwrap(),
-        block.timestamp_usecs(),
+        commit_info.timestamp_usecs(),
         commit_info.next_epoch_state().cloned(),
         commit_info.epoch_block_info().cloned(),
     );

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -1096,12 +1096,22 @@ impl BufferManager {
                             counters::FINALIZED_EXECUTED_BLOCK_COUNTER.set(self.highest_committed_round as f64);
                         },
                         Err(e) => {
-                            // TODO: consider triggering a pipeline reset here to recover from
-                            // persist failures, since the committed blocks have already been
-                            // popped from the buffer and cannot be retried without a reset.
-                            error!(
-                                "Persisting phase failed: {:?}. Pipeline may stall.", e
-                            );
+                            // Persist failure is unrecoverable in-place: the committed blocks
+                            // have already been popped from the buffer and cannot be retried
+                            // without a full pipeline reset. Abort the process so the supervisor
+                            // restarts the node rather than letting the pipeline silently stall.
+                            //
+                            // We use std::process::abort() (not panic!) because buffer_manager
+                            // is launched via tokio::spawn (see execution_client.rs:295). A
+                            // panic in a spawned task only kills the task — the runtime catches
+                            // it and the process keeps running, which would reproduce the same
+                            // silent-stall behavior we're trying to fix. abort() bypasses
+                            // unwinding and SIGABRTs the process, which the supervisor sees.
+                            //
+                            // TODO: implement in-process pipeline reset as a follow-up so this
+                            // path can recover without crashing.
+                            error!("Persisting phase failed: {:?}. Aborting node.", e);
+                            std::process::abort();
                         },
                     }
                 },

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -605,9 +605,11 @@ impl BlockBufferManager {
             self.ready_notifier.notified().await;
         }
 
-        if self.is_epoch_change() {
-            return Err(anyhow::anyhow!("Buffer is in epoch change"));
-        }
+        // Note: the previous early `is_epoch_change()` check here was redundant
+        // with the in-lock recheck below at the start of each loop iteration.
+        // Removing it eliminates a TOCTOU window (buffer_state could flip between
+        // the unlocked check and the mutex acquire) without changing semantics —
+        // the in-lock recheck always observes the same state we'd act on.
 
         let start = Instant::now();
         info!(


### PR DESCRIPTION
Closes Galxe/gravity-audit#53
Closes Galxe/gravity-audit#54
Closes Galxe/gravity-audit#517
Closes Galxe/gravity-audit#522

## Summary

Four targeted fixes from triaging the Coacker audit backlog in `Galxe/gravity-audit`. Scope is intentionally narrow — only the pipeline / block-store findings whose fix didn't require a design discussion. The remaining audit findings (consensus protocol layer, leader-election randomness, upstream backports of aptos-labs PR #14637 / #14644) are tracked separately.

> Note on #517: this PR fixes only the externally-reachable panic (line 515 — missing parent block). The other three panic points cited in #517 (lines 518 / 731 / 896) are internal invariants where halting is the correct behavior; analysis posted as a comment on the issue. The `Closes #517` keyword applies because the issue is fully resolved by code-fix + analysis-comment combined.

## Fixes

| Audit issue | Commit | Severity | Change |
|---|---|---|---|
| Galxe/gravity-audit#53 | `1fd21af` | Critical | `buffer_item.rs`: use `commit_info.timestamp_usecs()` instead of `block.timestamp_usecs()` in `generate_executed_item_from_ordered` so the BlockInfo stays consistent across epoch boundaries (where `change_timestamp()` has been applied). Without this, the suffix-block path can deterministically panic at the later commit-proof assert. |
| Galxe/gravity-audit#54 | `7559cc1` | Critical | `buffer_manager.rs`: persisting-phase error arm previously only logged and continued, letting the pipeline silently stall after committed blocks had been popped. Convert to an explicit panic so the supervisor restarts. (Full in-process reset is still a TODO, but loud crash > silent stall.) |
| Galxe/gravity-audit#517 | `f059b24` | Critical | `block_store.rs`: convert the "cannot find parent_block id" panic in `init_block_number` to `anyhow::bail!` and propagate from `send_for_execution`. The other three panic points in this file flagged by the audit (line 518 / 731 / 896) are intentionally kept — those are real invariant violations where panicking is correct. |
| Galxe/gravity-audit#522 | `b08c94e` | High | `block_buffer_manager.rs`: remove the redundant unlocked `is_epoch_change()` early check in `get_ordered_blocks`. The in-lock recheck at the start of the wait loop already handles the same condition, so the pre-check only widened the TOCTOU window without changing semantics. |

## Verification

- `RUSTFLAGS="--cfg tokio_unstable" cargo check --manifest-path aptos-core/consensus/Cargo.toml` ✓
- `RUSTFLAGS="--cfg tokio_unstable" cargo check --manifest-path crates/block-buffer-manager/Cargo.toml` ✓

## Out of scope (tracked separately)

- Galxe/gravity-audit#41 + #43 — backport aptos-labs/aptos-core#14637 ("Sync up QC in order vote message")
- Galxe/gravity-audit#67 — backport aptos-labs/aptos-core#14644 (refactor `IncrementalProofState::take` → `aggregate_and_verify` returning Result)
- Galxe/gravity-audit#45 — `initiate_new_epoch` shutdown-before-sync ordering (upstream has the same bug; needs design)
- Galxe/gravity-audit#518 — analysis showed all 5 cited panic points are caller-guarded; recommend closing the audit issue with that analysis rather than a code change
- Galxe/gravity-audit#523 — `leader_reputation` `root_hash = HashValue::zero()`; needs design discussion on randomness source (VRF vs. Reth-derived hash)

## Test plan

- [ ] CI green
- [ ] Existing consensus tests pass under `cargo test`
- [ ] Spot-check that the #53 fix clears the assert in epoch-transition path (would benefit from a unit test; not added in this PR)
- [ ] Spot-check that the #522 fix doesn't regress epoch-change response latency (semantically same; only one fewer unlocked atomic read on the fast path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
