### PR TITLE
fix(consensus): three minimal audit fixes (#67, #41, #43)

### DIFF
--- a/aptos-core/consensus/consensus-types/src/proof_of_store.rs
+++ b/aptos-core/consensus/consensus-types/src/proof_of_store.rs
@@ -274,6 +274,7 @@ pub enum SignedBatchInfoError {
     NotFound,
     AlreadyCommitted,
     NoTimeStamps,
+    UnableToAggregate,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/aptos-core/consensus/src/pending_order_votes.rs
+++ b/aptos-core/consensus/src/pending_order_votes.rs
@@ -21,6 +21,8 @@ pub enum OrderVoteReceptionResult {
     /// The vote has been added but QC has not been formed yet. Return the amount of voting power
     /// QC currently has.
     VoteAdded(u128),
+    /// The very same author has already voted for another LedgerInfo digest (equivocation).
+    EquivocateVote,
     /// This block has just been certified after adding the vote.
     NewLedgerInfoWithSignatures(LedgerInfoWithSignatures),
     /// There might be some issues adding a vote
@@ -43,12 +45,20 @@ pub struct PendingOrderVotes {
     /// LedgerInfoWithSignatures). Order vote status stores caches the information on whether
     /// the votes are enough to form a QC.
     li_digest_to_votes: HashMap<HashValue /* LedgerInfo digest */, OrderVoteStatus>,
+    /// Maps Author to the LedgerInfo digest they have already voted for, used to
+    /// detect equivocation. Mirrors `PendingVotes::author_to_vote` so a Byzantine
+    /// validator cannot split its voting power across conflicting ordering
+    /// candidates within the same retention window.
+    author_to_li_digest: HashMap<Author, HashValue>,
 }
 
 impl PendingOrderVotes {
     /// Creates an empty PendingOrderVotes structure
     pub fn new() -> Self {
-        Self { li_digest_to_votes: HashMap::new() }
+        Self {
+            li_digest_to_votes: HashMap::new(),
+            author_to_li_digest: HashMap::new(),
+        }
     }
 
     /// Add a vote to the pending votes
@@ -60,6 +70,23 @@ impl PendingOrderVotes {
     ) -> OrderVoteReceptionResult {
         // derive data from order vote
         let li_digest = order_vote.ledger_info().hash();
+
+        // Equivocation check: if this author has previously voted for a different
+        // LedgerInfo digest, reject the new vote and surface a SecurityEvent. We
+        // intentionally do NOT short-circuit when the digest matches the previously
+        // seen one; the existing `add_signature` path is idempotent on duplicate
+        // signatures and we want to keep that behaviour observable via VoteAdded.
+        if let Some(previous_li_digest) = self.author_to_li_digest.get(&order_vote.author()) {
+            if previous_li_digest != &li_digest {
+                error!(
+                    SecurityEvent::ConsensusEquivocatingVote,
+                    remote_peer = order_vote.author(),
+                    order_vote = order_vote,
+                    previous_li_digest = previous_li_digest,
+                );
+                return OrderVoteReceptionResult::EquivocateVote;
+            }
+        }
 
         // obtain the ledger info with signatures associated to the order vote's ledger info
         let status = self.li_digest_to_votes.entry(li_digest).or_insert_with(|| {
@@ -89,6 +116,10 @@ impl PendingOrderVotes {
                 if validator_voting_power == 0 {
                     warn!("Received vote with no voting power, from {}", order_vote.author());
                 }
+                // Record the author -> digest mapping now that we know the author is
+                // a known validator. Used for equivocation detection on subsequent
+                // votes from the same author.
+                self.author_to_li_digest.insert(order_vote.author(), li_digest);
                 li_with_sig.add_signature(order_vote.author(), order_vote.signature().clone());
                 // check if we have enough signatures to create a QC
                 match validator_verifier.check_voting_power(li_with_sig.signatures().keys(), true) {
@@ -130,14 +161,29 @@ impl PendingOrderVotes {
 
     // Removes votes older than highest_ordered_round
     pub fn garbage_collect(&mut self, highest_ordered_round: u64) {
-        self.li_digest_to_votes.retain(|_, status| match status {
-            OrderVoteStatus::EnoughVotes(li_with_sig) => {
-                li_with_sig.ledger_info().round() > highest_ordered_round
+        // Collect the digests that are about to be evicted so we can drop the
+        // matching entries from `author_to_li_digest`. Without this, equivocation
+        // tracking would leak memory and (worse) keep stale digests around that
+        // could falsely flag legitimate future votes.
+        let mut evicted_digests: Vec<HashValue> = Vec::new();
+        self.li_digest_to_votes.retain(|digest, status| {
+            let keep = match status {
+                OrderVoteStatus::EnoughVotes(li_with_sig) => {
+                    li_with_sig.ledger_info().round() > highest_ordered_round
+                }
+                OrderVoteStatus::NotEnoughVotes(li_with_sig) => {
+                    li_with_sig.ledger_info().round() > highest_ordered_round
+                }
+            };
+            if !keep {
+                evicted_digests.push(*digest);
             }
-            OrderVoteStatus::NotEnoughVotes(li_with_sig) => {
-                li_with_sig.ledger_info().round() > highest_ordered_round
-            }
+            keep
         });
+        if !evicted_digests.is_empty() {
+            self.author_to_li_digest
+                .retain(|_, digest| !evicted_digests.contains(digest));
+        }
     }
 
     pub fn has_enough_order_votes(&self, ledger_info: &LedgerInfo) -> bool {

--- a/aptos-core/consensus/src/quorum_store/proof_coordinator.rs
+++ b/aptos-core/consensus/src/quorum_store/proof_coordinator.rs
@@ -117,17 +117,25 @@ impl IncrementalProofState {
         }
     }
 
-    fn take(&mut self, validator_verifier: &ValidatorVerifier) -> ProofOfStore {
+    fn take(
+        &mut self,
+        validator_verifier: &ValidatorVerifier,
+    ) -> Result<ProofOfStore, SignedBatchInfoError> {
         if self.completed {
             panic!("Cannot call take twice, unexpected issue occurred");
         }
-        self.completed = true;
 
         match validator_verifier.aggregate_signatures(
             PartialSignatures::new(self.aggregated_signature.clone()).signatures_iter(),
         ) {
-            Ok(sig) => ProofOfStore::new(self.info.clone(), sig),
-            Err(e) => unreachable!("Cannot aggregate signatures on digest err = {:?}", e),
+            Ok(sig) => {
+                self.completed = true;
+                Ok(ProofOfStore::new(self.info.clone(), sig))
+            }
+            Err(e) => {
+                error!("Cannot aggregate signatures on digest err = {:?}", e);
+                Err(SignedBatchInfoError::UnableToAggregate)
+            }
         }
     }
 
@@ -216,7 +224,7 @@ impl ProofCoordinator {
         if let Some(value) = self.batch_info_to_proof.get_mut(signed_batch_info.batch_info()) {
             value.add_signature(&signed_batch_info, validator_verifier)?;
             if !value.completed && value.ready(validator_verifier) {
-                let proof = value.take(validator_verifier);
+                let proof = value.take(validator_verifier)?;
                 txn_metrics::TxnLifeTime::get_txn_life_time().record_proof(proof.info().batch_id());
                 // proof validated locally, so adding to cache
                 self.proof_cache.insert(proof.info().clone(), proof.multi_signature().clone());

--- a/aptos-core/consensus/src/round_manager.rs
+++ b/aptos-core/consensus/src/round_manager.rs
@@ -1135,8 +1135,47 @@ impl RoundManager {
                 Err(anyhow::anyhow!("Injected error in process_order_vote_msg"))
             });
 
+            // Defense-in-depth for #43: unlike every other validator message
+            // handler, `process_order_vote_msg` does not run through
+            // `ensure_round_and_sync_up` (OrderVoteMsg carries no SyncInfo,
+            // just one QC + one OrderVote). A Byzantine peer can therefore
+            // submit an OrderVoteMsg whose embedded QC fast-forwards our
+            // local state by many rounds, then have the attached order vote
+            // accepted for a round we never sequentially processed.
+            //
+            // Snapshot `highest_ordered_round` BEFORE we apply the embedded
+            // QC, then bound how far past that snapshot the order vote round
+            // is allowed to be. The order vote signature itself is already
+            // verified inside `UnverifiedEvent::verify` (round_manager.rs
+            // line ~130 -> `verify_order_vote`), so no re-verification here.
+            //
+            // `MAX_ORDER_VOTE_ROUND_JUMP` is set to 3 to leave room for
+            // legitimate back-pressure / pipelined ordering scenarios where
+            // a node can legitimately lag a couple of rounds behind. Tighten
+            // further if telemetry shows real-world deltas are smaller.
+            const MAX_ORDER_VOTE_ROUND_JUMP: u64 = 3;
+            let pre_highest_ordered_round =
+                self.block_store.sync_info().highest_ordered_round();
+            let pre_current_round = self.round_state.current_round();
+
             let order_vote = order_vote_msg.order_vote();
             self.new_qc_from_order_vote_msg(&order_vote_msg).await?;
+
+            let vote_round = order_vote_msg.order_vote().ledger_info().round();
+            if vote_round > pre_highest_ordered_round + MAX_ORDER_VOTE_ROUND_JUMP {
+                // The embedded QC fast-forwarded us; the order vote itself
+                // is for a round we never sequentially processed. Reject as
+                // a defense-in-depth measure.
+                error!(
+                    SecurityEvent::ConsensusInvalidMessage,
+                    remote_peer = order_vote_msg.order_vote().author(),
+                    pre_current_round = pre_current_round,
+                    pre_highest_ordered_round = pre_highest_ordered_round,
+                    vote_round = vote_round,
+                    "OrderVoteMsg jumped highest_ordered_round by more than MAX_ORDER_VOTE_ROUND_JUMP",
+                );
+                return Ok(());
+            }
 
             debug!(
                 self.new_log(LogEvent::ReceiveOrderVote).remote_peer(order_vote.author()),
@@ -1354,6 +1393,12 @@ impl RoundManager {
                 ORDER_VOTE_ADDED.inc();
                 Ok(())
             }
+            // Equivocating order vote: the SecurityEvent has already been logged
+            // inside `PendingOrderVotes::insert_order_vote`. Drop the vote
+            // non-fatally so a single Byzantine validator can't poison the
+            // message handler, mirroring `VoteReceptionResult::EquivocateVote`
+            // handling in `process_vote_reception_result`.
+            OrderVoteReceptionResult::EquivocateVote => Ok(()),
             e => {
                 ORDER_VOTE_OTHER_ERRORS.inc();
                 Err(anyhow::anyhow!("{:?}", e))


### PR DESCRIPTION
## Summary
Combined PR — three minimal surgical fixes for [gravity-audit](https://github.com/Galxe/gravity-audit) findings in the vendored aptos-core consensus crate. Supersedes #726 and #727.

### Commit 1 — [gravity-audit#67](https://github.com/Galxe/gravity-audit/issues/67) (Critical)
`IncrementalProofState::take()` panicked via `unreachable!()` when BLS signature aggregation failed (legitimately reachable after a validator-set rotation), crashing the `ProofCoordinator` task and halting consensus. Changed return type to `Result<ProofOfStore, SignedBatchInfoError>`, added `SignedBatchInfoError::UnableToAggregate`, propagated `?` at the one caller in `add_signature`.

### Commit 2 — [gravity-audit#41](https://github.com/Galxe/gravity-audit/issues/41) (Critical) + [#43](https://github.com/Galxe/gravity-audit/issues/43) (High)
- **#41**: `PendingOrderVotes` had no per-author tracking, so a Byzantine validator could vote for conflicting `LedgerInfo` digests and have its voting power counted in each bucket. Added `author_to_li_digest: HashMap<Author, HashValue>` mirroring `PendingVotes::insert_vote`, equivocation detection with `SecurityEvent::ConsensusEquivocatingVote` log, GC of the new map alongside existing entries.
- **#43**: `process_order_vote_msg` was the only message handler not calling `ensure_round_and_sync_up`. Since `OrderVoteMsg` carries no `SyncInfo`, added a snapshot of `highest_ordered_round` before `new_qc_from_order_vote_msg` runs, and a `MAX_ORDER_VOTE_ROUND_JUMP = 3` guard rejecting order votes that jump past that window via the embedded QC.

## Why minimal (not full upstream backports)
- #67 ⟸ upstream [aptos-core#14644](https://github.com/aptos-labs/aptos-core/pull/14644) refactors the whole signature-aggregator path (~466 lines of conflicts here).
- #41 + #43 ⟸ upstream [aptos-core#14637](https://github.com/aptos-labs/aptos-core/pull/14637) reshapes `li_digest_to_votes` into a `(QuorumCert, OrderVoteStatus)` map and plumbs `verified_quorum_cert` through the call chain (~164 lines of conflicts).

These PRs port only the security-bearing slices.

## Notable deviations the reviewer should check
- `MAX_ORDER_VOTE_ROUND_JUMP = 3` — chosen to avoid breaking pipelined ordering; reviewer should confirm the window is safe vs. legitimate sync flows.
- Round-jump log uses `SecurityEvent::ConsensusInvalidMessage` (the variant `epoch_manager.rs` already uses); `InvalidConsensusVote` does not exist in the codebase.
- `author_to_li_digest` insert is inside the `NotEnoughVotes` arm after the unknown-author filter — unknown authors are already rejected at `UnverifiedEvent::verify` upstream, so this keeps the equivocation map clean.
- No `DuplicateVote` variant added — existing `add_signature` path is already idempotent and the existing `order_vote_aggregation` test asserts `VoteAdded` for the duplicate case.

## Test plan
- [x] `cargo check --tests` passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (1 pre-existing warning in `aptos-executor-types`, unrelated).
- [x] `pending_order_votes::tests::order_vote_aggregation` passes — direct coverage of the modified `insert_order_vote`.
- [ ] Reviewer: `round_manager_test::*` and `proof_coordinator_test::test_proof_coordinator_basic` cannot run locally — they hit pre-existing `todo!()` stubs in `mock_storage.rs:119` and `proof_coordinator_test.rs:65` on `origin/main`. Out of scope for this PR.
- [ ] Reviewer: confirm `MAX_ORDER_VOTE_ROUND_JUMP = 3` is safe.

## Diff
4 files changed, 112 insertions(+), 12 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)