### PR TITLE
chore(consensus): downgrade per-vote/per-block commit-pipeline logs to debug

### DIFF
--- a/aptos-core/consensus/src/pipeline/buffer_item.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_item.rs
@@ -324,7 +324,7 @@ impl BufferItem {
                             callback,
                         }))
                     } else {
-                        warn!(
+                        debug!(
                             commit_info = ?commit_ledger_info.commit_info(),
                             block_hash = ?commit_ledger_info.block_hash(),
                             block_number = commit_ledger_info.block_number(),
@@ -461,7 +461,7 @@ impl BufferItem {
                         callback: signed_item.callback,
                     }))
                 } else {
-                    warn!(
+                    debug!(
                         commit_info = ?signed_item.partial_commit_proof.commit_info(),
                         block_hash = ?signed_item.partial_commit_proof.ledger_info().block_hash(),
                         block_number = signed_item.partial_commit_proof.ledger_info().block_number(),
@@ -488,7 +488,7 @@ impl BufferItem {
                         callback: executed_item.callback,
                     }))
                 } else {
-                    warn!(
+                    debug!(
                         commit_info = ?executed_item.partial_commit_proof.commit_info(),
                         block_hash = ?executed_item.partial_commit_proof.ledger_info().block_hash(),
                         block_number = executed_item.partial_commit_proof.ledger_info().block_number(),

--- a/aptos-core/consensus/src/pipeline/buffer_manager.rs
+++ b/aptos-core/consensus/src/pipeline/buffer_manager.rs
@@ -512,7 +512,7 @@ impl BufferManager {
             // Schedule retry.
             self.execution_root
         } else {
-            info!("Advance execution root from {:?} to {:?}", cursor, self.execution_root);
+            debug!("Advance execution root from {:?} to {:?}", cursor, self.execution_root);
             // Otherwise do nothing, because the execution wait phase is driven by the response of
             // the execution schedule phase, which is in turn fed as soon as the ordered blocks
             // come in.
@@ -528,7 +528,7 @@ impl BufferManager {
             self.buffer.find_elem_from(cursor.or_else(|| *self.buffer.head_cursor()), |item| {
                 item.is_executed()
             });
-        info!("Advance signing root from {:?} to {:?}", cursor, self.signing_root);
+        debug!("Advance signing root from {:?} to {:?}", cursor, self.signing_root);
         if self.signing_root.is_some() {
             let item = self.buffer.get(&self.signing_root);
             let executed_item = item.unwrap_executed_ref();
@@ -596,7 +596,7 @@ impl BufferManager {
                     }))
                     .await
                     .expect("Failed to send persist request");
-                info!("Advance head to {:?}", self.buffer.head_cursor());
+                debug!("Advance head to {:?}", self.buffer.head_cursor());
                 self.previous_commit_time = Instant::now();
                 return;
             }
@@ -767,7 +767,7 @@ impl BufferManager {
                 return;
             }
         };
-        info!("Receive executed response {}", executed_blocks.last().unwrap().block_info());
+        debug!("Receive executed response {}", executed_blocks.last().unwrap().block_info());
         let current_item = self.buffer.get(&current_cursor);
 
         if current_item.block_id() != block_id {
@@ -833,7 +833,7 @@ impl BufferManager {
                 return;
             }
         };
-        info!("Receive signing response {}", commit_ledger_info.commit_info());
+        debug!("Receive signing response {}", commit_ledger_info.commit_info());
         // find the corresponding item, may not exist if a reset or aggregated happened
         let current_cursor =
             self.buffer.find_elem_by_key(self.signing_root, commit_ledger_info.commit_info().id());
@@ -885,7 +885,7 @@ impl BufferManager {
                 // find the corresponding item
                 let author = vote.author();
                 let commit_info = vote.commit_info().clone();
-                info!("Receive commit vote {} from {}", commit_info, author);
+                debug!("Receive commit vote {} from {}", commit_info, author);
                 let target_block_id = vote.commit_info().id();
                 let current_cursor =
                     self.buffer.find_elem_by_key(*self.buffer.head_cursor(), target_block_id);
@@ -1009,7 +1009,7 @@ impl BufferManager {
             cursor = self.buffer.get_next(&cursor);
         }
         if count > 0 {
-            info!("Start reliable broadcast {} commit votes", count);
+            debug!("Start reliable broadcast {} commit votes", count);
         }
     }
 


### PR DESCRIPTION
The commit-vote pipeline (`buffer_manager` / `buffer_item`) logs at `info!`/`warn!` for **every commit vote** and **every per-block pipeline step**. Measured on **mainnet core-1**, these dominate the consensus log volume:

| line | level | rate |
|---|---|---|
| `Receive commit vote ... from ...` | `info!` | **~112k / hour** (per vote) |
| `... does not have enough commit voting power` (×3) | `warn!` | **~80k / hour** (per vote) |

That's **~190k lines/hour (~17%** of the node's ~1.1M lines/hour) of pure happy-path noise. A `TooLittleVotingPower` `warn!` is just the **expected pre-quorum state** — the `is_ok()` branch that actually reaches quorum already logs at `debug!` — and the per-vote / per-block cursor advances are internal mechanics, not operator events. At `INFO` they bury real warnings and inflate log cost.

### Change (pure log-level, no behavior change)
- **`buffer_item.rs`**: `warn!` → `debug!` ×3 — `Commit vote signatures do not have enough voting power after execution`, `Signed buffer item does not have enough commit voting power`, `Executed buffer item does not have enough commit voting power`.
- **`buffer_manager.rs`**: `info!` → `debug!` ×7 — `Advance execution root`, `Advance signing root`, `Advance head`, `Receive executed response`, `Receive signing response`, `Receive commit vote`, `Start reliable broadcast … commit votes`.

### Kept at `info!` (low-volume, meaningful)
`Receive reset` (epoch reset) and `Receive commit decision` (commit certificate). Actual block commits remain logged at the state-computer level.