### PR TITLE
docs(cluster): note stale-output + contracts-ref pitfalls in genesis flow

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -41,9 +41,14 @@ make genesis
 ```
 *This generates `genesis.json` and `waypoint.txt` in `./output`.*
 
-> ⚠️ **Important**: The `genesis.sh` script will clone `gravity_chain_core_contracts` to `external/` if it doesn't exist, but will **NOT** automatically update it. To update:
+> ⚠️ **Important**: The `genesis.sh` script will clone `gravity_chain_core_contracts` to `external/` if it doesn't exist, but will **NOT** automatically update it. Keep the contracts checkout in sync with the SDK (a stale `ref` in `genesis.toml` can make `genesis-tool` reject the generated config, e.g. `missing field minimumProposalStake`). To update:
 > ```bash
 > cd external/gravity_chain_core_contracts && git pull origin main
+> ```
+
+> ⚠️ **Always regenerate from scratch**: do not reuse a leftover `./output/` from a previous (or partial) run — an incomplete genesis makes every node fail to bootstrap (`The genesis transaction was not found`, stuck at block 0). For a fresh chain:
+> ```bash
+> make clean && make init && make genesis
 > ```
 
 ### 5. Deploy and Start


### PR DESCRIPTION
Two gotchas hit when standing up a fresh local devnet from `cluster/`, both surfacing the same way — every node fails to bootstrap and sits at block 0 with `The genesis transaction was not found` / `chain ID (None)`. Documents both in `cluster/README.md` so the next operator doesn't have to reverse-engineer them.

### 1. Reusing a stale `./output/`
If `./output/` holds artifacts from a previous (or partial) run, `make deploy_start` alone happily distributes an **incomplete** genesis (no consensus genesis transaction), and nodes can't bootstrap. The fix is to always regenerate from scratch:
```bash
make clean && make init && make genesis
```

### 2. `gravity_chain_core_contracts` out of sync with the SDK
The existing note already says the contracts repo isn't auto-updated. Added that a stale `ref` in `genesis.toml` (vs the SDK's `genesis-tool`) makes generation fail with e.g. `missing field minimumProposalStake` — so keep the contracts checkout in sync.

Both notes go in the `make genesis` section next to the existing contracts-update warning. Docs only.