### PR TITLE
test(e2e): repro reth-ahead-of-consensus cross-store desync (audit #703/#704)

### DIFF
--- a/gravity_e2e/cluster_test_cases/cross_store_desync_703_704/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/cross_store_desync_703_704/cluster.toml
@@ -1,0 +1,42 @@
+# Gravity Cluster Configuration - Cross-Store Desync Suite (gravity-audit #703/#704)
+#
+# Single node: the cross-store reth-ahead-of-consensus desync is a PER-NODE
+# crash-consistency bug between reth's execution rocksdb and the aptos consensus
+# DB, so a single validator is enough to reproduce it (no 4-validator quorum
+# needed; that only adds flakiness/time).
+#
+# UNIQUE base_dir + UNIQUE ports so this suite never collides with the existing
+# suites (single_node 8545, four_validator 8546-8549, vfn/pfn 8645-8654 /
+# 8745-8754, fuzzy 18545+). Everything here lives in its own 6480/6490, 89xx,
+# 9050, 10300, 1324, 12324 ranges.
+
+[cluster]
+name = "gravity-devnet-desync"
+base_dir = "/tmp/gravity-cluster-desync"
+
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+# Same as every other suite: build/reuse the repo's quick-release gravity_node.
+# deploy.sh uses <project_path>/target/quick-release/gravity_node and only
+# builds if it is missing. (When running from a git worktree that has no
+# target/ of its own, point this at the shared checkout instead, e.g.
+# source = { bin_path = "/abs/path/to/target/quick-release/gravity_node" }.)
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 6480
+vfn_port = 6490
+rpc_port = 8945
+metrics_port = 9050
+inspection_port = 10300
+https_port = 1324
+authrpc_port = 8953
+reth_p2p_port = 12324
+
+[faucet_init]
+num_accounts = 100

--- a/gravity_e2e/cluster_test_cases/cross_store_desync_703_704/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/cross_store_desync_703_704/genesis.toml
@@ -1,0 +1,80 @@
+# Gravity Genesis Configuration - Cross-Store Desync Suite (gravity-audit #703/#704)
+
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "main"
+
+# Genesis validators with stake and voting power
+[[genesis_validators]]
+id = "node1"
+address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+host = "127.0.0.1"
+validator_port = 6480
+vfn_port = 6490
+stake_amount = "10000000000000000000"
+voting_power = "10000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 60000000 # 60 second
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+initial_locked_until_micros = 1798848000000000
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "10000000000000000000"
+voting_duration_micros = 604800000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
+
+[genesis.oracle_config.bridge_config]
+deploy = true
+trusted_bridge = "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc"
+trusted_source_id = 11155111
+
+[[genesis.oracle_config.tasks]]
+source_type = 0
+source_id = 11155111
+task_name = "sepolia"
+config = "gravity://0/11155111/events?contract=0x0f761B1B3c1aC9232C9015A7276692560aD6a05F&eventSignature=0x5646e682c7d994bf11f5a2c8addb60d03c83cda3b65025a826346589df43406e&fromBlock=10201260"
+
+# JWK config - Google OIDC provider
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/cross_store_desync_703_704/test_cross_store_desync.py
+++ b/gravity_e2e/cluster_test_cases/cross_store_desync_703_704/test_cross_store_desync.py
@@ -1,0 +1,294 @@
+"""
+Deterministic e2e reproduction for gravity-audit #703 and #704.
+
+Refs Galxe/gravity-audit#703, Galxe/gravity-audit#704
+(see galxe/RESTART_RECOVERY_FINDINGS.md, findings F1 and F2).
+
+THE BUG (F2, #704): reth's execution rocksdb and the aptos consensus DB persist
+on INDEPENDENT stores with no cross-store write-ordering barrier. In the
+commit_ledger/commit_blocks window reth can durably persist block N while the
+consensus DB's BlockNumberSchema / LedgerInfoSchema is still at N-1. A crash in
+that window leaves reth AHEAD of consensus.
+
+On restart, recovery anchors on reth's height N but the consensus index does not
+contain N, so either:
+  * crates/api/src/bootstrap.rs:335-344 early-returns after setting
+    latest_commit_block_number = N but BEFORE marking the block-buffer-manager
+    Ready -> the buffer stays Uninitialized -> every get_ordered_blocks awaits
+    ready_notifier forever = SILENT PERMANENT STALL (one error!, no panic); or
+  * RecoveryData::new fails find_root ->
+    aptos-core/consensus/src/persistent_liveness_storage.rs:550 panic!("")
+    (the PartialRecoveryData / state-sync fallback is commented out and
+    recovery_manager.rs:104 is todo!()) = CRASH-LOOP (F1, #703).
+
+HOW WE INDUCE IT DETERMINISTICALLY (no need for a real power-loss race):
+  1. Bring the single node live, let it commit past height H (> 5).
+  2. node.stop() cleanly.
+  3. Run `gravity_cli unwind --consensus-db-path <data/consensus_db>
+     --target H-3` (see bin/gravity_cli/src/unwind.rs). unwind_to_block deletes
+     consensus Block/QC/BlockNumber entries with block_number > target, and the
+     ledger-info / rand state, WITHOUT touching <data/reth>. That is EXACTLY the
+     "reth ahead of consensus" state the crash window would leave behind.
+  4. node.start() again and observe the failure: a panic in
+     consensus_log/validator.log, OR a silent stall (process up, RPC up, height
+     never advances past reth's persisted H, buffer Uninitialized).
+
+The test asserts the CORRECT post-fix behaviour (node detects reth > consensus,
+auto-reconciles, and RESUMES producing blocks). On current code it cannot, so it
+is marked xfail. The captured panic string / stall evidence is logged and
+attached to the assertion message.
+"""
+
+import asyncio
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from gravity_e2e.cluster.manager import Cluster
+
+LOG = logging.getLogger(__name__)
+
+# A real Rust panic always logs "panicked at". The recovery failure also logs
+# the specific F1 string before the empty-message panic.
+PANIC_MARKER = "panicked at"
+RECOVERY_FAIL_MARKER = "Failed to construct recovery data"
+# Bootstrap early-return / buffer-uninitialized evidence (bootstrap.rs:335-344).
+STALL_MARKERS = (
+    "Uninitialized",
+    "latest_commit_block_number",
+    "block buffer",
+)
+
+# gravity_cli / gravity_node live under the cargo target dir (quick-release).
+# Honour CARGO_TARGET_DIR (the harness exports it to the shared checkout's
+# target/, since a git worktree has no target/ of its own), else fall back to
+# <repo-root>/target.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TARGET_DIR = Path(os.environ.get("CARGO_TARGET_DIR", _REPO_ROOT / "target"))
+_GRAVITY_CLI = _TARGET_DIR / "quick-release" / "gravity_cli"
+
+# How long to wait after restart for the node to resume block production. A
+# healthy (fixed) node resumes within a few seconds; the buggy node stalls
+# forever, so a flat height across this whole window IS the stall evidence.
+RESUME_TIMEOUT = 45
+STALL_OBSERVE = 30
+
+
+def _consensus_log(node) -> Path:
+    return node._infra_path / "consensus_log" / "validator.log"
+
+
+def _scan_log(path: Path, markers) -> str | None:
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", errors="ignore") as f:
+            for line in f:
+                for m in markers:
+                    if m in line:
+                        return line.strip()
+    except OSError:
+        return None
+    return None
+
+
+def _grep_panic(node) -> str | None:
+    """Return the panic / recovery-failure line from validator.log, if any."""
+    log = _consensus_log(node)
+    hit = _scan_log(log, (RECOVERY_FAIL_MARKER,))
+    if hit:
+        return hit
+    return _scan_log(log, (PANIC_MARKER,))
+
+
+def _grep_stall_evidence(node) -> str | None:
+    log = _consensus_log(node)
+    return _scan_log(log, STALL_MARKERS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason="gravity-audit#703/#704: reth-ahead-of-consensus cross-store desync. "
+    "Recovery anchors on reth's height (gravity_node/src/main.rs:123 "
+    "recover_block_number) but the unwound consensus index lacks it, so "
+    "RecoveryData::new -> find_root fails with 'unable to find root' -> "
+    "persistent_liveness_storage.rs:550 panic!(\"\") and the node CRASHES "
+    "(the PartialRecoveryData/state-sync fallback on :551 is commented out and "
+    "recovery_manager.rs:104 is todo!()). The sibling F2 path is the "
+    "block_buffer_manager.rs:343 early-return (map non-empty but missing reth's "
+    "height) leaving the buffer Uninitialized -> get_ordered_blocks awaits "
+    "ready_notifier forever (silent stall). Remove this xfail once startup "
+    "auto-reconciles reth_height > consensus_index instead of panicking/stalling.",
+    strict=True,
+    raises=AssertionError,
+)
+async def test_reth_ahead_of_consensus_recovers(cluster: Cluster):
+    # ---- 1. Bring the single node live and commit past H -------------------
+    assert await cluster.set_full_live(timeout=90), "node failed to become live"
+    node = cluster.get_node("node1")
+    assert node, "node1 not found"
+    assert _GRAVITY_CLI.exists(), f"gravity_cli not found at {_GRAVITY_CLI}"
+
+    assert await node.wait_for_block_increase(timeout=60, delta=6), (
+        "node never committed past height 6 — cannot set up the desync"
+    )
+    h_before_stop = node.get_block_number()
+    LOG.info(f"node committed to height {h_before_stop}; stopping cleanly")
+    assert h_before_stop > 5, f"height {h_before_stop} too low to unwind"
+
+    # ---- 2. Clean stop -----------------------------------------------------
+    assert await node.stop(), "node failed to stop cleanly"
+    assert not node.is_running(), "node still running after stop()"
+
+    # GOTCHA: `gravity_cli unwind --consensus-db-path P` internally does
+    # ConsensusDB::new(P, ...) which JOINS "consensus_db" onto P (see
+    # consensusdb/mod.rs:112, CONSENSUS_DB_NAME). The node's real rocksdb lives
+    # at <data>/consensus_db, so the path we must hand the tool is the PARENT
+    # <data> dir — passing <data>/consensus_db makes the tool operate on an empty
+    # <data>/consensus_db/consensus_db and silently no-op. So:
+    data_dir = node._infra_path / "data"
+    consensus_db = data_dir / "consensus_db"  # the actual rocksdb the node opens
+    reth_db = data_dir / "reth"
+    assert consensus_db.exists(), f"consensus_db missing at {consensus_db}"
+    assert reth_db.exists(), f"reth db missing at {reth_db}"
+
+    # reth's on-disk height is the anchor recovery will use. We deliberately do
+    # NOT touch reth_db; only the consensus DB is rolled back.
+    reth_size_before = sum(
+        f.stat().st_size for f in reth_db.rglob("*") if f.is_file()
+    )
+
+    # ---- 3. Roll the CONSENSUS DB back, leaving reth ahead -----------------
+    # Unwind aggressively (to floor(H/2), well below reth's H): deletes consensus
+    # Block/QC/BlockNumber for block_number > target plus the stale ledger-info /
+    # rand state, but does NOT touch reth. This leaves the consensus index well
+    # behind reth so the recovery map no longer contains reth's height.
+    target = max(1, h_before_stop // 2)
+    LOG.info(
+        f"unwinding CONSENSUS DB to block {target} (reth stays at ~{h_before_stop}) "
+        f"to induce reth-ahead-of-consensus; passing parent dir {data_dir} "
+        f"(tool appends 'consensus_db')"
+    )
+    proc = subprocess.run(
+        [
+            str(_GRAVITY_CLI),
+            "unwind",
+            "--consensus-db-path",
+            str(data_dir),
+            "--target",
+            str(target),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    LOG.info(f"gravity_cli unwind stdout:\n{proc.stdout}")
+    if proc.stderr.strip():
+        LOG.info(f"gravity_cli unwind stderr:\n{proc.stderr}")
+    assert proc.returncode == 0, (
+        f"gravity_cli unwind failed (rc={proc.returncode}): {proc.stderr}"
+    )
+    # Confirm the tool hit the node's real DB, not an empty nested one.
+    assert "consensus_db/consensus_db" not in proc.stdout, (
+        "unwind operated on a NESTED consensus_db (wrong path) — it would no-op. "
+        f"stdout: {proc.stdout}"
+    )
+
+    # Sanity: reth was untouched (still ahead of the unwound consensus index).
+    reth_size_after = sum(
+        f.stat().st_size for f in reth_db.rglob("*") if f.is_file()
+    )
+    LOG.info(
+        f"reth db size {reth_size_before} -> {reth_size_after} bytes (unchanged; "
+        f"reth still at ~{h_before_stop}, consensus now at {target})"
+    )
+
+    # ---- 4. Restart and observe recovery -----------------------------------
+    if node.pid_file.exists():
+        node.pid_file.unlink()
+    LOG.info("restarting node with reth AHEAD of consensus...")
+    started = await node.start()
+
+    # Give recovery a moment to either panic or settle into the stall, then
+    # watch for block progress past reth's persisted height.
+    panic = None
+    resumed = False
+    base_height = None
+    deadline = time.time() + RESUME_TIMEOUT
+    while time.time() < deadline:
+        panic = _grep_panic(node)
+        if panic:
+            break
+        try:
+            if node.is_running():
+                bn = node.get_block_number()
+                if base_height is None:
+                    base_height = bn
+                # Healthy recovery: height climbs past where it restarted.
+                if bn > target + 1 and bn >= h_before_stop:
+                    resumed = True
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2)
+
+    # If still up and not resumed, confirm the stall is *persistent* (flat
+    # height) over an additional observation window — that is the F2 silent
+    # stall, distinct from a slow-but-progressing node.
+    stall_flat = False
+    if not panic and not resumed and node.is_running():
+        h0 = node.get_block_number()
+        await asyncio.sleep(STALL_OBSERVE)
+        h1 = node.get_block_number()
+        stall_flat = h1 == h0
+        LOG.info(
+            f"stall observation: height {h0} -> {h1} over {STALL_OBSERVE}s "
+            f"(flat={stall_flat})"
+        )
+
+    stall_log = _grep_stall_evidence(node)
+    final_running = node.is_running()
+    final_height = node.get_block_number() if final_running else None
+
+    # ---- 5. Build the evidence string and assert CORRECT behaviour ---------
+    if panic:
+        evidence = (
+            f"RECOVERY PANIC (F1/#703): validator.log -> {panic!r}. "
+            f"Source: aptos-core/consensus/src/persistent_liveness_storage.rs:550 "
+            f"panic!(\"\") after 'Failed to construct recovery data' / "
+            f"RecoveryData::new -> find_root 'unable to find root' "
+            f"(PartialRecoveryData fallback on :551 commented out; "
+            f"recovery_manager.rs:104 todo!())."
+        )
+    elif stall_flat or (not resumed and not started):
+        evidence = (
+            f"SILENT STALL (F2/#704): node up={final_running}, height frozen at "
+            f"{final_height} (reth persisted ~{h_before_stop}, consensus unwound "
+            f"to {target}); no progress in {RESUME_TIMEOUT}+{STALL_OBSERVE}s. "
+            f"Source: crates/block-buffer-manager/src/block_buffer_manager.rs:343 "
+            f"early-return (latest_commit_block_number not in the recovered map) "
+            f"leaves the buffer Uninitialized -> get_ordered_blocks awaits "
+            f"ready_notifier forever."
+            + (f" log: {stall_log!r}" if stall_log else "")
+        )
+    elif not final_running:
+        evidence = (
+            f"NODE DIED on restart (reth ahead of consensus): process not "
+            f"running, no clean panic captured. start()={started}. "
+            f"Inspect {_consensus_log(node)}."
+        )
+    else:
+        evidence = "node resumed cleanly"
+
+    LOG.info(f"OBSERVED: {evidence}")
+
+    # CORRECT post-fix behaviour: the node detects reth_height > consensus_index,
+    # reconciles, and RESUMES producing blocks past the desync point. Until that
+    # path exists this assertion fails -> xfail.
+    assert resumed and final_running and panic is None, (
+        f"node did NOT recover from reth-ahead-of-consensus desync. {evidence}"
+    )


### PR DESCRIPTION
## Summary

Adds a deterministic single-node e2e suite (`gravity_e2e/cluster_test_cases/cross_store_desync_703_704/`) that reproduces the **non-atomic cross-store commit** bug and the recovery-path crash it triggers — findings **F1/F2** in `galxe/RESTART_RECOVERY_FINDINGS.md`.

reth (execution rocksdb) and the aptos consensus DB persist on independent stores with no write-ordering barrier. A crash in the commit window can leave **reth at block N while consensus is at N-1**. On restart, recovery anchors on reth's height (`bin/gravity_node/src/main.rs:123` `recover_block_number`) but the consensus index no longer contains it, so recovery cannot find the root and the node dies — there is no reconcile / state-sync fallback.

## Reproduction (no power-loss race needed)

1. Bring the node live, commit past height H, `node.stop()` cleanly.
2. `gravity_cli unwind` the **consensus** DB back to ~H/2, leaving reth at H.
   - Gotcha encoded in the test: `--consensus-db-path` must be the **parent `<data>` dir**, because `ConsensusDB::new` joins `consensus_db` internally (`aptos-core/consensus/src/consensusdb/mod.rs:112`). Passing `<data>/consensus_db` operates on an empty nested DB and silently no-ops.
3. `node.start()` and observe recovery.

## Observed failure (current code)

```
ERROR aptos-core/consensus/src/persistent_liveness_storage.rs:549
  Failed to construct recovery data {"error":"unable to find root: 80dce1e8 ...
  LedgerRecoveryData::find_root ... RecoveryData::new ..."}
panicked at aptos-core/consensus/src/persistent_liveness_storage.rs:550:17
  (panic!(""))   -> node process dead (crash)
```

This is **F1 (#703)**: the `PartialRecoveryData` / state-sync fallback at `:551` is commented out and `recovery_manager.rs:104` is `todo!()`, so any inconsistent recovery data is a `panic!("")`. The sibling **F2 (#704)** silent-stall path (`crates/block-buffer-manager/src/block_buffer_manager.rs:343` early-return leaving the buffer `Uninitialized` → `get_ordered_blocks` awaits `ready_notifier` forever) is also asserted as a recovery failure.

## Test status

The test asserts the **correct post-fix behaviour** (node detects `reth_height > consensus_index`, reconciles, and resumes producing blocks), so it is `@pytest.mark.xfail(strict=True)` on current code:

```
1 xfailed in 6.48s
```

Remove the xfail once startup auto-reconciles instead of panicking/stalling.

## Notes

- Test-only; **no production code changed**.
- Unique `base_dir=/tmp/gravity-cluster-desync` and unique ports (rpc 8945, validator 6480, vfn 6490, authrpc 8953, reth_p2p 12324, metrics 9050, inspection 10300) — no collision with existing suites.
- Cross-repo refs: Galxe/gravity-audit#703, Galxe/gravity-audit#704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)