### PR TITLE
chore(deps): bump gravity-reth to acc45884 (rocksdb durability fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 
 [[package]]
 name = "gravity-sdk"
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8034,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -13486,7 +13486,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13532,7 +13532,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13556,7 +13556,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13585,7 +13585,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13605,7 +13605,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13619,7 +13619,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13696,7 +13696,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13706,7 +13706,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13724,7 +13724,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13742,7 +13742,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13753,7 +13753,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13768,7 +13768,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13781,7 +13781,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13793,7 +13793,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13819,7 +13819,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13840,7 +13840,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13865,7 +13865,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13896,7 +13896,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13910,7 +13910,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13936,7 +13936,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13960,7 +13960,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13984,7 +13984,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14014,7 +14014,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14045,7 +14045,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14067,7 +14067,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14092,7 +14092,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "futures",
  "pin-project",
@@ -14115,7 +14115,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14167,7 +14167,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14195,7 +14195,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14211,7 +14211,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14226,7 +14226,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14248,7 +14248,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14259,7 +14259,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14287,7 +14287,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14308,7 +14308,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14330,7 +14330,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14346,7 +14346,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14364,7 +14364,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14377,7 +14377,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14406,7 +14406,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14425,7 +14425,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14435,7 +14435,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14458,7 +14458,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14480,7 +14480,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14493,7 +14493,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14549,7 +14549,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14563,7 +14563,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "serde",
  "serde_json",
@@ -14573,7 +14573,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14600,7 +14600,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "bytes",
  "futures",
@@ -14620,7 +14620,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "futures",
  "metrics",
@@ -14632,7 +14632,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14640,7 +14640,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14654,7 +14654,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14709,7 +14709,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14756,7 +14756,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14771,7 +14771,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14785,7 +14785,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14802,7 +14802,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14826,7 +14826,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14895,7 +14895,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14948,7 +14948,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14986,7 +14986,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15010,7 +15010,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15034,7 +15034,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15055,7 +15055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15067,7 +15067,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15088,7 +15088,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15100,7 +15100,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15120,7 +15120,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15130,7 +15130,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15143,7 +15143,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15189,7 +15189,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15213,7 +15213,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15226,7 +15226,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15256,7 +15256,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15299,7 +15299,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15327,7 +15327,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15340,7 +15340,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15359,7 +15359,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15386,7 +15386,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15399,7 +15399,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15478,7 +15478,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15506,7 +15506,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15545,7 +15545,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15566,7 +15566,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15596,7 +15596,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15640,7 +15640,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15687,7 +15687,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15701,7 +15701,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15717,7 +15717,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15761,7 +15761,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15788,7 +15788,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15801,7 +15801,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15821,7 +15821,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15833,7 +15833,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15863,7 +15863,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15879,7 +15879,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15897,7 +15897,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15907,7 +15907,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15922,7 +15922,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15964,7 +15964,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15988,7 +15988,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16015,7 +16015,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16034,7 +16034,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16059,7 +16059,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16096,7 +16096,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7#41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=acc458846c2f1fc684fa4344cf02ae9488efd252#acc458846c2f1fc684fa4344cf02ae9488efd252"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "acc458846c2f1fc684fa4344cf02ae9488efd252" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }


### PR DESCRIPTION
## What

Bump the `gravity-reth` git dependency:

- `41c0b7092ad578abcfb59b3aeb0ce9ec43f5fcf7` → `acc458846c2f1fc684fa4344cf02ae9488efd252`

Updates `bin/gravity_node/Cargo.toml` and the regenerated `Cargo.lock`. No SDK source changes.

## Why

Pulls in **gravity-reth#340** — a RocksDB durability fix. The rev range is exactly one commit ahead (`ahead 1, behind 0`); this bump introduces #340 and nothing else.

`provider_rw.commit()` called `rocksdb::DB::write()` without `fdatasync()`. With `wal_bytes_per_sync=4MB`, the low-traffic `account_db`/`storage_db` could go 2000+ blocks without syncing, risking large trie data loss on power failure and a state-root mismatch panic during consensus re-execution after a crash.

The fix:
1. All `write()` calls in `commit_view()` use `write_opt(sync=true)` — every `commit()` is fsync-durable before returning.
2. Disable pipelined write and drop `wal_bytes_per_sync` (redundant with per-commit sync).
3. Recovery always re-checks every stage checkpoint (no early return), repairing only stages that are behind.

Ref: https://github.com/Galxe/gravity-reth/pull/340