### PR TITLE
chore(deps): bump gravity-reth to 408ef602 (audit-710 InvalidTransaction filter) + e2e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,7 +4607,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -7898,9 +7898,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gravity-precompiles"
+version = "1.8.3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+dependencies = [
+ "alloy-primitives",
+ "reth-evm",
+ "revm",
+ "tracing",
+]
+
+[[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 
 [[package]]
 name = "gravity-sdk"
@@ -7914,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8034,7 +8045,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -11527,7 +11538,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12752,7 +12763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13487,7 +13498,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13533,7 +13544,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13557,7 +13568,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13586,7 +13597,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13606,7 +13617,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13620,7 +13631,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13697,7 +13708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13707,7 +13718,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13725,7 +13736,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13743,7 +13754,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13754,7 +13765,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13769,7 +13780,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13782,7 +13793,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13794,7 +13805,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13820,7 +13831,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13841,7 +13852,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13866,7 +13877,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13897,7 +13908,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13911,7 +13922,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13937,7 +13948,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13961,7 +13972,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13985,7 +13996,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14015,7 +14026,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14046,7 +14057,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14068,7 +14079,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14093,7 +14104,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "futures",
  "pin-project",
@@ -14116,7 +14127,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14168,7 +14179,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14196,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14212,7 +14223,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14227,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14249,7 +14260,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14260,7 +14271,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14288,7 +14299,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14309,7 +14320,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14331,7 +14342,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14347,7 +14358,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14365,7 +14376,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14378,7 +14389,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14407,7 +14418,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14426,7 +14437,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14436,7 +14447,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14459,7 +14470,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14481,7 +14492,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14494,7 +14505,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14512,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14550,7 +14561,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14564,7 +14575,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "serde",
  "serde_json",
@@ -14574,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14601,7 +14612,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "bytes",
  "futures",
@@ -14621,7 +14632,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "futures",
  "metrics",
@@ -14633,7 +14644,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14641,7 +14652,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14655,7 +14666,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14710,7 +14721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14735,7 +14746,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14757,7 +14768,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14772,7 +14783,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14786,7 +14797,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14803,7 +14814,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14827,7 +14838,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14896,7 +14907,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14949,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14987,7 +14998,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15011,7 +15022,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15035,7 +15046,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15056,7 +15067,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15068,7 +15079,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15089,7 +15100,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15101,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15121,7 +15132,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15131,7 +15142,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15144,7 +15155,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15155,6 +15166,7 @@ dependencies = [
  "api-types",
  "bcs 0.1.6",
  "blst",
+ "gravity-precompiles",
  "gravity-primitives",
  "gravity-storage",
  "grevm",
@@ -15191,7 +15203,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15215,7 +15227,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15228,7 +15240,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15258,7 +15270,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15301,7 +15313,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15329,7 +15341,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15342,7 +15354,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15361,7 +15373,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15388,7 +15400,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15401,7 +15413,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15428,6 +15440,7 @@ dependencies = [
  "derive_more 2.1.1",
  "dyn-clone",
  "futures",
+ "gravity-precompiles",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
@@ -15480,7 +15493,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15508,7 +15521,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15547,7 +15560,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15568,7 +15581,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15598,7 +15611,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15642,7 +15655,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15689,7 +15702,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15703,7 +15716,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15719,7 +15732,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15763,7 +15776,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15790,7 +15803,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15803,7 +15816,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15823,7 +15836,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15835,7 +15848,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15865,7 +15878,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15881,7 +15894,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15899,7 +15912,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15909,7 +15922,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15924,7 +15937,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15966,7 +15979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15990,7 +16003,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16017,7 +16030,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16036,7 +16049,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16061,7 +16074,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16080,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16098,7 +16111,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=0adbb4c90c4a91a461e0766d4d31bba32d097363#0adbb4c90c4a91a461e0766d4d31bba32d097363"
+source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "0adbb4c90c4a91a461e0766d4d31bba32d097363" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "408ef602ccd6e5d8c37e0054e4d93a06df4613b3" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }

--- a/gravity_e2e/cluster_test_cases/prague/test_eip7702.py
+++ b/gravity_e2e/cluster_test_cases/prague/test_eip7702.py
@@ -7,6 +7,8 @@ Verifies post-Prague behavior observable via contract execution:
   P-B4  pipe-exec filter discards low-intrinsic-gas SetCode tx
   P-B5  filter admits sufficiently-gassed SetCode tx
   P-B6  self-sponsored self-delegation (tx.from == authority) does not halt the chain
+  P-B7  type-4 tx with empty authorizationList is filtered; chain stays alive
+  P-B8  delegated EOA can still send a plain type-2 tx (EIP-3607 designator carve-out)
 """
 
 import asyncio
@@ -15,7 +17,10 @@ import logging
 from pathlib import Path
 
 import pytest
+import rlp
 from eth_account import Account
+from eth_keys import keys as eth_keys_keys
+from eth_utils import keccak, to_bytes
 from web3 import Web3
 
 from gravity_e2e.cluster.manager import Cluster
@@ -327,3 +332,173 @@ async def test_p_b6_self_sponsored_self_delegation(cluster: Cluster):
         f"no new block after self-sponsored SetCode (head stuck at {head_after_tx}) "
         "— chain may have halted"
     )
+
+
+def _hand_build_type4_with_empty_authlist(
+    sender,
+    *,
+    chain_id: int,
+    nonce: int,
+    to: str,
+    value: int,
+    data: bytes,
+    gas: int,
+    max_fee_per_gas: int,
+    max_priority_fee_per_gas: int,
+) -> bytes:
+    """Hand-encode a type-4 tx with an empty authorizationList.
+
+    eth_account.sign_transaction asserts authorizationList non-empty client-side
+    (per EIP-7702 spec), so to exercise the on-chain filter we have to bypass
+    its validation. A real attacker would do the same — that's exactly why the
+    filter has to exist server-side.
+
+    RLP layout (EIP-7702):
+        0x04 || rlp([chain_id, nonce, max_priority, max_fee, gas_limit,
+                     to, value, data, access_list, authorization_list,
+                     y_parity, r, s])
+    """
+    fields_unsigned = [
+        chain_id,
+        nonce,
+        max_priority_fee_per_gas,
+        max_fee_per_gas,
+        gas,
+        to_bytes(hexstr=to),
+        value,
+        data,
+        [],  # access_list
+        [],  # authorization_list — malformed: empty
+    ]
+    sign_payload = b"\x04" + rlp.encode(fields_unsigned)
+    msg_hash = keccak(sign_payload)
+    priv = eth_keys_keys.PrivateKey(bytes(sender.key))
+    sig = priv.sign_msg_hash(msg_hash)
+    fields_signed = fields_unsigned + [sig.v, sig.r, sig.s]
+    return b"\x04" + rlp.encode(fields_signed)
+
+
+@pytest.mark.asyncio
+async def test_p_b7_empty_authorization_list_filtered(cluster: Cluster):
+    """P-B7: type-4 SetCode tx with empty authorizationList must be filter-rejected.
+
+    Regression for gravity-reth#357 / gravity-audit#710 (EmptyAuthorizationList
+    branch). EIP-7702 mandates >=1 authorization; an empty list yields
+    revm `InvalidTransaction::EmptyAuthorizationList`. The executor cannot
+    recover from `EVMError`, so without the admission filter this tx would
+    bring the validator down. We hand-build the RLP because eth_account
+    refuses to sign the malformed form — a hostile client would do the same.
+    Oracles:
+      - submission either errors at the pool, or returns a hash that never
+        produces a receipt (silent drop);
+      - the node continues to mine new blocks (gravity_node did not panic).
+    """
+    node = cluster.get_node("node1")
+    chain_id = node.w3.eth.chain_id
+    faucet = cluster.faucet
+
+    head_before = node.w3.eth.block_number
+    sender_nonce = node.w3.eth.get_transaction_count(faucet.address)
+    fee = max(node.w3.eth.gas_price * 2, 10**9)
+
+    raw = _hand_build_type4_with_empty_authlist(
+        faucet,
+        chain_id=chain_id,
+        nonce=sender_nonce,
+        to=faucet.address,
+        value=0,
+        data=b"",
+        gas=100_000,
+        max_fee_per_gas=fee,
+        max_priority_fee_per_gas=fee,
+    )
+
+    tx_hash = None
+    try:
+        tx_hash = node.w3.eth.send_raw_transaction(raw).hex()
+        LOG.info(f"P-B7 empty-authList submitted: {tx_hash}; expecting silent drop")
+    except Exception as exc:
+        LOG.info(f"P-B7 pool rejected at submission: {type(exc).__name__}: {exc}")
+
+    if tx_hash is not None:
+        receipt = await _wait_for_receipt(node, tx_hash, timeout=15.0)
+        assert receipt is None, (
+            f"empty-authList type-4 tx unexpectedly mined: {receipt} — "
+            "InvalidTransaction::EmptyAuthorizationList filter is missing"
+        )
+
+    # Liveness oracle: chain must still be producing blocks.
+    deadline = asyncio.get_event_loop().time() + 30.0
+    while asyncio.get_event_loop().time() < deadline:
+        if node.w3.eth.block_number > head_before:
+            return
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"no new block after empty-authList tx (head stuck at {head_before}) "
+        "— gravity_node may have panicked on InvalidTransaction::EmptyAuthorizationList"
+    )
+
+
+@pytest.mark.asyncio
+async def test_p_b8_delegated_eoa_can_send_plain_tx(cluster: Cluster):
+    """P-B8: EOA with an installed 7702 delegation designator can still send a plain type-2 tx.
+
+    Regression for the EIP-3607 designator carve-out added in gravity-reth#357.
+    The filter rejects senders that have code, EXCEPT when the bytecode is the
+    23-byte `EF01 00 || target` delegation designator from EIP-7702. Without
+    the carve-out the filter would reject every subsequent tx signed by a
+    delegated EOA, silently breaking all 7702-based smart-account flows.
+    """
+    node = cluster.get_node("node1")
+    chain_id = node.w3.eth.chain_id
+    faucet = cluster.faucet
+
+    _, delegate_addr = await _deploy(node, faucet, "Delegate")
+    delegated = Account.create()
+    LOG.info(f"P-B8 delegated={delegated.address}, delegate={delegate_addr}")
+
+    # Fund the delegated EOA so it can pay gas for its own plain tx.
+    tb = TransactionBuilder(node.w3, faucet)
+    fund = await tb.send_ether(to=delegated.address, amount_wei=10**18)
+    assert fund.success, f"funding delegated EOA failed: {fund.error}"
+
+    # Install the delegation (faucet-sponsored).
+    install_hash = await _send_setcode_tx(
+        node, faucet, delegated, delegate_addr, gas=200_000, chain_id=chain_id
+    )
+    install_receipt = await _wait_for_receipt(node, install_hash)
+    assert install_receipt is not None and install_receipt["status"] == 1, (
+        f"delegation install failed: {install_receipt}"
+    )
+
+    # Sanity: the EOA now carries the 23-byte designator (EF0100 || target).
+    code = node.w3.eth.get_code(delegated.address)
+    assert len(code) == 23 and bytes(code).startswith(b"\xef\x01\x00"), (
+        f"unexpected code on delegated EOA: {code.hex()}"
+    )
+
+    # Plain type-2 transfer signed by the delegated EOA itself.
+    # Pre-fix (no designator carve-out) the filter would reject this with
+    # InvalidTransaction::RejectCallerWithCode.
+    sink = Account.create().address  # fresh EOA, no code — avoids fallback rathole
+    fee = max(node.w3.eth.gas_price * 2, 10**9)
+    plain_tx = {
+        "type": 2,
+        "chainId": chain_id,
+        "nonce": node.w3.eth.get_transaction_count(delegated.address),
+        "to": sink,
+        "value": 0,
+        "data": b"",
+        "gas": 25_000,
+        "maxFeePerGas": fee,
+        "maxPriorityFeePerGas": fee,
+        "accessList": [],
+    }
+    signed = delegated.sign_transaction(plain_tx)
+    plain_hash = node.w3.eth.send_raw_transaction(signed.raw_transaction).hex()
+    receipt = await _wait_for_receipt(node, plain_hash, timeout=30.0)
+    assert receipt is not None, (
+        "delegated-EOA type-2 tx receipt timeout — filter may be wrongly "
+        "rejecting senders with the 7702 delegation designator (EIP-3607 carve-out broken)"
+    )
+    assert receipt["status"] == 1, f"delegated-EOA plain tx failed: {receipt}"


### PR DESCRIPTION
## Summary
- Bumps `greth` from `0adbb4c9` to `408ef602` (Galxe/gravity-reth#357), which closes the remaining 6 of 9 `revm::InvalidTransaction` variants at the admission filter (gas/priority fee, empty authList, balance, chainId, EIP-3607 sender-with-code). Closes the audit-710 follow-up: the executor cannot recover from `EVMError`, so the filter is the only practical defense.
- Adds two Prague E2E cases in `cluster_test_cases/prague/test_eip7702.py`:
  - **P-B7** — hand-built type-4 tx with empty `authorizationList` (eth_account refuses to sign the malformed form, so we encode RLP directly — a hostile client would too). Oracle: RPC rejects at admission + chain keeps producing blocks (`gravity_node` didn't panic on `InvalidTransaction::EmptyAuthorizationList`).
  - **P-B8** — EIP-3607 designator carve-out: an EOA with an installed 7702 delegation designator can still send a plain type-2 tx with its own key. Without the carve-out the filter would silently break every 7702-based smart-account flow.

## Test plan
- [x] `RUSTFLAGS="--cfg tokio_unstable" cargo check -p gravity_node` — passes
- [x] `RUSTFLAGS="--cfg tokio_unstable" cargo build -p gravity_node -p gravity_cli --profile quick-release` — passes
- [x] `python3 gravity_e2e/runner.py prague` — **13/13 passed in 92s** (existing P-B1..P-B6 + EIP-2935 cases unaffected; new P-B7 confirmed pool-reject `Web3RPCError -32000 "no items in authorization list for EIP7702 transaction"`; P-B8 delegated EOA tx succeeded)