### PR TITLE
fix(consensus): replay ordered path after recovery

### DIFF
--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -213,6 +213,9 @@ impl BlockStore {
         )
         .await;
         block_store.recover_blocks().await;
+        if let Err(e) = block_store.replay_ordered_path_if_needed().await {
+            error!("replay ordered path after recovery failed: {e}");
+        }
         block_store
     }
 
@@ -289,6 +292,20 @@ impl BlockStore {
         }
 
         RECOVERY_GAUGE.set_with(&[], 0);
+    }
+
+    pub(crate) async fn replay_ordered_path_if_needed(&self) -> anyhow::Result<()> {
+        let ordered_root_round = self.ordered_root().round();
+        let highest_ordered_cert = self.highest_ordered_cert().as_ref().clone();
+        let highest_ordered_round = highest_ordered_cert.commit_info().round();
+        if ordered_root_round < highest_ordered_round {
+            info!(
+                "[BlockStore] replay ordered path: ordered_root_round={}, highest_ordered_round={}",
+                ordered_root_round, highest_ordered_round,
+            );
+            self.send_for_execution(highest_ordered_cert, false, None).await?;
+        }
+        Ok(())
     }
 
     /// Returns the WrappedLedgerInfo for fast_forward_sync.

--- a/aptos-core/consensus/src/block_storage/sync_manager.rs
+++ b/aptos-core/consensus/src/block_storage/sync_manager.rs
@@ -213,21 +213,6 @@ impl BlockStore {
         Ok(())
     }
 
-    async fn replay_ordered_path_if_needed(&self) -> anyhow::Result<()> {
-        let ordered_root_round = self.ordered_root().round();
-        let highest_ordered_cert = self.highest_ordered_cert().as_ref().clone();
-        let highest_ordered_round = highest_ordered_cert.commit_info().round();
-        if ordered_root_round < highest_ordered_round {
-            info!(
-                "[BlockStore] replay ordered path after adding certs: ordered_root_round={}, highest_ordered_round={}",
-                ordered_root_round,
-                highest_ordered_round,
-            );
-            self.send_for_execution(highest_ordered_cert, false, None).await?;
-        }
-        Ok(())
-    }
-
     pub async fn insert_quorum_cert(
         &self,
         qc: &QuorumCert,


### PR DESCRIPTION
## Summary
- Move replay_ordered_path_if_needed into BlockStore so it can be shared by recovery and sync paths.
- Replay the persisted highest ordered cert after recover_blocks() during BlockStore startup.
- Keep SyncManager using the same replay helper after adding certs.

## Context
After restart, a node may already have a persisted highest_ordered_cert ahead of ordered_root, but receive no newer certs from peers. In that case the old sync-only path never calls replay_ordered_path_if_needed(), so the ordered suffix is not sent to execution.

## Testing
- cargo fmt --package aptos-consensus
- git diff --check
- cargo check was attempted but failed on an unrelated tokio::runtime::Builder::disable_lifo_slot API issue in the workspace.