### PR TITLE
chore(deps): bump gravity-reth dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,8 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.21.3"
-source = "git+https://github.com/Galxe/alloy-evm?branch=v0.21.3-gravity#b1e00249990b054c90681931f03db9edccda7e89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1bfade4de9f464719b5aca30cf5bb02b9fda7036f0cf43addc3a0e66a0340c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4607,7 +4608,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -7900,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "reth-evm",
@@ -7911,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 
 [[package]]
 name = "gravity-sdk"
@@ -7925,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8047,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -8088,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=a368f423a967678f556c8b07cbf0c6e6d1a31335#a368f423a967678f556c8b07cbf0c6e6d1a31335"
+source = "git+https://github.com/Galxe/grevm?rev=2a42859a56f03197fce5be4ceb475d9f1a7d7c3d#2a42859a56f03197fce5be4ceb475d9f1a7d7c3d"
 dependencies = [
  "ahash 0.8.12",
  "alloy-evm",
@@ -11540,7 +11541,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -11653,8 +11654,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "10.1.0"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+version = "10.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826f43a5b1613c224f561847c152bfbaefcb593a9ae2c612ff4dc4661c6e625f"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12765,7 +12767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13500,7 +13502,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13546,7 +13548,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13570,7 +13572,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13599,7 +13601,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13619,7 +13621,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13633,7 +13635,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13710,7 +13712,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13720,7 +13722,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13738,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13756,7 +13758,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13767,7 +13769,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13782,7 +13784,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13795,7 +13797,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13807,7 +13809,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13833,7 +13835,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13854,7 +13856,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13879,7 +13881,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13910,7 +13912,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13924,7 +13926,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13950,7 +13952,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13974,7 +13976,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13998,7 +14000,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14028,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14059,7 +14061,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14081,7 +14083,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14106,7 +14108,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "futures",
  "pin-project",
@@ -14129,7 +14131,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14181,7 +14183,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14209,7 +14211,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14225,7 +14227,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14240,7 +14242,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14262,7 +14264,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14273,7 +14275,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14301,7 +14303,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14322,7 +14324,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14344,7 +14346,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14360,7 +14362,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14378,7 +14380,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14391,7 +14393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14420,7 +14422,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14439,7 +14441,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14449,7 +14451,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14472,7 +14474,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14494,7 +14496,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14507,7 +14509,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14525,7 +14527,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14563,7 +14565,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14577,7 +14579,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "serde",
  "serde_json",
@@ -14587,7 +14589,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14614,7 +14616,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "bytes",
  "futures",
@@ -14634,7 +14636,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "futures",
  "metrics",
@@ -14646,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14654,7 +14656,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14668,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14723,7 +14725,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14748,7 +14750,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14770,7 +14772,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14785,7 +14787,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14799,7 +14801,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14816,7 +14818,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14840,7 +14842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14909,7 +14911,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14962,7 +14964,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -15000,7 +15002,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15024,7 +15026,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15048,7 +15050,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15069,7 +15071,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15081,7 +15083,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15102,7 +15104,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15114,7 +15116,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15134,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15144,7 +15146,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15157,7 +15159,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15205,7 +15207,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15229,7 +15231,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15242,7 +15244,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15272,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15315,7 +15317,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15343,7 +15345,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15356,7 +15358,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15375,7 +15377,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15402,7 +15404,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15415,7 +15417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15495,7 +15497,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15523,7 +15525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15562,7 +15564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15583,7 +15585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15613,7 +15615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15657,7 +15659,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15704,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15718,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15734,7 +15736,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15778,7 +15780,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15805,7 +15807,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15818,7 +15820,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15838,7 +15840,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15850,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15880,7 +15882,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15896,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15914,7 +15916,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15924,7 +15926,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15939,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15981,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16005,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16032,7 +16034,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16051,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16076,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16095,7 +16097,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16113,7 +16115,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3174e8d93d045fd0ec03a844993d20212dbb86a7#3174e8d93d045fd0ec03a844993d20212dbb86a7"
+source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
 dependencies = [
  "zstd",
 ]
@@ -16132,7 +16134,8 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "29.0.1"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718d90dce5f07e115d0e66450b1b8aa29694c1cf3f89ebddaddccc2ccbd2f13e"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -16150,7 +16153,8 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "6.2.2"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
 dependencies = [
  "bitvec 1.0.1",
  "phf 0.11.3",
@@ -16161,7 +16165,8 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "9.1.0"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a20c98e7008591a6f012550c2a00aa36cba8c14cc88eb88dec32eb9102554b4"
 dependencies = [
  "bitvec 1.0.1",
  "cfg-if",
@@ -16177,7 +16182,8 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "10.2.0"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50d241ed1ce647b94caf174fcd0239b7651318b2c4c06b825b59b973dfb8495"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -16192,7 +16198,8 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "7.0.5"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -16205,7 +16212,8 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "7.0.5"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
 dependencies = [
  "auto_impl",
  "either",
@@ -16217,7 +16225,8 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "10.0.1"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550331ea85c1d257686e672081576172fe3d5a10526248b663bbf54f1bef226a"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -16235,7 +16244,8 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "10.0.1"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0a6e9ccc2ae006f5bed8bd80cd6f8d3832cd55c5e861b9402fdd556098512f"
 dependencies = [
  "auto_impl",
  "either",
@@ -16251,8 +16261,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.30.0"
-source = "git+https://github.com/Galxe/revm-inspectors?branch=v0.30.0-gravity#aa13a14da925d754efb4889ad2d54beba981aa9f"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de23199c4b6181a6539e4131cf7e31cde4df05e1192bcdce491c34a511241588"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -16271,7 +16282,8 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "25.0.3"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06575dc51b1d8f5091daa12a435733a90b4a132dca7ccee0666c7db3851bc30c"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -16282,7 +16294,8 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "27.0.0"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b57d4bd9e6b5fe469da5452a8a137bc2d030a3cd47c46908efc615bbc699da"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-bn254 0.5.0",
@@ -16307,7 +16320,8 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "20.2.1"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -16318,7 +16332,8 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "7.0.5"
-source = "git+https://github.com/Galxe/revm?branch=v29.0.1-gravity#bfa048c6339ccac692370ef9a779a13d64be399a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
  "bitflags 2.10.0",
  "revm-bytecode",

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "3174e8d93d045fd0ec03a844993d20212dbb86a7" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "e75679c08b65f913e2408ca154ff949de61eaac6" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }


### PR DESCRIPTION
## Summary
- bump gravity_node's greth dependency from 3174e8d93d045fd0ec03a844993d20212dbb86a7 to e75679c08b65f913e2408ca154ff949de61eaac6
- refresh Cargo.lock for the updated gravity-reth dependency graph

## Validation
- RUSTFLAGS="--cfg tokio_unstable" cargo check -p gravity_node --locked