### PR TITLE
feat(metrics): expose gravity node binary info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8029,6 +8029,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.9.9",
  "shadow-rs",
  "tempfile",
  "tikv-jemalloc-ctl",

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -29,6 +29,7 @@ jsonrpsee = "0.24"
 hex = "0.4.3"
 serde_json = "1.0.128"
 serde = "^1.0.226"
+sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"

--- a/bin/gravity_node/src/main.rs
+++ b/bin/gravity_node/src/main.rs
@@ -44,6 +44,7 @@ mod chainspec;
 mod cli;
 mod consensus;
 mod mempool;
+mod node_metrics;
 pub mod relayer;
 mod reth_cli;
 mod reth_coordinator;
@@ -295,6 +296,7 @@ fn main() {
     }
 
     // Full node path: requires config, consensus, relayer, etc.
+    node_metrics::register_binary_info_metrics();
     let relayer_config_path = cli.gravity_node_config.relayer_config_path.clone();
     let gcei_config = check_bootstrap_config(cli.gravity_node_config.node_config_path.clone());
 

--- a/bin/gravity_node/src/node_metrics.rs
+++ b/bin/gravity_node/src/node_metrics.rs
@@ -1,0 +1,76 @@
+use build_info::{
+    build_information, BUILD_BRANCH, BUILD_CLEAN_CHECKOUT, BUILD_COMMIT_HASH, BUILD_OS,
+    BUILD_PKG_VERSION, BUILD_PROFILE_NAME, BUILD_RUST_VERSION, BUILD_TAG, BUILD_TIME,
+};
+use gaptos::aptos_metrics_core::{register_int_gauge_vec, IntGaugeVec};
+use once_cell::sync::Lazy;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{self, Read},
+};
+use tracing::warn;
+
+static GRAVITY_NODE_BUILD_INFO: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "gravity_node_build_info",
+        "Static gravity_node build and binary information",
+        &[
+            "package_version",
+            "commit_hash",
+            "branch",
+            "tag",
+            "build_time",
+            "build_os",
+            "rust_version",
+            "profile",
+            "clean_checkout",
+            "binary_sha256",
+        ],
+    )
+    .unwrap()
+});
+
+pub(crate) fn register_binary_info_metrics() {
+    let build_info = build_information!();
+    let binary_sha256 = current_binary_sha256().unwrap_or_else(|err| {
+        warn!("Failed to compute gravity_node binary sha256: {err}");
+        "unknown".to_string()
+    });
+
+    GRAVITY_NODE_BUILD_INFO
+        .with_label_values(&[
+            build_info_value(&build_info, BUILD_PKG_VERSION),
+            build_info_value(&build_info, BUILD_COMMIT_HASH),
+            build_info_value(&build_info, BUILD_BRANCH),
+            build_info_value(&build_info, BUILD_TAG),
+            build_info_value(&build_info, BUILD_TIME),
+            build_info_value(&build_info, BUILD_OS),
+            build_info_value(&build_info, BUILD_RUST_VERSION),
+            build_info_value(&build_info, BUILD_PROFILE_NAME),
+            build_info_value(&build_info, BUILD_CLEAN_CHECKOUT),
+            binary_sha256.as_str(),
+        ])
+        .set(1);
+}
+
+fn build_info_value<'a>(build_info: &'a BTreeMap<String, String>, key: &str) -> &'a str {
+    build_info.get(key).map(String::as_str).unwrap_or("unknown")
+}
+
+fn current_binary_sha256() -> io::Result<String> {
+    let mut file = File::open(std::env::current_exe()?)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    Ok(hex::encode(hasher.finalize()))
+}


### PR DESCRIPTION
## Summary
- add a gravity_node_build_info info gauge for gravity_node binary identity
- include package/build metadata from build-info plus the running binary sha256
- register the metric only on the full node startup path

## Validation
- RUSTFLAGS="--cfg tokio_unstable" cargo build --bin gravity_node --profile quick-release
- single_node e2e: 18 passed, 1 warning
- verified locally via inspection metrics endpoint: curl http://127.0.0.1:10002/metrics | rg gravity_node_build_info
- verified binary_sha256 label matches /tmp/gravity-cluster-single/node1/bin/gravity_node and target/quick-release/gravity_node