### PR TITLE
Gracefully stop reth coordinator tasks

### DIFF
--- a/bin/gravity_node/src/main.rs
+++ b/bin/gravity_node/src/main.rs
@@ -66,13 +66,13 @@ fn run_reth(
     cli: Cli<EthereumChainSpecParser>,
     execution_args_rx: oneshot::Receiver<ExecutionArgs>,
     mut shutdown: broadcast::Receiver<()>,
-) -> (ConsensusArgs<impl RethEthCall>, u64, oneshot::Receiver<PathBuf>) {
+) -> (ConsensusArgs<impl RethEthCall>, u64, oneshot::Receiver<PathBuf>, thread::JoinHandle<()>) {
     let (datadir_tx, datadir_rx) = oneshot::channel::<PathBuf>();
     reth_cli_util::sigsegv_handler::install();
 
     let (tx, rx) = std::sync::mpsc::sync_channel(1);
 
-    std::thread::spawn(move || {
+    let reth_thread = std::thread::spawn(move || {
         // Trick code to ensure the `rx.recv` won't panic before the error message is printed
         let _tx = tx.clone();
         let res = cli.run(
@@ -174,7 +174,7 @@ fn run_reth(
     });
 
     let (args, block_number) = rx.recv().unwrap();
-    (args, block_number, datadir_rx)
+    (args, block_number, datadir_rx, reth_thread)
 }
 
 struct ProfilingState {
@@ -298,7 +298,7 @@ fn main() {
     });
 
     let (execution_args_tx, execution_args_rx) = oneshot::channel();
-    let (consensus_args, latest_block_number, datadir_rx) =
+    let (consensus_args, latest_block_number, datadir_rx, reth_thread) =
         run_reth(cli, execution_args_rx, shutdown_tx.subscribe());
     let rt = tokio::runtime::Runtime::new().unwrap();
     let chain_id = {
@@ -315,13 +315,17 @@ fn main() {
     ));
     let txn_cache = pool.tx_cache();
     let shutdown_rx_cli = shutdown_tx.subscribe();
-    rt.block_on(async move {
+    let coordinator_result = rt.block_on(async move {
         let datadir = datadir_rx.await.expect("datadir should be sent");
         let client = Arc::new(RethCli::new(consensus_args, txn_cache, shutdown_rx_cli).await);
         let chain_id = client.chain_id();
 
-        let coordinator =
-            Arc::new(RethCoordinator::new(client.clone(), latest_block_number, execution_args_tx));
+        let coordinator = Arc::new(RethCoordinator::new(
+            client.clone(),
+            latest_block_number,
+            execution_args_tx,
+            shutdown_tx.clone(),
+        ));
         let mut _engine = None;
         if std::env::var("MOCK_CONSENSUS").unwrap_or("false".to_string()).parse::<bool>().unwrap() {
             warn!("MOCK_CONSENSUS is enabled! This disables BFT consensus and should NEVER be used in production.");
@@ -354,10 +358,24 @@ fn main() {
             );
         }
         coordinator.send_execution_args().await;
-        coordinator.run().await;
+        let result = coordinator.run().await;
+        if let Err(err) = &result {
+            tracing::error!("Reth coordinator stopped with error: {err}");
+            let _ = shutdown_tx.send(());
+        }
 
-        let mut shutdown_rx = shutdown_tx.subscribe();
-        let _ = shutdown_rx.recv().await;
         info!("Main shutdown complete");
+        result
     });
+    drop(rt);
+
+    if let Err(err) = reth_thread.join() {
+        eprintln!("Reth thread panicked: {err:?}");
+        std::process::exit(1);
+    }
+
+    if let Err(err) = coordinator_result {
+        eprintln!("Reth coordinator stopped with error: {err}");
+        std::process::exit(1);
+    }
 }

--- a/bin/gravity_node/src/reth_coordinator/mod.rs
+++ b/bin/gravity_node/src/reth_coordinator/mod.rs
@@ -1,15 +1,21 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::reth_cli::{RethCli, RethEthCall};
 use alloy_primitives::B256;
 use block_buffer_manager::get_block_buffer_manager;
 use greth::reth_pipe_exec_layer_ext_v2::ExecutionArgs;
-use tokio::sync::{oneshot, Mutex};
+use tokio::{
+    sync::{broadcast, oneshot, Mutex},
+    task::{JoinError, JoinHandle},
+};
 use tracing::info;
+
+const COORDINATOR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct RethCoordinator<EthApi: RethEthCall> {
     reth_cli: Arc<RethCli<EthApi>>,
     execution_args_tx: Arc<Mutex<Option<oneshot::Sender<ExecutionArgs>>>>,
+    shutdown_tx: broadcast::Sender<()>,
 }
 
 impl<EthApi: RethEthCall> RethCoordinator<EthApi> {
@@ -17,8 +23,13 @@ impl<EthApi: RethEthCall> RethCoordinator<EthApi> {
         reth_cli: Arc<RethCli<EthApi>>,
         _latest_block_number: u64,
         execution_args_tx: oneshot::Sender<ExecutionArgs>,
+        shutdown_tx: broadcast::Sender<()>,
     ) -> Self {
-        Self { reth_cli, execution_args_tx: Arc::new(Mutex::new(Some(execution_args_tx))) }
+        Self {
+            reth_cli,
+            execution_args_tx: Arc::new(Mutex::new(Some(execution_args_tx))),
+            shutdown_tx,
+        }
     }
 
     pub async fn send_execution_args(&self) {
@@ -39,23 +50,88 @@ impl<EthApi: RethEthCall> RethCoordinator<EthApi> {
         }
     }
 
-    pub async fn run(&self) {
+    pub async fn run(&self) -> Result<(), String> {
         let reth_cli1 = self.reth_cli.clone();
-        let h1 = tokio::spawn(async move { reth_cli1.start_execution().await });
+        let mut h1 = tokio::spawn(async move { reth_cli1.start_execution().await });
 
         let reth_cli2 = self.reth_cli.clone();
-        let h2 = tokio::spawn(async move { reth_cli2.start_commit_vote().await });
+        let mut h2 = tokio::spawn(async move { reth_cli2.start_commit_vote().await });
 
         let reth_cli3 = self.reth_cli.clone();
-        let h3 = tokio::spawn(async move { reth_cli3.start_commit().await });
+        let mut h3 = tokio::spawn(async move { reth_cli3.start_commit().await });
 
-        tokio::spawn(async move {
-            tokio::select! {
-                res = h1 => tracing::error!("start_execution task exited unexpectedly: {:?}", res),
-                res = h2 => tracing::error!("start_commit_vote task exited unexpectedly: {:?}", res),
-                res = h3 => tracing::error!("start_commit task exited unexpectedly: {:?}", res),
-            };
-            std::process::exit(1);
-        });
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
+        tokio::select! {
+            res = &mut h1 => {
+                let result = Self::task_result("start_execution", res);
+                self.signal_shutdown();
+                Self::wait_for_task("start_commit_vote", h2).await;
+                Self::wait_for_task("start_commit", h3).await;
+                result
+            }
+            res = &mut h2 => {
+                let result = Self::task_result("start_commit_vote", res);
+                self.signal_shutdown();
+                Self::wait_for_task("start_execution", h1).await;
+                Self::wait_for_task("start_commit", h3).await;
+                result
+            }
+            res = &mut h3 => {
+                let result = Self::task_result("start_commit", res);
+                self.signal_shutdown();
+                Self::wait_for_task("start_execution", h1).await;
+                Self::wait_for_task("start_commit_vote", h2).await;
+                result
+            }
+            _ = shutdown_rx.recv() => {
+                info!("Shutdown signal received, stopping reth coordinator tasks");
+                self.signal_shutdown();
+                Self::wait_for_task("start_execution", h1).await;
+                Self::wait_for_task("start_commit_vote", h2).await;
+                Self::wait_for_task("start_commit", h3).await;
+                Ok(())
+            }
+        }
+    }
+
+    fn task_result(
+        task_name: &'static str,
+        result: Result<Result<(), String>, JoinError>,
+    ) -> Result<(), String> {
+        match result {
+            Ok(Ok(())) => {
+                info!("{task_name} task stopped");
+                Ok(())
+            }
+            Ok(Err(err)) => {
+                tracing::error!("{task_name} task failed: {err}");
+                Err(format!("{task_name} task failed: {err}"))
+            }
+            Err(err) => {
+                tracing::error!("{task_name} task join failed: {err}");
+                Err(format!("{task_name} task join failed: {err}"))
+            }
+        }
+    }
+
+    async fn wait_for_task(task_name: &'static str, mut handle: JoinHandle<Result<(), String>>) {
+        match tokio::time::timeout(COORDINATOR_SHUTDOWN_TIMEOUT, &mut handle).await {
+            Ok(result) => {
+                if let Err(err) = Self::task_result(task_name, result) {
+                    tracing::warn!("reth coordinator observed task shutdown error: {err}");
+                }
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "{task_name} task did not stop within {:?}; aborting",
+                    COORDINATOR_SHUTDOWN_TIMEOUT
+                );
+                handle.abort();
+            }
+        }
+    }
+
+    fn signal_shutdown(&self) {
+        let _ = self.shutdown_tx.send(());
     }
 }


### PR DESCRIPTION
## Summary
- replace the coordinator watchdog's direct process::exit path with an awaited Result-returning shutdown path
- broadcast shutdown when a coordinator task exits, then wait briefly for the remaining coordinator tasks to stop
- join the reth runner thread before returning a non-zero exit for coordinator failures

## Validation
- RUSTFLAGS="--cfg tokio_unstable" cargo check -p gravity_node

Related audit context: Galxe/gravity-audit#11