### PR TITLE
chore(consensus): downgrade hot-path per-round logs from info to debug

### DIFF
--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -1000,7 +1000,7 @@ impl BlockStore {
 
     /// Validates quorum certificates and inserts it into block tree assuming dependencies exist.
     pub fn insert_single_quorum_cert(&self, qc: QuorumCert, rebuild: bool) -> anyhow::Result<()> {
-        info!("insert qc {}", qc);
+        debug!("insert qc {}", qc);
         // If the parent block is not the root block (i.e not None), ensure the executed state
         // of a block is consistent with its QuorumCert, otherwise persist the QuorumCert's
         // state and on restart, a new execution will agree with it.  A new execution will match

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -1973,7 +1973,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 // Handles Direct Send/Broadcast messages (e.g. ProposalMsg, VoteMsg, etc).
                 // "Fire and forget" style messages that do not require an immediate response.
                 (peer, msg) = network_receivers.consensus_messages.select_next_some() => {
-                    info!("consensus message peer {:?} msg {:?}", peer, msg);
+                    debug!("consensus message peer {:?} msg {:?}", peer, msg);
                     monitor!("epoch_manager_process_consensus_messages",
                     if let Err(e) = self.process_message(peer, msg).await {
                         error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));

--- a/aptos-core/consensus/src/liveness/round_state.rs
+++ b/aptos-core/consensus/src/liveness/round_state.rs
@@ -260,7 +260,7 @@ impl RoundState {
         if sync_info.highest_ordered_round() > self.highest_ordered_round {
             self.highest_ordered_round = sync_info.highest_ordered_round();
         }
-        info!(
+        debug!(
             round = self.current_round,
             highest_ordered_round = self.highest_ordered_round,
             "Processing certificates With SyncInfo",

--- a/aptos-core/consensus/src/quorum_store/proof_manager.rs
+++ b/aptos-core/consensus/src/quorum_store/proof_manager.rs
@@ -184,7 +184,7 @@ impl ProofManager {
         block_timestamp: u64,
         batches: Vec<BatchInfo>,
     ) {
-        info!("QS: got clean request from execution at block timestamp {}", block_timestamp);
+        debug!("QS: got clean request from execution at block timestamp {}", block_timestamp);
         trace!("QS: got clean request from execution at block timestamp {}", block_timestamp);
         self.batch_queue.remove_expired_batches();
         for batch in &batches {

--- a/aptos-core/consensus/src/round_manager.rs
+++ b/aptos-core/consensus/src/round_manager.rs
@@ -665,7 +665,7 @@ impl RoundManager {
     async fn sync_up(&mut self, sync_info: &SyncInfo, author: Author) -> anyhow::Result<()> {
         let local_sync_info = self.block_store.sync_info();
         if sync_info.has_newer_certificates(&local_sync_info) {
-            info!(
+            debug!(
                 self.new_log(LogEvent::ReceiveNewCertificate).remote_peer(author),
                 "Local state {},\n remote state {}", local_sync_info, sync_info
             );


### PR DESCRIPTION
## Problem

On the sub-second AptosBFT mainnet (~4–5 blocks/s) the consensus log floods at **INFO**: measured **~370 lines/s ≈ ~18.5 GB/day** on a live mainnet validator. By **bytes** it is dominated by per-message / per-round chatter and full certificate Debug dumps that carry no operational value at INFO. This drives node disk pressure and (where shipped) Cloud Logging cost.

## Change

Downgrade **10** hot-path log points `info!` → `debug!`. Pure log-level change, **no behavioral change**; `debug!` is already in scope via `aptos_logger::prelude::*` in every touched file.

**Measured impact** (114 MB consensus-log sample on a live mainnet validator): these 10 account for **~78% of consensus-log bytes** → the consensus log drops to **~22% of current (~18.5 → ~4 GB/day)**.

| file | log | share |
| --- | --- | --- |
| `epoch_manager.rs` | `"consensus message peer {} msg {}"` — logs **every inbound consensus message** with full Debug; `msg {:?}` expands SyncInfo/Vote certs into the giant `hqc:`/`hcc:` QuorumCert+LedgerInfo blobs | **~62%** |
| `block_storage/block_store.rs` | `"insert qc {}"` — full QuorumCert Display per block | ~4% |
| `pipeline/buffer_manager.rs` | `"Receive commit vote …"` | ~7% |
| `pipeline/buffer_manager.rs` | `"Advance execution root …"` / `"Advance signing root …"` | ~2.5% |
| `round_manager.rs` | `"Local state {} … remote state {}"` (SyncInfo dump) | per-sync |
| `block_storage/sync_manager.rs` | `"Fetching {} blocks, retry …"` | per-retry |
| `epoch_manager.rs` | `"advancing block sync from peer …"` | catch-up |
| `liveness/round_state.rs` | `"Processing certificates With SyncInfo"` | per round |
| `quorum_store/proof_manager.rs` | `"QS: got clean request …"` | per QS req |

## Deliberately kept at `info`

Operational signals stay at INFO: **NewRound**, **block commits**, **epoch changes**, and all `warn!`/`error!` (stale proposals, long waits, etc.).

## Scope / safety

- 10 lines, 7 files, all `info!` → `debug!`. No logic / control-flow / signature changes.
- Follow-up (separate PR): reth-side per-block execution logs (`reth.log`, ~21 lines/block) live in `gravity-reth` + `crates/block-buffer-manager`.