### PR TITLE
chore(genesis): enable Prague on mainnet

### DIFF
--- a/genesis/mainnet/genesis.json
+++ b/genesis/mainnet/genesis.json
@@ -26,6 +26,7 @@
     "mergeNetsplitBlock": 0,
     "shanghaiTime": 0,
     "cancunTime": 0,
+    "pragueTime": 1782709200,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "extraFields": {},


### PR DESCRIPTION
## Summary
- add the Prague hardfork activation time to the mainnet genesis config

## Test
- git diff --check -- genesis/mainnet/genesis.json