### PR TITLE
chore(build): avoid downloading grevm test data during compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 
 [[package]]
 name = "gravity-sdk"
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8668,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -8709,7 +8709,7 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=25b71edcac1b94be7fc5ee0e4f20e5fcce6908ad#25b71edcac1b94be7fc5ee0e4f20e5fcce6908ad"
+source = "git+https://github.com/Galxe/grevm?rev=ee9d4e2e4c17b22a44974ee321b6386aed4b3e71#ee9d4e2e4c17b22a44974ee321b6386aed4b3e71"
 dependencies = [
  "ahash 0.8.12",
  "alloy-evm",
@@ -14539,7 +14539,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 2.0.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14613,7 +14613,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14642,7 +14642,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14662,7 +14662,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -14675,7 +14675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -14769,7 +14769,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14818,7 +14818,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -14834,7 +14834,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -14848,7 +14848,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14861,7 +14861,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14886,7 +14886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -14910,7 +14910,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14967,7 +14967,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15006,7 +15006,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15030,7 +15030,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -15054,7 +15054,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15085,7 +15085,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -15113,7 +15113,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15136,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15161,7 +15161,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15216,7 +15216,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15246,7 +15246,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15262,7 +15262,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15278,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -15311,7 +15311,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -15339,7 +15339,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -15361,7 +15361,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15384,7 +15384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15400,7 +15400,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15416,7 +15416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -15429,7 +15429,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15459,7 +15459,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15473,7 +15473,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -15483,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -15509,7 +15509,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15534,7 +15534,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -15552,7 +15552,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -15565,7 +15565,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15584,7 +15584,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15622,7 +15622,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15636,7 +15636,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "serde",
  "serde_json",
@@ -15646,7 +15646,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15674,7 +15674,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "bytes",
  "futures",
@@ -15694,7 +15694,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -15711,7 +15711,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "bindgen",
  "cc",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "futures",
  "metrics",
@@ -15733,7 +15733,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -15742,7 +15742,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -15756,7 +15756,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15813,7 +15813,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15838,7 +15838,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15860,7 +15860,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15875,7 +15875,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -15889,7 +15889,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "anyhow",
  "bincode",
@@ -15906,7 +15906,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -15930,7 +15930,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15999,7 +15999,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16055,7 +16055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16102,7 +16102,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16126,7 +16126,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16150,7 +16150,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "bytes",
  "eyre",
@@ -16174,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -16186,7 +16186,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16210,7 +16210,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -16222,7 +16222,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16245,7 +16245,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
@@ -16255,7 +16255,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -16268,7 +16268,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16315,7 +16315,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -16339,7 +16339,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "once_cell",
@@ -16352,7 +16352,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.4.1"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16382,7 +16382,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16425,7 +16425,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16453,7 +16453,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16468,7 +16468,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16487,7 +16487,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16514,7 +16514,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16529,7 +16529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16606,7 +16606,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -16636,7 +16636,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-provider 2.0.5",
@@ -16679,7 +16679,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -16700,7 +16700,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16731,7 +16731,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16777,7 +16777,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -16827,7 +16827,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -16841,7 +16841,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16872,7 +16872,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16916,7 +16916,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16944,7 +16944,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16957,7 +16957,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -16991,7 +16991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17021,7 +17021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -17039,7 +17039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -17060,7 +17060,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -17070,7 +17070,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -17088,7 +17088,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "base64 0.22.1",
  "clap 4.5.57",
@@ -17106,7 +17106,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17152,7 +17152,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17177,7 +17177,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -17203,7 +17203,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17222,7 +17222,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-eip7928 0.4.5",
  "alloy-evm",
@@ -17251,7 +17251,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17272,7 +17272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=9952514731d630a29bf341df56acb710ea9a19dd#9952514731d630a29bf341df56acb710ea9a19dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=556a5fd4f8d7fa246cb53929a8585bbaf9dc6323#556a5fd4f8d7fa246cb53929a8585bbaf9dc6323"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "9952514731d630a29bf341df56acb710ea9a19dd" }
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "556a5fd4f8d7fa246cb53929a8585bbaf9dc6323" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = "0.3.30"
 clap = { version = "4.5.17", features = ["derive", "env"] }
 futures = "0.3.30"
 dirs = "5.0.1"
-tokio = { version = "=1.52.3", features = ["taskdump"] }
+tokio = { version = "=1.52.3" }
 tokio-stream = "0.1.16"
 eyre = "0.6.12"
 tracing = "0.1.40"
@@ -34,7 +34,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "9952514731d630a29bf341df56acb710ea9a19dd" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "556a5fd4f8d7fa246cb53929a8585bbaf9dc6323" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.6.0", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "=2.0.5", default-features = false }
@@ -77,3 +77,6 @@ bcs.workspace = true
 
 [build-dependencies]
 shadow-rs.workspace = true
+
+[target.'cfg(all(target_os = "linux", any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
+tokio = { version = "=1.52.3", features = ["taskdump"] }


### PR DESCRIPTION
## Summary

Speeds up PFN/VFN **fast-sync (catch-up) block application** by removing the lockstep between
consensus and execution in the recovery path, and parallelizing block-retrieval verification on the
fetch path. The new look-ahead behavior is **opt-in via a config field** and defaults to the original
strictly-serial behavior, so existing nodes are unchanged unless tuned.

On the internal test box (8 cores, gap = 8192, from block 0, 10K→150K window) sustained catch-up
throughput improved from **~496 blk/s (serial) to ~630 blk/s at lookahead=4** (the knee), up to
~663 blk/s at lookahead=64, with **0 state-root mismatches** across the sweep.

## Motivation

During fast-forward sync the recovery apply path fed execution **strictly one block at a time**:

```
set_ordered_blocks → await get_executed_res → state-root check → set_commit_blocks → await persist
```

Consensus and execution never overlapped (`reth_blockchain_tree_in_mem_state_num_blocks ≈ 0`, the
executor sat idle waiting for the next feed). This capped catch-up throughput well below execution
capacity, while the live validator path was already pipelined.

## What's in this PR

1. **Bounded look-ahead pipeline for the recovery apply path** (`block_storage/block_store.rs`).
   The recovery branch now feeds up to `K` blocks to execution before draining results, so
   consensus→execution runs continuously instead of lockstep-per-block. **`set_commit_blocks`,
   per-block persist ack, and the per-block state-root comparison are preserved**; only the feed is
   pipelined. `recover_blocks` commits up to the highest committable QC in a single
   `send_for_execution` call so the pipeline can look ahead across the whole path.
   `send_for_execution` was also refactored from one ~240-line function into a thin dispatcher plus
   focused helpers (`commit_recovery_path` / `pipeline_recovery_blocks` / `drain_recovery_block` /
   `commit_live_path`).

2. **Parallelize block-retrieval signature verification**
   (`consensus-types/src/block_retrieval.rs`). `BlockRetrievalResponse::verify` split the cheap
   sequential chain-linkage check from the per-block BLS aggregate verify (~1.8 ms/block) and runs
   the latter with `rayon`. A single fast-sync response can carry up to 1000 blocks, so the serial
   verify was the dominant per-chunk cost on the requester.

3. **Pipeline fast-sync chunk verify off the fetch loop** (`block_storage/sync_manager.rs`,
   `network.rs`). `request_block` gains a `verify: bool` flag; `retrieve_block_for_id` fetches each
   chunk unverified and verifies it on a blocking thread via a bounded (depth-4) pipeline, so chunk
   N's verify overlaps chunk N+1's fetch. **Every chunk is still verified before its blocks are
   returned/used**; a failed verify bails before use. The zero-start-id (epoch-anchored first chunk)
   guard is unchanged.

4. **New config knob** `consensus.fast_sync_execute_lookahead` (see Configuration). Replaces the
   prior `FAST_SYNC_EXECUTE_LOOKAHEAD` environment variable. Threaded from `ConsensusConfig` through
   `epoch_manager` into `BlockStore`.

5. **Dependency bumps**
   - `gaptos` `e9544c8 → b9e5c60` — adds the `fast_sync_execute_lookahead` field to `ConsensusConfig`
     (gravity-aptos change; config-crate-only, `api-types` unchanged).
   - `greth` (gravity-reth) `1aec7b75 → 6ea2ba32`.

## Configuration

The look-ahead depth is a node-local consensus setting, a sibling of `max_blocks_per_receiving_request`.
Set it in the node's config YAML (e.g. `public_full_node.yaml`) under `consensus:`:

```yaml
consensus:
  # Bounded look-ahead depth for the fast-sync (recovery) execute pipeline.
  fast_sync_execute_lookahead: 4
```

- **Type / default:** `usize`, default **`1`**. The field is `#[serde(default)]`, so omitting it keeps
  the default — existing configs need no change.
- **`1`** = original strictly-serial recovery (byte-for-byte the previous behavior).
- **`4`–`8`** recommended for PFN/VFN catch-up nodes (`4` is the throughput knee; higher adds
  diminishing returns and more in-memory pipeline depth / memory use — avoid very large values on
  memory-constrained hosts).
- **Scope:** affects the **recovery / fast-sync path only**; the live validator path is untouched.
- No environment variable is involved anymore.

> Requires the gaptos bump in this PR (`b9e5c60`) which defines the field. On memory-constrained
> catch-up nodes also set the reth persist gap (`--gravity.cache.max-persist-gap`) appropriately;
> that is the dominant single lever for catch-up throughput and is configured separately on the reth
> side.

## Correctness

The look-ahead pipelines the **feed**, not the **commit**. Safety is preserved because:

- **Ordering:** blocks are fed in path order (parent before child) and drained FIFO, so commits and
  persists happen strictly in block order.
- **Per-block state-root gate:** every drained block compares its computed state root against the
  expected hash from the ledger DB (`drain_recovery_block`). Any execution divergence surfaces here
  as a graceful error (`ensure!`) instead of silently committing a bad root.
- **Execution dependency:** block N+1 executes on block N's in-memory post-state (the executor's
  in-memory state chain) — the same mechanism the live validator path already relies on; feeding
  ahead does not change execution inputs.
- **`lookahead = 1` is the original behavior** (feed→drain→feed→drain), and the recovery-vs-live
  dispatch keeps the live path identical.
- **`recover_blocks` highest-QC jump is end-state equivalent:** `commit_callback` prunes up to the
  last block and raises `highest_commit_cert` monotonically, and all committable QCs are in the same
  epoch as the latest ledger info, so one call reaches the same end state as the old per-QC sequence.

## Benchmarks

K-sweep, from block 0, 10K→150K window, `max-persist-gap=8192`, internal test box (8 cores):

| `fast_sync_execute_lookahead` | block tps | `in_mem` depth | state-root mismatches |
|---:|---:|---:|---:|
| 1 (serial) | ~496 | ~53 | 0 |
| 4 (knee)   | ~630 | ~147 | 0 |
| 16         | ~645 | ~153 | 0 |
| 64         | ~663 | ~160 | 0 |

Beyond the knee, throughput is bounded by per-block execution (merklize / state-root), not the
consensus→execution handoff. Validated at small state (0–~200K); high-state validation is follow-up.

## Testing

- Existing consensus unit/fuzz tests updated for the new `BlockStore` constructor argument
  (`round_manager_test`, `round_manager_fuzzing`, `test_utils`), all passing `1` (serial).
- Manual catch-up runs on the internal test box (local seed → catch-up node), measuring
  `reth_blockchain_tree_canonical_chain_height` over time at `lookahead` = 1/4/16/64.

## Notes / follow-ups

- A state-root mismatch during recovery is currently a graceful, non-fatal error (logged with
  expected vs computed). A mismatch is a deterministic corruption signal that a restart will
  re-hit at the same block; consider making it fatal so the node fails fast rather than continuing
  with in-flight, uncommitted blocks left in the buffer. (In-flight uncommitted blocks are
  in-memory only and are safely discarded on restart.)
- High-state (multi-million block) validation of the look-ahead is still pending.
