### PR TITLE
chore(deps): bump gravity-reth to 1aec7b75 (audit-715 wipe+recreate state root)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,7 +4607,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "reth-evm",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 
 [[package]]
 name = "gravity-sdk"
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8045,7 +8045,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=3c09e7ce5cfc904d566c89a4a60f160839890792#3c09e7ce5cfc904d566c89a4a60f160839890792"
+source = "git+https://github.com/Galxe/grevm?rev=a368f423a967678f556c8b07cbf0c6e6d1a31335#a368f423a967678f556c8b07cbf0c6e6d1a31335"
 dependencies = [
  "ahash 0.8.12",
  "alloy-evm",
@@ -11538,7 +11538,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12763,7 +12763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13498,7 +13498,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13544,7 +13544,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13568,7 +13568,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13597,7 +13597,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13617,7 +13617,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13631,7 +13631,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13708,7 +13708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13718,7 +13718,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13736,7 +13736,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13754,7 +13754,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13765,7 +13765,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13780,7 +13780,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13793,7 +13793,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13805,7 +13805,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13831,7 +13831,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13852,7 +13852,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13877,7 +13877,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13908,7 +13908,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13922,7 +13922,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13948,7 +13948,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13972,7 +13972,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13996,7 +13996,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14026,7 +14026,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14057,7 +14057,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14079,7 +14079,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14104,7 +14104,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "futures",
  "pin-project",
@@ -14127,7 +14127,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14179,7 +14179,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14207,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14223,7 +14223,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14238,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14260,7 +14260,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14271,7 +14271,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14299,7 +14299,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14320,7 +14320,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14342,7 +14342,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14358,7 +14358,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14376,7 +14376,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14389,7 +14389,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14418,7 +14418,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14437,7 +14437,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14447,7 +14447,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14470,7 +14470,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14492,7 +14492,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14505,7 +14505,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14523,7 +14523,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14561,7 +14561,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14575,7 +14575,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "serde",
  "serde_json",
@@ -14585,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14612,7 +14612,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "bytes",
  "futures",
@@ -14632,7 +14632,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "futures",
  "metrics",
@@ -14644,7 +14644,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14652,7 +14652,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14666,7 +14666,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14721,7 +14721,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14746,7 +14746,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14768,7 +14768,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14783,7 +14783,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14797,7 +14797,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14814,7 +14814,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14838,7 +14838,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14907,7 +14907,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14960,7 +14960,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14998,7 +14998,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15022,7 +15022,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15046,7 +15046,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15067,7 +15067,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15079,7 +15079,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15100,7 +15100,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15112,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15132,7 +15132,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15142,7 +15142,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15155,7 +15155,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15203,7 +15203,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15227,7 +15227,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15240,7 +15240,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15270,7 +15270,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15313,7 +15313,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15341,7 +15341,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15354,7 +15354,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15373,7 +15373,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15400,7 +15400,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15413,7 +15413,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15493,7 +15493,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15521,7 +15521,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15560,7 +15560,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15581,7 +15581,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15611,7 +15611,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15655,7 +15655,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15702,7 +15702,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15716,7 +15716,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15732,7 +15732,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15776,7 +15776,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15803,7 +15803,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15816,7 +15816,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15836,7 +15836,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15848,7 +15848,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15878,7 +15878,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15894,7 +15894,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15912,7 +15912,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15922,7 +15922,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15937,7 +15937,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15979,7 +15979,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16003,7 +16003,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16030,7 +16030,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16049,7 +16049,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16074,7 +16074,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16093,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16111,7 +16111,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=408ef602ccd6e5d8c37e0054e4d93a06df4613b3#408ef602ccd6e5d8c37e0054e4d93a06df4613b3"
+source = "git+https://github.com/Galxe/gravity-reth?rev=1aec7b75487aff6c4d41f66d0f457d3dbb905eff#1aec7b75487aff6c4d41f66d0f457d3dbb905eff"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "408ef602ccd6e5d8c37e0054e4d93a06df4613b3" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "1aec7b75487aff6c4d41f66d0f457d3dbb905eff" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }


### PR DESCRIPTION
## Summary
- Bumps `greth` from `408ef602` to `1aec7b75` (Galxe/gravity-reth#356), which fixes a CRITICAL nested-trie bug surfaced by the internal audit (Galxe/gravity-audit#715): when an account is selfdestructed and recreated in the same block (revm emits `DestroyedChanged` with `HashedStorage { wiped: true, storage: { new slots } }`), the prior `wiped` branch in `crates/trie/db/src/nested_hash.rs` returned `EMPTY_ROOT_HASH` and `continue`d without ever applying the recreated slots. The new slots were silently dropped from both the computed state root and the persisted `StoragesTrieV2` table.
- Cluster-level impact: a homogeneous gravity cluster would have agreed on the **wrong** state root (no self-halt) but **forked from geth / upstream reth** with permanent on-disk storage loss — a funds-safety / consensus-divergence issue.
- Fix in greth: when `wiped` is true, build a fresh storage trie from an empty base, insert the recreated non-zero slots, take the real storage root, and only emit `EMPTY_ROOT_HASH` when the post-wipe storage map is genuinely empty. Old on-disk nodes are still delete-marked.

## Test plan
- [x] `RUSTFLAGS="--cfg tokio_unstable" cargo update -p greth` — Cargo.lock regenerated cleanly
- [x] `RUSTFLAGS="--cfg tokio_unstable" cargo check -p gravity_node` — passes
- [ ] (Upstream coverage) The fix ships with `wipe_recreate_e2e.rs` + `mainnet_replay.rs` + a `repro_nested_hash_wiped_recreate_storage_root` differential test in Galxe/gravity-reth#356; no SDK-side wiring needed here.