### PR TITLE
fix(consensus): equivocation detection + round-jump guard for order votes

### DIFF
--- a/aptos-core/consensus/src/pending_order_votes.rs
+++ b/aptos-core/consensus/src/pending_order_votes.rs
@@ -21,6 +21,8 @@ pub enum OrderVoteReceptionResult {
     /// The vote has been added but QC has not been formed yet. Return the amount of voting power
     /// QC currently has.
     VoteAdded(u128),
+    /// The very same author has already voted for another LedgerInfo digest (equivocation).
+    EquivocateVote,
     /// This block has just been certified after adding the vote.
     NewLedgerInfoWithSignatures(LedgerInfoWithSignatures),
     /// There might be some issues adding a vote
@@ -43,12 +45,20 @@ pub struct PendingOrderVotes {
     /// LedgerInfoWithSignatures). Order vote status stores caches the information on whether
     /// the votes are enough to form a QC.
     li_digest_to_votes: HashMap<HashValue /* LedgerInfo digest */, OrderVoteStatus>,
+    /// Maps Author to the LedgerInfo digest they have already voted for, used to
+    /// detect equivocation. Mirrors `PendingVotes::author_to_vote` so a Byzantine
+    /// validator cannot split its voting power across conflicting ordering
+    /// candidates within the same retention window.
+    author_to_li_digest: HashMap<Author, HashValue>,
 }
 
 impl PendingOrderVotes {
     /// Creates an empty PendingOrderVotes structure
     pub fn new() -> Self {
-        Self { li_digest_to_votes: HashMap::new() }
+        Self {
+            li_digest_to_votes: HashMap::new(),
+            author_to_li_digest: HashMap::new(),
+        }
     }
 
     /// Add a vote to the pending votes
@@ -60,6 +70,23 @@ impl PendingOrderVotes {
     ) -> OrderVoteReceptionResult {
         // derive data from order vote
         let li_digest = order_vote.ledger_info().hash();
+
+        // Equivocation check: if this author has previously voted for a different
+        // LedgerInfo digest, reject the new vote and surface a SecurityEvent. We
+        // intentionally do NOT short-circuit when the digest matches the previously
+        // seen one; the existing `add_signature` path is idempotent on duplicate
+        // signatures and we want to keep that behaviour observable via VoteAdded.
+        if let Some(previous_li_digest) = self.author_to_li_digest.get(&order_vote.author()) {
+            if previous_li_digest != &li_digest {
+                error!(
+                    SecurityEvent::ConsensusEquivocatingVote,
+                    remote_peer = order_vote.author(),
+                    order_vote = order_vote,
+                    previous_li_digest = previous_li_digest,
+                );
+                return OrderVoteReceptionResult::EquivocateVote;
+            }
+        }
 
         // obtain the ledger info with signatures associated to the order vote's ledger info
         let status = self.li_digest_to_votes.entry(li_digest).or_insert_with(|| {
@@ -89,6 +116,10 @@ impl PendingOrderVotes {
                 if validator_voting_power == 0 {
                     warn!("Received vote with no voting power, from {}", order_vote.author());
                 }
+                // Record the author -> digest mapping now that we know the author is
+                // a known validator. Used for equivocation detection on subsequent
+                // votes from the same author.
+                self.author_to_li_digest.insert(order_vote.author(), li_digest);
                 li_with_sig.add_signature(order_vote.author(), order_vote.signature().clone());
                 // check if we have enough signatures to create a QC
                 match validator_verifier.check_voting_power(li_with_sig.signatures().keys(), true) {
@@ -130,14 +161,29 @@ impl PendingOrderVotes {
 
     // Removes votes older than highest_ordered_round
     pub fn garbage_collect(&mut self, highest_ordered_round: u64) {
-        self.li_digest_to_votes.retain(|_, status| match status {
-            OrderVoteStatus::EnoughVotes(li_with_sig) => {
-                li_with_sig.ledger_info().round() > highest_ordered_round
+        // Collect the digests that are about to be evicted so we can drop the
+        // matching entries from `author_to_li_digest`. Without this, equivocation
+        // tracking would leak memory and (worse) keep stale digests around that
+        // could falsely flag legitimate future votes.
+        let mut evicted_digests: Vec<HashValue> = Vec::new();
+        self.li_digest_to_votes.retain(|digest, status| {
+            let keep = match status {
+                OrderVoteStatus::EnoughVotes(li_with_sig) => {
+                    li_with_sig.ledger_info().round() > highest_ordered_round
+                }
+                OrderVoteStatus::NotEnoughVotes(li_with_sig) => {
+                    li_with_sig.ledger_info().round() > highest_ordered_round
+                }
+            };
+            if !keep {
+                evicted_digests.push(*digest);
             }
-            OrderVoteStatus::NotEnoughVotes(li_with_sig) => {
-                li_with_sig.ledger_info().round() > highest_ordered_round
-            }
+            keep
         });
+        if !evicted_digests.is_empty() {
+            self.author_to_li_digest
+                .retain(|_, digest| !evicted_digests.contains(digest));
+        }
     }
 
     pub fn has_enough_order_votes(&self, ledger_info: &LedgerInfo) -> bool {

--- a/aptos-core/consensus/src/round_manager.rs
+++ b/aptos-core/consensus/src/round_manager.rs
@@ -1135,8 +1135,47 @@ impl RoundManager {
                 Err(anyhow::anyhow!("Injected error in process_order_vote_msg"))
             });
 
+            // Defense-in-depth for #43: unlike every other validator message
+            // handler, `process_order_vote_msg` does not run through
+            // `ensure_round_and_sync_up` (OrderVoteMsg carries no SyncInfo,
+            // just one QC + one OrderVote). A Byzantine peer can therefore
+            // submit an OrderVoteMsg whose embedded QC fast-forwards our
+            // local state by many rounds, then have the attached order vote
+            // accepted for a round we never sequentially processed.
+            //
+            // Snapshot `highest_ordered_round` BEFORE we apply the embedded
+            // QC, then bound how far past that snapshot the order vote round
+            // is allowed to be. The order vote signature itself is already
+            // verified inside `UnverifiedEvent::verify` (round_manager.rs
+            // line ~130 -> `verify_order_vote`), so no re-verification here.
+            //
+            // `MAX_ORDER_VOTE_ROUND_JUMP` is set to 3 to leave room for
+            // legitimate back-pressure / pipelined ordering scenarios where
+            // a node can legitimately lag a couple of rounds behind. Tighten
+            // further if telemetry shows real-world deltas are smaller.
+            const MAX_ORDER_VOTE_ROUND_JUMP: u64 = 3;
+            let pre_highest_ordered_round =
+                self.block_store.sync_info().highest_ordered_round();
+            let pre_current_round = self.round_state.current_round();
+
             let order_vote = order_vote_msg.order_vote();
             self.new_qc_from_order_vote_msg(&order_vote_msg).await?;
+
+            let vote_round = order_vote_msg.order_vote().ledger_info().round();
+            if vote_round > pre_highest_ordered_round + MAX_ORDER_VOTE_ROUND_JUMP {
+                // The embedded QC fast-forwarded us; the order vote itself
+                // is for a round we never sequentially processed. Reject as
+                // a defense-in-depth measure.
+                error!(
+                    SecurityEvent::ConsensusInvalidMessage,
+                    remote_peer = order_vote_msg.order_vote().author(),
+                    pre_current_round = pre_current_round,
+                    pre_highest_ordered_round = pre_highest_ordered_round,
+                    vote_round = vote_round,
+                    "OrderVoteMsg jumped highest_ordered_round by more than MAX_ORDER_VOTE_ROUND_JUMP",
+                );
+                return Ok(());
+            }
 
             debug!(
                 self.new_log(LogEvent::ReceiveOrderVote).remote_peer(order_vote.author()),
@@ -1354,6 +1393,12 @@ impl RoundManager {
                 ORDER_VOTE_ADDED.inc();
                 Ok(())
             }
+            // Equivocating order vote: the SecurityEvent has already been logged
+            // inside `PendingOrderVotes::insert_order_vote`. Drop the vote
+            // non-fatally so a single Byzantine validator can't poison the
+            // message handler, mirroring `VoteReceptionResult::EquivocateVote`
+            // handling in `process_vote_reception_result`.
+            OrderVoteReceptionResult::EquivocateVote => Ok(()),
             e => {
                 ORDER_VOTE_OTHER_ERRORS.inc();
                 Err(anyhow::anyhow!("{:?}", e))


### PR DESCRIPTION
## Summary
Minimal surgical fixes for two related gravity-audit findings in the order-vote path:

- **[#41](https://github.com/Galxe/gravity-audit/issues/41) (Critical)** — `PendingOrderVotes` now tracks `author -> LedgerInfo digest` and detects equivocation, mirroring `PendingVotes::insert_vote`. A Byzantine validator can no longer split its voting power across conflicting ordering candidates.
- **[#43](https://github.com/Galxe/gravity-audit/issues/43) (High)** — `process_order_vote_msg` now snapshots `highest_ordered_round` before the embedded QC is inserted and rejects votes whose round jumps more than `MAX_ORDER_VOTE_ROUND_JUMP` past that snapshot. Closes the fast-forward window where a single valid QC could be used to land an order vote for a round we never sequentially processed.

## Why minimal (not a full backport of upstream #14637)
Upstream aptos-core PR [#14637](https://github.com/aptos-labs/aptos-core/pull/14637) covers both findings, but does so by reshaping `li_digest_to_votes` into a `(QuorumCert, OrderVoteStatus)` map and plumbing `verified_quorum_cert: Option<QuorumCert>` through `insert_order_vote`. That refactor conflicts on ~164 lines in our vendored consensus and changes call sites we'd then have to re-audit. This PR keeps the original types and only adds the security checks.

## Test plan
- [x] `cargo check -p aptos-consensus --tests` passes.
- [ ] Reviewer: confirm `MAX_ORDER_VOTE_ROUND_JUMP` value is safe vs. legitimate validator sync flows.
- [ ] Reviewer: confirm equivocation log uses the same `SecurityEvent::ConsensusEquivocatingVote` channel as `PendingVotes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)