### PR TITLE
fix(consensus): return Result from IncrementalProofState::take instead of panicking

### DIFF
--- a/aptos-core/consensus/consensus-types/src/proof_of_store.rs
+++ b/aptos-core/consensus/consensus-types/src/proof_of_store.rs
@@ -274,6 +274,7 @@ pub enum SignedBatchInfoError {
     NotFound,
     AlreadyCommitted,
     NoTimeStamps,
+    UnableToAggregate,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/aptos-core/consensus/src/quorum_store/proof_coordinator.rs
+++ b/aptos-core/consensus/src/quorum_store/proof_coordinator.rs
@@ -117,17 +117,25 @@ impl IncrementalProofState {
         }
     }
 
-    fn take(&mut self, validator_verifier: &ValidatorVerifier) -> ProofOfStore {
+    fn take(
+        &mut self,
+        validator_verifier: &ValidatorVerifier,
+    ) -> Result<ProofOfStore, SignedBatchInfoError> {
         if self.completed {
             panic!("Cannot call take twice, unexpected issue occurred");
         }
-        self.completed = true;
 
         match validator_verifier.aggregate_signatures(
             PartialSignatures::new(self.aggregated_signature.clone()).signatures_iter(),
         ) {
-            Ok(sig) => ProofOfStore::new(self.info.clone(), sig),
-            Err(e) => unreachable!("Cannot aggregate signatures on digest err = {:?}", e),
+            Ok(sig) => {
+                self.completed = true;
+                Ok(ProofOfStore::new(self.info.clone(), sig))
+            }
+            Err(e) => {
+                error!("Cannot aggregate signatures on digest err = {:?}", e);
+                Err(SignedBatchInfoError::UnableToAggregate)
+            }
         }
     }
 
@@ -216,7 +224,7 @@ impl ProofCoordinator {
         if let Some(value) = self.batch_info_to_proof.get_mut(signed_batch_info.batch_info()) {
             value.add_signature(&signed_batch_info, validator_verifier)?;
             if !value.completed && value.ready(validator_verifier) {
-                let proof = value.take(validator_verifier);
+                let proof = value.take(validator_verifier)?;
                 txn_metrics::TxnLifeTime::get_txn_life_time().record_proof(proof.info().batch_id());
                 // proof validated locally, so adding to cache
                 self.proof_cache.insert(proof.info().clone(), proof.multi_signature().clone());


### PR DESCRIPTION
## Summary
- Minimal surgical fix for [gravity-audit#67](https://github.com/Galxe/gravity-audit/issues/67) (Critical).
- Replaces `unreachable!()` in `IncrementalProofState::take` with a real `Result` return so the `ProofCoordinator` task survives a BLS aggregation failure (e.g. after validator-set rotation) instead of crashing and halting consensus.
- Adds `SignedBatchInfoError::UnableToAggregate` and propagates `?` at the single caller.

## Why minimal (not a full backport of upstream #14644)
Upstream aptos-core PR [#14644](https://github.com/aptos-labs/aptos-core/pull/14644) fixes the same panic but as part of a much larger refactor (~466 lines of conflicts against our vendored consensus). This PR ports only the panic→Result slice; we can decide later whether to take the rest of the refactor.

## Test plan
- [x] `cargo check -p aptos-consensus --tests` passes.
- [ ] Reviewer: confirm no other in-tree callers of `IncrementalProofState::take` (there is only one, in `aggregate_and_verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)