### PR TITLE
chore(deps): bump gravity-reth to 0adbb4c9 (EIP-7702 self-auth fix) + e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,7 +4607,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 
 [[package]]
 name = "gravity-sdk"
@@ -7914,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8034,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -8075,7 +8075,7 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?tag=v2.2.4#26b586cff564a0815c422bb2a2ac0b5a28e5dce0"
+source = "git+https://github.com/Galxe/grevm?rev=3c09e7ce5cfc904d566c89a4a60f160839890792#3c09e7ce5cfc904d566c89a4a60f160839890792"
 dependencies = [
  "ahash 0.8.12",
  "alloy-evm",
@@ -8095,6 +8095,7 @@ dependencies = [
  "revm-inspector",
  "revm-primitives",
  "revm-state",
+ "tracing",
 ]
 
 [[package]]
@@ -11526,7 +11527,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12751,7 +12752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13486,7 +13487,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13532,7 +13533,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13556,7 +13557,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13585,7 +13586,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13605,7 +13606,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13619,7 +13620,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13696,7 +13697,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13706,7 +13707,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13724,7 +13725,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13742,7 +13743,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13753,7 +13754,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13768,7 +13769,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13781,7 +13782,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13793,7 +13794,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13819,7 +13820,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13840,7 +13841,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13865,7 +13866,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13896,7 +13897,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13910,7 +13911,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13936,7 +13937,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13960,7 +13961,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13984,7 +13985,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14014,7 +14015,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14045,7 +14046,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14067,7 +14068,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14092,7 +14093,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "futures",
  "pin-project",
@@ -14115,7 +14116,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14167,7 +14168,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14195,7 +14196,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14211,7 +14212,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14226,7 +14227,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14248,7 +14249,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14259,7 +14260,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14287,7 +14288,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14308,7 +14309,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14330,7 +14331,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14346,7 +14347,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14364,7 +14365,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14377,7 +14378,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14406,7 +14407,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14425,7 +14426,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14435,7 +14436,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14458,7 +14459,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14480,7 +14481,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14493,7 +14494,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14511,7 +14512,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14549,7 +14550,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14563,7 +14564,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "serde",
  "serde_json",
@@ -14573,7 +14574,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14600,7 +14601,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "bytes",
  "futures",
@@ -14620,7 +14621,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "futures",
  "metrics",
@@ -14632,7 +14633,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14640,7 +14641,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14654,7 +14655,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14709,7 +14710,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14734,7 +14735,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14756,7 +14757,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14771,7 +14772,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14785,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14802,7 +14803,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14826,7 +14827,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14895,7 +14896,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14948,7 +14949,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14986,7 +14987,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15010,7 +15011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15034,7 +15035,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15055,7 +15056,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15067,7 +15068,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15088,7 +15089,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15100,7 +15101,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15120,7 +15121,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15130,7 +15131,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15143,7 +15144,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15190,7 +15191,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15214,7 +15215,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15227,7 +15228,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15257,7 +15258,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15300,7 +15301,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15328,7 +15329,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15341,7 +15342,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15360,7 +15361,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15387,7 +15388,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15400,7 +15401,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15479,7 +15480,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15507,7 +15508,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15546,7 +15547,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15567,7 +15568,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15597,7 +15598,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15641,7 +15642,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15688,7 +15689,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15702,7 +15703,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15718,7 +15719,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15762,7 +15763,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15789,7 +15790,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15802,7 +15803,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15822,7 +15823,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15834,7 +15835,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15864,7 +15865,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15880,7 +15881,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15898,7 +15899,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15908,7 +15909,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15923,7 +15924,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15965,7 +15966,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15989,7 +15990,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16016,7 +16017,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16035,7 +16036,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16060,7 +16061,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16079,7 +16080,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16097,7 +16098,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=46c91f90fe8b601d289e26dd052a1fa2337f6efc#46c91f90fe8b601d289e26dd052a1fa2337f6efc"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "46c91f90fe8b601d289e26dd052a1fa2337f6efc" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "0adbb4c90c4a91a461e0766d4d31bba32d097363" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }

--- a/gravity_e2e/cluster_test_cases/prague/test_eip7702.py
+++ b/gravity_e2e/cluster_test_cases/prague/test_eip7702.py
@@ -51,19 +51,26 @@ async def _send_setcode_tx(
     *,
     gas: int,
     chain_id: int,
+    to_override: str | None = None,
 ):
     """Build, sign and broadcast a SetCode tx. Returns tx_hash hex string.
 
-    Inner CALL targets `sender` (EOA self-call, no-op) so the tx exercises
-    only the designator-install path. Targeting `authority` here would
-    invoke the freshly-installed delegate's fallback — Delegate.sol /
+    Inner CALL targets `sender` by default (EOA self-call, no-op) so the tx
+    exercises only the designator-install path. Targeting `authority` here
+    would invoke the freshly-installed delegate's fallback — Delegate.sol /
     Counter.sol don't define one, and the revert would mask designator
     installation behind a tx-level failure.
 
-    When `sender == authority` (self-sponsored self-delegation), the auth
-    tuple's nonce must be `sender_nonce + 1` because the tx bumps the
-    sender's nonce before the authorization list is processed. P-B6
-    exercises this shape — pre-fix it panicked grevm and halted the chain.
+    When `sender == authority` (self-sponsored self-delegation), two things
+    differ:
+      - the auth tuple's nonce must be `sender_nonce + 1` because the tx
+        bumps the sender's nonce before the authorization list is processed;
+      - the default `to = sender.address` self-call would invoke the
+        freshly-installed delegate code on the sender itself, hitting the
+        missing fallback. Callers must pass `to_override` to a no-code
+        address (any fresh EOA works) to keep the inner call as a no-op.
+    P-B6 exercises this shape — pre-fix it panicked grevm and halted the
+    chain at testnet block 1400868.
     """
     sender_nonce = node.w3.eth.get_transaction_count(sender.address)
     if sender.address.lower() == authority.address.lower():
@@ -81,7 +88,7 @@ async def _send_setcode_tx(
         sender,
         chain_id=chain_id,
         nonce=sender_nonce,
-        to=sender.address,
+        to=to_override if to_override is not None else sender.address,
         authorization_list=[auth],
         gas=gas,
         max_fee_per_gas=fee,
@@ -289,8 +296,14 @@ async def test_p_b6_self_sponsored_self_delegation(cluster: Cluster):
     assert fund.success, f"funding self_signer failed: {fund.error}"
 
     # tx.from == authority — pre-fix this panicked grevm in async_commit.
+    # Inner call target is a no-code address; targeting self_signer itself
+    # would invoke the freshly-installed delegate's missing fallback and
+    # revert, masking whether the auth list applied. The inner call is
+    # *not* what we're testing — the auth-list processing is.
+    inner_target = Account.create().address
     tx_hash = await _send_setcode_tx(
-        node, self_signer, self_signer, delegate_addr, gas=200_000, chain_id=chain_id
+        node, self_signer, self_signer, delegate_addr,
+        gas=200_000, chain_id=chain_id, to_override=inner_target,
     )
     receipt = await _wait_for_receipt(node, tx_hash, timeout=60.0)
     assert receipt is not None, (

--- a/gravity_e2e/cluster_test_cases/prague/test_eip7702.py
+++ b/gravity_e2e/cluster_test_cases/prague/test_eip7702.py
@@ -6,6 +6,7 @@ Verifies post-Prague behavior observable via contract execution:
   P-B3  revocation (target = 0x0) reverts the authority to plain-EOA behavior
   P-B4  pipe-exec filter discards low-intrinsic-gas SetCode tx
   P-B5  filter admits sufficiently-gassed SetCode tx
+  P-B6  self-sponsored self-delegation (tx.from == authority) does not halt the chain
 """
 
 import asyncio
@@ -58,13 +59,21 @@ async def _send_setcode_tx(
     invoke the freshly-installed delegate's fallback — Delegate.sol /
     Counter.sol don't define one, and the revert would mask designator
     installation behind a tx-level failure.
+
+    When `sender == authority` (self-sponsored self-delegation), the auth
+    tuple's nonce must be `sender_nonce + 1` because the tx bumps the
+    sender's nonce before the authorization list is processed. P-B6
+    exercises this shape — pre-fix it panicked grevm and halted the chain.
     """
-    auth_nonce = node.w3.eth.get_transaction_count(authority.address)
+    sender_nonce = node.w3.eth.get_transaction_count(sender.address)
+    if sender.address.lower() == authority.address.lower():
+        auth_nonce = sender_nonce + 1
+    else:
+        auth_nonce = node.w3.eth.get_transaction_count(authority.address)
     auth = sign_authorization(
         authority, chain_id=chain_id, delegate=delegate_addr, nonce=auth_nonce
     )
 
-    sender_nonce = node.w3.eth.get_transaction_count(sender.address)
     # Use a healthy fee — single-node devnet base fee is tiny but keep margin.
     fee = max(node.w3.eth.gas_price * 2, 10**9)
 
@@ -250,3 +259,58 @@ async def test_p_b5_sufficient_intrinsic_gas_accepted(cluster: Cluster):
 
     authority_view = node.w3.eth.contract(address=authority.address, abi=delegate.abi)
     assert authority_view.functions.getValue().call() == 42
+
+
+@pytest.mark.asyncio
+async def test_p_b6_self_sponsored_self_delegation(cluster: Cluster):
+    """P-B6: self-sponsored self-delegation (tx.from listed as own authority).
+
+    Regression for Galxe/grevm#102 / gravity-reth#345: pre-fix, grevm's
+    StateAsyncCommit asserted on the caller-nonce relation and panicked when
+    a type-4 SetCode tx had `tx.from` in its own authorizationList. This is
+    the exact `simple-bench --transfer-type eip7702` pattern that halted
+    Gravity testnet at block 1400868 on 2026-06-09. The chain-halt oracle
+    here is "receipt arrives" — pre-fix the validator panicked and no
+    further blocks were produced, so the receipt would never come back.
+    """
+    node = cluster.get_node("node1")
+    chain_id = node.w3.eth.chain_id
+    faucet = cluster.faucet
+
+    delegate, delegate_addr = await _deploy(node, faucet, "Delegate")
+
+    self_signer = Account.create()
+    LOG.info(f"P-B6 self_signer={self_signer.address}, delegate={delegate_addr}")
+
+    # Fund the self-signer so it can pay for the SetCode tx itself.
+    # gas=200k * fee≈1 gwei ≈ 2e-4 ETH; 1 ETH is comfortable headroom.
+    tb = TransactionBuilder(node.w3, faucet)
+    fund = await tb.send_ether(to=self_signer.address, amount_wei=10**18)
+    assert fund.success, f"funding self_signer failed: {fund.error}"
+
+    # tx.from == authority — pre-fix this panicked grevm in async_commit.
+    tx_hash = await _send_setcode_tx(
+        node, self_signer, self_signer, delegate_addr, gas=200_000, chain_id=chain_id
+    )
+    receipt = await _wait_for_receipt(node, tx_hash, timeout=60.0)
+    assert receipt is not None, (
+        "self-sponsored SetCode tx receipt timeout — chain may have halted "
+        "(regression of grevm self-auth panic)"
+    )
+    assert receipt["status"] == 1, f"self-sponsored SetCode tx failed: {receipt}"
+
+    # Delegation is observable on the self-signer's address.
+    self_signer_view = node.w3.eth.contract(address=self_signer.address, abi=delegate.abi)
+    assert self_signer_view.functions.getValue().call() == 42
+
+    # Chain progression oracle: another block must be produced after the tx.
+    head_after_tx = receipt["blockNumber"]
+    deadline = asyncio.get_event_loop().time() + 30.0
+    while asyncio.get_event_loop().time() < deadline:
+        if node.w3.eth.block_number > head_after_tx:
+            return
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"no new block after self-sponsored SetCode (head stuck at {head_after_tx}) "
+        "— chain may have halted"
+    )


### PR DESCRIPTION
## What

Bump the `gravity-reth` git dependency and add e2e coverage for the bug it fixes:

- `bin/gravity_node/Cargo.toml`: greth rev `46c91f9` → `0adbb4c9` (Galxe/gravity-reth#345 merge).
- `Cargo.lock`: regenerated via `cargo update -p greth`. Net effect = grevm `26b586c` (v2.2.4) → `3c09e7c` (Galxe/grevm#102).
- `gravity_e2e/cluster_test_cases/prague/test_eip7702.py`: new `test_p_b6_self_sponsored_self_delegation` plus a small generalization of the shared `_send_setcode_tx` helper.

## Why

The previous grevm pin (v2.2.4 = `26b586c`) panicked deterministically inside `StateAsyncCommit::commit` on type-4 SetCode txs where `tx.from` was *also* listed in the authorization list as an authority. That is the exact `simple-bench --transfer-type eip7702` pattern that halted Gravity testnet at block 1400868 on 2026-06-09, and the same input shape is reachable on mainnet once EIP-7702 is open.

The grevm fix (Galxe/grevm#102) relaxes the caller-nonce assertion. This PR pulls it in via Galxe/gravity-reth#345 and locks in a regression test so the chain-halt shape can never silently come back.

## E2E details

- `_send_setcode_tx` now detects `sender == authority` and signs the auth tuple with `sender_nonce + 1` instead of `sender_nonce`. Per EIP-7702 the authorization is applied *after* the tx's own nonce bump, so for self-sponsored self-delegation the auth-tuple nonce must be one ahead. Existing P-B1..P-B5 are unaffected since they use distinct sender/authority accounts.
- `test_p_b6_self_sponsored_self_delegation` exercises the panic shape with three regression oracles:
  1. Receipt arrives within the timeout — pre-fix the validator panicked and no receipt would ever come back.
  2. `receipt.status == 1` — tx executed cleanly.
  3. A new block is produced after `receipt.blockNumber` within 30s — chain progression, not just landed-and-stuck.

## Test plan

- [x] `cargo update -p greth` resolves cleanly; lock-file diff is just the greth subtree + grevm rev swap.
- [ ] `cargo build -p gravity_node --profile quick-release` (in progress locally; CI will repeat).
- [ ] `python3 gravity_e2e/runner.py prague` — full prague suite (EIP-2935 + EIP-7702 incl. new P-B6).
- [ ] CI: workspace clippy / tests / e2e.

## Refs

- Galxe/gravity-reth#345
- Galxe/grevm#102
- Galxe/gravity-audit#677