### PR TITLE
fix(sentinel): switch to patched linemux fork to stop 100% CPU busy spin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9924,8 +9924,7 @@ dependencies = [
 [[package]]
 name = "linemux"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb035c7806bd7982a317d8d66815021e91f7ab14a5fbedee22b06f608f11b43"
+source = "git+https://github.com/Galxe/linemux.git?rev=0194e0222134c587dcd50039a1ff9c8a14fae550#0194e0222134c587dcd50039a1ff9c8a14fae550"
 dependencies = [
  "futures-util",
  "notify 5.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -501,4 +501,10 @@ merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }
 darling = { git = "https://github.com/TedDriggs/darling.git", rev = "v0.20.10"}
 alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.37" }
+# Galxe fork of linemux 0.3.0 with a fix for the sentinel busy-spin bug
+# (when `watched_files` goes empty upstream returns Ready(Ok(None)) without
+# re-registering the waker, and `MuxedLines::poll_next_line` converts that
+# into a `continue` via `unwrap_or_continue!`, producing a pure-user-space
+# 100% CPU spin). Upstream issue: https://github.com/jmagnuson/linemux/issues/57
+linemux = { git = "https://github.com/Galxe/linemux.git", rev = "0194e0222134c587dcd50039a1ff9c8a14fae550" }
 

--- a/bin/sentinel/src/reader.rs
+++ b/bin/sentinel/src/reader.rs
@@ -17,7 +17,24 @@ impl Reader {
     }
 
     /// Returns next line with source path. Blocks until available.
+    ///
+    /// `Ok(None)` from the patched linemux fork signals that `watched_files`
+    /// went empty — a state the upstream crate would have busy-spun on (see
+    /// <https://github.com/jmagnuson/linemux/issues/57>). The periodic
+    /// `add_file()` re-attach in `spawn_log_monitor` should keep this from
+    /// ever happening; if it does, exit so systemd restarts us rather than
+    /// risk silently losing monitoring.
     pub async fn next_line(&mut self) -> Option<Line> {
-        self.lines.next_line().await.ok().flatten()
+        match self.lines.next_line().await {
+            Ok(Some(line)) => Some(line),
+            Ok(None) => {
+                eprintln!("FATAL: linemux exhausted (watched_files empty) — exiting for restart");
+                std::process::exit(2);
+            }
+            Err(e) => {
+                eprintln!("linemux error: {e:?}");
+                None
+            }
+        }
     }
 }

--- a/bin/sentinel/systemd/sentinel.service
+++ b/bin/sentinel/systemd/sentinel.service
@@ -1,0 +1,21 @@
+# /etc/systemd/system/sentinel.service
+# Template — replace User= / WorkingDirectory= / ExecStart= for your deployment.
+# `Restart=always` is what catches the exit(2) sentinel emits when linemux
+# returns Ok(None) (i.e. watched_files has gone empty); systemd restarts
+# the process and the discovery loop re-attaches inotify watches.
+[Unit]
+Description=Gravity sentinel (log monitor + health probes)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/gravity/sentinel-deploy/sentinel /home/gravity/sentinel-deploy/sentinel.toml
+Restart=always
+RestartSec=5
+User=gravity
+WorkingDirectory=/home/gravity/sentinel-deploy
+StandardOutput=append:/home/gravity/sentinel-deploy/sentinel.log
+StandardError=append:/home/gravity/sentinel-deploy/sentinel.log
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Switch sentinel's `linemux` dependency to a Galxe fork (`Galxe/linemux@0194e022`) that fixes the upstream busy-spin when `watched_files` becomes empty (linemux issue [#57](https://github.com/jmagnuson/linemux/issues/57)). In production this bug ran six sentinel processes at 100% CPU for 21 days with all log-based alerting silently disabled.
- Handle `Ok(None)` in `Reader::next_line` with `exit(2)` so systemd restarts the process if the patched linemux ever does report an exhausted stream, instead of silently looping with zero watches.
- Ship a systemd unit template at `bin/sentinel/systemd/sentinel.service` (`Restart=always`) so the exit→restart path is real.

## Why a fork instead of upstream

Upstream `linemux` last shipped 0.3.0 in 2023 and the busy-spin bug is open since 2024. The patch on our fork is six lines (`unwrap_or_continue!` chain → explicit `match`); we'll send a PR upstream but don't want to gate prod recovery on their review cadence.

## Test plan

- [x] `cargo build -p sentinel` against the new git-sourced fork
- [x] Local smoke: fake webhook + sentinel watching a log file. CPU stays 0.0% across the polling window; `smoke-error` injection → alert; `SIGINT` → clean shutdown.
- [x] Regression test in the fork (`Galxe/linemux@0194e022`) — `regression_no_busy_spin_on_drained_watched_files` constructs the exact production state (`Inner::readers` non-empty + `MuxedEvents::watched_files` empty + `StreamState::Events`) and asserts `next_line()` resolves to `Ok(None)` within 500ms. Verified the test catches a revert of the fix: it hangs (busy-spin) until `cargo test` is killed.
- [x] Filed upstream as [jmagnuson/linemux#76](https://github.com/jmagnuson/linemux/issues/76) (issue) and [jmagnuson/linemux#77](https://github.com/jmagnuson/linemux/pull/77) (PR). If upstream merges we can switch back to crates.io once a release lands.
- [ ] Deploy as canary to one testnet node (24h soak on CPU + sentinel.log mtime) before rolling out to the rest.

## Out of scope / follow-ups

- An OS-thread watchdog (probe-counter + reth.log mtime cross-check) is deliberately deferred — the fork patch + `Ok(None)`→exit(2) + systemd `Restart=always` handle the known failure mode; the watchdog is meant for unknown future regressions and can land in a separate PR.
- An earlier revision of this PR also removed `known_files` dedup in `watcher.rs` so `discover()` would re-call `add_file()` every tick as a self-heal layer. With the linemux patch in place that path is redundant, so the revision was reverted to keep the diff focused on the actual fix.
