### PR TITLE
ci(release): switch to v*.*.* tag trigger and add workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,19 @@ name: Release
 on:
   push:
     tags:
-      - 'gravity-mainnet-*'
-      - 'gravity-testnet-*'
+      - 'v*.*.*'
   pull_request:
     paths:
       - '.github/workflows/release.yml'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (must match v*.*.*, e.g. v1.7.0). The tag and its GitHub Release must already exist.'
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.event.pull_request.number || github.ref_name }}
+  group: release-${{ github.event.pull_request.number || inputs.tag || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -45,6 +50,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # For workflow_dispatch, check out the user-specified tag instead of
+          # the branch where the dispatch was triggered. For push/PR, fall back
+          # to the default ref (the tag or PR head).
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Show build environment
         # Logs runner OS / glibc / rustc so any future divergence from
@@ -139,13 +149,19 @@ jobs:
         id: tag
         if: github.event_name != 'pull_request'
         shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF##refs/tags/}"
-          case "$TAG" in
-            gravity-mainnet-*|gravity-testnet-*) ;;
-            *) echo "tag must start with gravity-mainnet- or gravity-testnet-: $TAG" >&2; exit 1 ;;
-          esac
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF##refs/tags/}"
+          fi
+          if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "tag must match v*.*.* (e.g. v1.7.0, v1.7.0-rc1): $TAG" >&2
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Upload assets to GitHub release


### PR DESCRIPTION
## Summary

- Auto-trigger of `Release` workflow is now scoped to `v*.*.*` tags only. The legacy `gravity-mainnet-*` / `gravity-testnet-*` patterns are dropped — future releases follow a single `v<major>.<minor>.<patch>` track.
- Added a `workflow_dispatch` input so a release can be re-run manually from the Actions UI against any existing `v*.*.*` tag (useful for retrying a failed upload or pushing the docker image for a tag whose initial run was interrupted).
- Checkout step now follows the dispatched tag when invoked via `workflow_dispatch`; on `push` / `pull_request` it falls back to the default ref.
- `Resolve tag` step validates the pattern via a regex (`^v[0-9]+\.[0-9]+\.[0-9]+`) for both push and dispatch paths — accepts `v1.7.0`, `v1.7.0-rc1`, etc., rejects anything that doesn't start with a SemVer-shaped prefix.

## Test plan

- [ ] `lint-workflows` (actionlint) passes on this PR.
- [ ] PR dry-run path (`if: github.event_name == 'pull_request'`) still runs build + stage assets + docker build (no push).
- [ ] After merge to `main`: open Actions → Release → Run workflow → enter a known existing tag (e.g. `v0.5.0`) and confirm the dispatch path resolves the tag, builds, and re-uploads assets to that release with `--clobber`.
- [ ] Cut `v1.7.0` via GitHub UI Draft Release → Publish → confirm the push path triggers and the release receives `gravity_node`, `gravity_cli`, their `.sha256` files, and `ghcr.io/galxe/gravity_node:v1.7.0`.

## Notes

- `workflow_dispatch` registrations are only visible on the **default branch's** copy of the workflow file. So the UI button will not appear until this is merged into `main`.
- This PR does not change the requirement that a GitHub Release must exist before the `gh release upload` step — that contract is unchanged.