### PR TITLE
test(e2e): regression for self-sponsored EIP-7702 chain halt (audit #677)

### DIFF
--- a/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/cluster.toml
@@ -1,0 +1,28 @@
+# Gravity Cluster Configuration - Prague EIP-7702 Self-Sponsor Suite
+#
+# Single validator node used to verify the node's handling of a self-sponsored
+# EIP-7702 (type-4) transaction (authority == sender). Requires Prague active —
+# enabled for THIS suite only via hooks.py:pre_start (no shared genesis change).
+# Distinct base_dir + ports from other suites so it never collides.
+
+[cluster]
+name = "gravity-devnet-7702"
+base_dir = "/tmp/gravity-cluster-7702"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 6482
+vfn_port = 6492
+rpc_port = 8845
+metrics_port = 9303
+inspection_port = 10302
+https_port = 1324
+authrpc_port = 8853
+reth_p2p_port = 12326

--- a/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/genesis.toml
@@ -1,0 +1,84 @@
+# Gravity Genesis Configuration - Prague EIP-7702 Self-Sponsor Suite
+#
+# Identical to the single_node suite (one genesis validator, devnet faucet),
+# only the validator_port / vfn_port differ so this cluster can run alongside
+# single_node without port collisions.
+
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "main"
+
+# Genesis validators with stake and voting power
+[[genesis_validators]]
+id = "node1"
+address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+host = "127.0.0.1"
+validator_port = 6482
+vfn_port = 6492
+stake_amount = "10000000000000000000"
+voting_power = "10000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 60000000 # 60 second
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+initial_locked_until_micros = 1798848000000000
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "10000000000000000000"
+voting_duration_micros = 604800000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
+
+[genesis.oracle_config.bridge_config]
+deploy = true
+trusted_bridge = "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
+trusted_source_id = 11155111
+
+[[genesis.oracle_config.tasks]]
+source_type = 0
+source_id = 11155111
+task_name = "sepolia"
+config = "gravity://0/11155111/events?contract=0x0f761B1B3c1aC9232C9015A7276692560aD6a05F&eventSignature=0x5646e682c7d994bf11f5a2c8addb60d03c83cda3b65025a826346589df43406e&fromBlock=10201260"
+
+# JWK config - Google OIDC provider
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/hooks.py
+++ b/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/hooks.py
@@ -1,0 +1,74 @@
+"""
+Per-suite lifecycle hooks (called by runner.py around the node lifecycle).
+
+pre_start: enable Prague (EIP-7702) for THIS suite only. The shared devnet
+genesis template does not set `pragueTime`, so a type-4 (set-code) transaction
+would be rejected by the reth pool ("transaction type not supported") before it
+can exercise the code path under test. Activating Prague at genesis for this
+suite — without touching the shared genesis template or any other suite — lets
+the type-4 tx reach execution. (This is also the coverage gap that let
+gravity-audit #677 reach the testnet: the e2e harness never exercised any
+Prague/7702 path.)
+
+IMPORTANT ordering note: runner.py runs `deploy.sh` (step 2) BEFORE this hook
+(step 2.5). deploy.sh copies the suite's `artifacts/genesis.json` to
+`<base_dir>/genesis.json` and starts the node from THAT copy (deploy.sh:796,
+GENESIS_PATH=<base_dir>/genesis.json). So patching only the source
+`artifacts/genesis.json` here is too late — the node already read the unpatched
+copy. We must patch the DEPLOYED copy at `<base_dir>/genesis.json` (which exists
+by the time pre_start runs). We patch the source too so cached/`--resume` reuse
+and on-disk inspection stay consistent.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+try:
+    import tomllib as toml_reader  # py311+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as toml_reader
+
+LOG = logging.getLogger(__name__)
+
+
+def _enable_prague(genesis_path: Path) -> bool:
+    """Set pragueTime=0 in the given reth genesis.json. Returns True if applied."""
+    if not genesis_path.exists():
+        LOG.warning("genesis.json not found at %s; cannot enable Prague", genesis_path)
+        return False
+    genesis = json.loads(genesis_path.read_text())
+    cfg = genesis.setdefault("config", {})
+    if cfg.get("pragueTime") == 0:
+        LOG.info("Prague already enabled (pragueTime=0) in %s", genesis_path)
+        return True
+    cfg["pragueTime"] = 0  # activate Prague (EIP-7702) from genesis
+    genesis_path.write_text(json.dumps(genesis, indent=2))
+    LOG.info("Enabled Prague (pragueTime=0) in %s for the 7702 suite", genesis_path)
+    return True
+
+
+def pre_start(test_dir: Path, env: dict, pytest_args=None):
+    test_dir = Path(test_dir)
+
+    # 1. The DEPLOYED genesis the node actually boots from. deploy.sh copies the
+    #    suite genesis to <base_dir>/genesis.json (deploy.sh:796) and the node
+    #    reads that path, so this is the copy that must carry pragueTime=0.
+    base_dir = None
+    cluster_toml = test_dir / "cluster.toml"
+    if cluster_toml.exists():
+        with open(cluster_toml, "rb") as f:
+            base_dir = toml_reader.load(f).get("cluster", {}).get("base_dir")
+    if base_dir:
+        deployed = Path(base_dir) / "genesis.json"
+        if not _enable_prague(deployed):
+            LOG.error(
+                "Deployed genesis %s missing — Prague will NOT be active and the "
+                "7702 tx will be rejected before execution (false negative).",
+                deployed,
+            )
+    else:
+        LOG.error("Could not resolve cluster.base_dir from %s", cluster_toml)
+
+    # 2. The source artifact, so cached/`--resume` reuse and inspection match.
+    _enable_prague(test_dir / "artifacts" / "genesis.json")

--- a/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/test_prague_7702_selfsponsor.py
+++ b/gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/test_prague_7702_selfsponsor.py
@@ -1,0 +1,197 @@
+"""
+E2E regression for gravity-audit #677 (CRITICAL, deterministic chain halt):
+a self-sponsored EIP-7702 transaction must be processed as an ordinary tx, not
+panic the node.
+
+Background
+----------
+This issue actually halted the testnet on 2026-06-09 (block 1400867 -> 1400868).
+A *self-sponsored* EIP-7702 (type-4) transaction — one whose sender is also the
+`authority` of an authorization tuple in its own `authorization_list` — bumps
+the sender's nonce TWICE during execution (once in `deduct_caller`, once in
+`apply_eip7702_auth_list`, because `authority == caller`), so the caller's
+post-state nonce is `expect + 2`. The pinned grevm (`v2.2.4` / 26b586c) commit
+path hard-asserts `assert_eq!(change.info.nonce, expect + 1)` in
+`async_commit.rs` and panics. Because the tx is spec-valid and pool-valid, any
+funded EOA can submit it; every validator then panics deterministically on the
+ordered block (and re-panics on replay) -> permanent network halt.
+
+The fix exists in a newer grevm rev (>= 3c09e7c, which allows a post-nonce in
+`[expect+1, expect+1+self_auth_count]`) but is NOT pinned by gravity-sdk, so the
+deployed chain remains exposed even though #677 was closed.
+
+This test attacks the node from OUTSIDE over JSON-RPC exactly as a remote
+attacker would, and asserts the CORRECT (post-fix) behavior: the node survives
+the tx and keeps producing blocks. It is marked xfail until the grevm bump lands.
+
+Prague (EIP-7702) is enabled for this suite via hooks.py:pre_start.
+"""
+
+import asyncio
+import logging
+import time
+
+import pytest
+from web3 import Web3
+
+from gravity_e2e.cluster.manager import Cluster
+
+LOG = logging.getLogger(__name__)
+
+# Any non-zero delegate target; its code is irrelevant to the bug.
+DELEGATE_TARGET = Web3.to_checksum_address("0x000000000000000000000000000000000000c0de")
+
+# Panic site for #677 (grevm async_commit nonce assertion).
+PANIC_MARKERS = ("async_commit", "assertion `left == right`")
+
+
+def _grep_panic(cluster: Cluster) -> str | None:
+    from pathlib import Path
+
+    base = Path(cluster.config["cluster"]["base_dir"])
+    for p in (base / "node1" / "logs").rglob("*"):
+        if not p.is_file():
+            continue
+        try:
+            with open(p, "r", errors="ignore") as f:
+                for line in f:
+                    if any(m in line for m in PANIC_MARKERS):
+                        return f"{p}: {line.strip()}"
+        except OSError:
+            continue
+    return None
+
+
+@pytest.mark.xfail(
+    reason=(
+        "gravity-audit #677: a self-sponsored EIP-7702 tx makes the caller "
+        "post-nonce = expect+2, but the pinned grevm v2.2.4 async_commit "
+        "hard-asserts expect+1 and panics -> deterministic chain halt. Remove "
+        "this xfail once grevm is bumped to >= 3c09e7c and relocked."
+    ),
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_self_sponsored_7702_does_not_halt_node(cluster: Cluster):
+    # ---- 1. Node live, Prague active, producing blocks --------------------
+    assert await cluster.set_full_live(timeout=60), "Cluster failed to become live"
+    node = cluster.get_node("node1")
+    assert node, "node1 not found in cluster config"
+    assert await cluster.check_block_increasing(timeout=30), "Node not producing blocks"
+
+    faucet = cluster.faucet
+    assert faucet, "Faucet account not configured"
+    w3 = node.w3
+    chain_id = w3.eth.chain_id
+    h0 = node.get_block_number()
+    LOG.info(f"Node live at height {h0}, chain_id={chain_id}, sender={faucet.address}")
+
+    # ---- 2. Build the self-sponsored EIP-7702 (type-4) transaction --------
+    # authority == sender, and authorization.nonce == tx.nonce + 1 (the value the
+    # caller nonce holds after deduct_caller), so the auth tuple is APPLIED and
+    # bumps the caller nonce a second time (-> post-nonce = nonce + 2).
+    nonce = w3.eth.get_transaction_count(faucet.address)
+    gas_price = w3.eth.gas_price
+    auth = faucet.sign_authorization(
+        {"chainId": chain_id, "address": DELEGATE_TARGET, "nonce": nonce + 1}
+    )
+    tx = {
+        "type": 4,
+        "chainId": chain_id,
+        "nonce": nonce,
+        "to": faucet.address,  # self-sponsored
+        "value": 0,
+        "gas": 200000,
+        "maxFeePerGas": int(gas_price * 2),
+        "maxPriorityFeePerGas": gas_price,
+        "data": b"",
+        "authorizationList": [auth],
+    }
+    signed = faucet.sign_transaction(tx)
+    LOG.info(f"Submitting self-sponsored 7702 tx (nonce={nonce}, auth.nonce={nonce+1})...")
+    tx_hash = None
+    try:
+        # Do not wait for a receipt yet: on the buggy build the node panics while
+        # executing this tx, so no receipt would ever return.
+        tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+        LOG.info(f"Submitted: {tx_hash.hex()}")
+    except Exception as e:
+        # CRITICAL guard against a false negative: if the node REJECTS the tx
+        # before execution (e.g. "transaction type not supported" because Prague
+        # is not actually active in the genesis the node booted from), then the
+        # #677 code path was never reached. In that case the node trivially
+        # "survives" — but that proves nothing about the bug. Fail hard so this
+        # is fixed in the harness rather than silently passing.
+        msg = str(e)
+        if "transaction type not supported" in msg or "not supported" in msg:
+            pytest.fail(
+                "Self-sponsored EIP-7702 tx was REJECTED before execution "
+                f"({msg!r}). Prague/EIP-7702 is not active in the genesis the "
+                "node booted from, so the #677 code path was never exercised. "
+                "This is a harness setup error (see hooks.py:pre_start — the "
+                "DEPLOYED <base_dir>/genesis.json must carry pragueTime=0), NOT "
+                "evidence that the node is healthy."
+            )
+        # Any other send error may just be the node already dying mid-execution
+        # (the bug reproducing); fall through to the health/panic checks below.
+        LOG.warning(f"send raced the node (it may already be dying): {e}")
+
+    # ---- 3. The node must stay healthy ------------------------------------
+    LOG.info("Polling block height for ~30s...")
+    heights: list[int] = []
+    rpc_failures = 0
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        try:
+            heights.append(node.get_block_number())
+        except Exception:
+            rpc_failures += 1
+        await asyncio.sleep(2)
+
+    max_height = max(heights) if heights else h0
+    process_alive = node.is_running()
+    panic_line = _grep_panic(cluster)
+    advanced = max_height - h0
+    LOG.info(
+        f"After 7702 tx: samples={heights}, advanced={advanced}, "
+        f"rpc_failures={rpc_failures}, process_alive={process_alive}, panic={panic_line}"
+    )
+
+    node_healthy = (
+        process_alive
+        and rpc_failures == 0
+        and advanced >= 1
+        and panic_line is None
+    )
+    assert node_healthy, (
+        "Node did not survive a self-sponsored EIP-7702 tx (gravity-audit #677): "
+        f"process_alive={process_alive}, rpc_failures={rpc_failures}, "
+        f"height_advanced={advanced}, panic_line={panic_line}"
+    )
+
+    # The node is alive — but on a build that simply DROPPED the tx (never
+    # executed it) the node would also look alive. To prove the #677 code path
+    # was actually exercised and handled correctly, require positive evidence of
+    # execution: a receipt for the tx AND the sender nonce advanced by exactly 2
+    # (one bump in deduct_caller + one in apply_eip7702_auth_list, because
+    # authority == caller). Without this, "node survived" is not evidence of a fix.
+    assert tx_hash is not None, (
+        "Node stayed alive but the 7702 tx was never accepted (no hash). Cannot "
+        "conclude #677 is fixed without the tx actually being processed."
+    )
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+    post_nonce = w3.eth.get_transaction_count(faucet.address)
+    LOG.info(
+        f"Tx mined in block {receipt.blockNumber}, status={receipt.status}; "
+        f"sender nonce {nonce} -> {post_nonce} (expected {nonce + 2})"
+    )
+    assert post_nonce == nonce + 2, (
+        "Self-sponsored EIP-7702 tx did not double-bump the caller nonce "
+        f"(got {post_nonce}, expected {nonce + 2}). The #677 code path "
+        "(authority == caller applying its own auth tuple) was not exercised, "
+        "so a green result here would be a false negative."
+    )
+    LOG.info(
+        "Node remained healthy AND correctly applied the self-sponsored 7702 tx "
+        "(nonce +2, no panic) — #677 fixed."
+    )


### PR DESCRIPTION
## What

Adds a single-node e2e regression suite (`gravity_e2e/cluster_test_cases/prague_7702_selfsponsor/`) for **gravity-audit #677** — a CRITICAL, externally-triggerable, deterministic chain halt.

## The bug

A **self-sponsored** EIP-7702 (type-4) transaction — sender is also the `authority` of an authorization tuple in its own `authorization_list` — bumps the sender's nonce **twice** during execution:
- once in `deduct_caller` (revm `pre_execution.rs:170`)
- once in `apply_eip7702_auth_list` (revm `pre_execution.rs:251`), because `authority == caller`

so the caller's post-state nonce is `expect + 2`. The **currently-pinned** grevm (`v2.2.4` / `26b586c`) hard-asserts `assert_eq!(change.info.nonce, expect + 1)` at `async_commit.rs:78` and **panics**.

The tx is spec-valid and pool-valid, so any funded EOA can submit it over public JSON-RPC; every validator then panics deterministically on the ordered block (and re-panics on replay) → **permanent network halt**. This is the bug that halted the testnet on 2026-06-09 (block 1400867 → 1400868).

The fix exists in a newer grevm rev (`>= 3c09e7c`, which allows a post-nonce in `[expect+1, expect+1+self_auth_count]`) but is **not pinned** by gravity-sdk, so the deployed chain remains exposed even though #677 was closed.

## Reproduced locally (gate evidence)

Against the pinned build, the self-sponsored 7702 tx kills the node — process exits, 14 RPC failures, zero block progress:

```
panicked at .../grevm/26b586c/src/async_commit.rs:78:29:
assertion `left == right` failed
  left: 2
 right: 1
```

→ test reports **XFAIL** (expected failure: bug present).

## Test design / why it's trustworthy

- **Prague coverage gap:** the shared devnet genesis doesn't set `pragueTime`, so a type-4 tx is rejected by the reth pool (`transaction type not supported`) **before** execution — the very gap that let #677 ship. `hooks.py:pre_start` enables Prague for this suite only.
- **Ordering fix:** `deploy.sh` copies the suite genesis to `<base_dir>/genesis.json` and boots the node from it *before* `pre_start` runs, so patching only the source artifact is too late and yields a Prague-disabled node + false-negative pass. The hook patches the **deployed** copy.
- **No false negatives:** the test **fails hard** (not xfail) if the tx is rejected pre-execution, and requires positive proof of execution (receipt present + sender nonce advances by exactly 2) before ever concluding the node is healthy. A Prague-disabled or tx-dropping harness can never masquerade as "fixed."
- **xfail (strict=False):** CI stays green until the grevm bump lands; it then flips to **xpass** to prompt removal of the marker.

## Scope

Test-only — adds one e2e suite, no production-code changes. Remove the `xfail` once grevm is bumped to `>= 3c09e7c` and relocked.