### PR TITLE
chore(deps): bump epoch-start recovery deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7901,9 +7901,10 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
+ "blst",
  "reth-evm",
  "revm",
  "tracing",
@@ -7912,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 
 [[package]]
 name = "gravity-sdk"
@@ -7926,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8048,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -13502,7 +13503,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13548,7 +13549,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13572,7 +13573,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13601,7 +13602,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13621,7 +13622,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13635,7 +13636,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13712,7 +13713,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13722,7 +13723,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13740,7 +13741,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13758,7 +13759,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13769,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13784,7 +13785,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13797,7 +13798,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13809,7 +13810,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13835,7 +13836,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13856,7 +13857,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13881,7 +13882,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13912,7 +13913,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13926,7 +13927,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13952,7 +13953,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13976,7 +13977,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -14000,7 +14001,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14030,7 +14031,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14061,7 +14062,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14083,7 +14084,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14108,7 +14109,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "futures",
  "pin-project",
@@ -14131,7 +14132,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14183,7 +14184,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14211,7 +14212,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14227,7 +14228,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14242,7 +14243,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14264,7 +14265,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14275,7 +14276,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14303,7 +14304,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14324,7 +14325,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14346,7 +14347,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14362,7 +14363,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14380,7 +14381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14393,7 +14394,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14422,7 +14423,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14441,7 +14442,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14451,7 +14452,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14474,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14496,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14509,7 +14510,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14527,7 +14528,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14565,7 +14566,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14579,7 +14580,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "serde",
  "serde_json",
@@ -14589,7 +14590,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14616,7 +14617,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "bytes",
  "futures",
@@ -14636,7 +14637,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "futures",
  "metrics",
@@ -14648,7 +14649,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14656,7 +14657,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14670,7 +14671,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14725,7 +14726,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14750,7 +14751,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14772,7 +14773,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14787,7 +14788,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14801,7 +14802,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14818,7 +14819,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14842,7 +14843,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14911,7 +14912,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14964,7 +14965,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -15002,7 +15003,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15026,7 +15027,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15050,7 +15051,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15071,7 +15072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15083,7 +15084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15104,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15116,7 +15117,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15136,7 +15137,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15146,7 +15147,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15159,7 +15160,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15169,7 +15170,6 @@ dependencies = [
  "alloy-sol-types",
  "api-types",
  "bcs 0.1.6",
- "blst",
  "gravity-precompiles",
  "gravity-primitives",
  "gravity-storage",
@@ -15207,7 +15207,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15231,7 +15231,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15244,7 +15244,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15274,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15317,7 +15317,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15345,7 +15345,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15358,7 +15358,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15377,7 +15377,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15404,7 +15404,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15417,7 +15417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15497,7 +15497,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15525,7 +15525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15564,7 +15564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15585,7 +15585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15615,7 +15615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15659,7 +15659,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15706,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15736,7 +15736,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15780,7 +15780,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15807,7 +15807,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15820,7 +15820,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15840,7 +15840,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15852,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15882,7 +15882,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15898,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15916,7 +15916,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15926,7 +15926,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15983,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16007,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16034,7 +16034,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16053,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16097,7 +16097,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16115,7 +16115,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
+source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1074,7 +1074,7 @@ dependencies = [
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1096,7 +1096,7 @@ dependencies = [
 [[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-types",
  "bcs 0.1.4",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1143,7 +1143,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-global-constants",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-sdk",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "hex",
@@ -1212,7 +1212,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "proptest",
  "serde",
@@ -1222,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "futures",
  "rustversion",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "shadow-rs",
 ]
@@ -1301,7 +1301,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1315,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1326,12 +1326,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1436,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1445,25 +1445,25 @@ dependencies = [
  "aptos-collections",
  "aptos-config",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-schemadb",
  "aptos-secure-storage",
  "aptos-short-hex-str",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -1552,13 +1552,13 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-short-hex-str",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1721,7 +1721,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-jellyfish-merkle",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1781,7 +1781,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1830,13 +1830,13 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-enum-conversion-derive",
@@ -1847,7 +1847,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "api-types",
@@ -1919,15 +1919,15 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-executor-service",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-experimental-runtimes",
  "aptos-indexer-grpc-table-info",
  "aptos-infallible",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-block-executor",
  "aptos-block-partitioner",
@@ -1981,16 +1981,16 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-db",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-layered-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "ahash 0.8.12",
  "aptos-crypto",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2075,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "either",
  "move-core-types",
@@ -2155,7 +2155,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2170,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -2203,17 +2203,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2222,7 +2222,7 @@ dependencies = [
  "aptos-config",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-metrics-core",
  "aptos-moving-average",
  "aptos-protos",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2259,7 +2259,7 @@ dependencies = [
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-storage-interface",
@@ -2281,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
@@ -2317,12 +2317,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -2348,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2376,7 +2376,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "api-types",
@@ -2384,7 +2384,7 @@ dependencies = [
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
@@ -2395,7 +2395,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2498,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -2575,13 +2575,13 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-event-notifications",
  "aptos-infallible",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2649,7 +2649,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2801,7 +2801,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2853,7 +2853,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "pbjson",
  "prost",
@@ -2911,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "ipnet",
 ]
@@ -2919,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2931,11 +2931,11 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-enum-conversion-derive",
  "aptos-infallible",
  "aptos-logger",
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2968,7 +2968,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "rayon",
  "tokio",
@@ -3028,10 +3028,10 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-infallible",
@@ -3052,7 +3052,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-drop-helper",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -3172,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -3183,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3194,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3203,7 +3203,7 @@ dependencies = [
  "aptos-data-client",
  "aptos-data-streaming-service",
  "aptos-event-notifications",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-mempool-notifications",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -3312,17 +3312,17 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crypto",
  "aptos-db",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-node-resource-metrics",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3400,7 +3400,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-filter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-protos",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "api-types",
@@ -3495,12 +3495,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-environment"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-framework",
  "aptos-gas-algebra",
@@ -3604,7 +3604,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -7452,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "gaptos"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "api-types",
  "aptos-bitvec",
@@ -7463,9 +7463,9 @@ dependencies = [
  "aptos-collections",
  "aptos-compression",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-crash-handler",
  "aptos-crypto",
  "aptos-crypto-derive",
@@ -7473,9 +7473,9 @@ dependencies = [
  "aptos-dkg-runtime",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-executor-test-helpers",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-global-constants",
@@ -7486,7 +7486,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-log-derive",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-mempool-notifications",
  "aptos-memsocket",
  "aptos-metrics-core",
@@ -7502,7 +7502,7 @@ dependencies = [
  "aptos-reliable-broadcast",
  "aptos-rest-client",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
  "aptos-schemadb",
  "aptos-secure-net",
  "aptos-secure-storage",
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "reth-evm",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 
 [[package]]
 name = "gravity-sdk"
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -10393,7 +10393,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10410,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10425,12 +10425,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10445,7 +10445,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "once_cell",
  "quote",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -10467,7 +10467,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10496,7 +10496,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10526,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "difference",
@@ -10543,7 +10543,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10566,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10600,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10626,7 +10626,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10645,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10662,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10681,7 +10681,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -10693,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10709,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -10727,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "hex",
@@ -10740,7 +10740,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -10753,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "codespan",
@@ -10780,7 +10780,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10814,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "atty",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10870,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10886,7 +10886,7 @@ dependencies = [
 [[package]]
 name = "move-prover-lab"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10904,7 +10904,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "hex",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10939,7 +10939,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "hex",
@@ -10962,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "once_cell",
  "serde",
@@ -10971,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "better_any",
  "bytes",
@@ -10986,7 +10986,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "better_any",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11027,7 +11027,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "ambassador",
  "better_any",
@@ -11052,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11069,7 +11069,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=e9544c8cb3d8a5757d4c7f1b4807b312c03ba060#e9544c8cb3d8a5757d4c7f1b4807b312c03ba060"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
@@ -13502,7 +13502,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13548,7 +13548,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13572,7 +13572,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13601,7 +13601,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13621,7 +13621,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13635,7 +13635,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13712,7 +13712,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13722,7 +13722,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13740,7 +13740,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13758,7 +13758,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13769,7 +13769,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13784,7 +13784,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13797,7 +13797,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13809,7 +13809,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13835,7 +13835,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13856,7 +13856,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13881,7 +13881,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13912,7 +13912,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13926,7 +13926,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13952,7 +13952,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13976,7 +13976,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -14000,7 +14000,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14030,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14061,7 +14061,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14083,7 +14083,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14108,7 +14108,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "futures",
  "pin-project",
@@ -14131,7 +14131,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14183,7 +14183,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14211,7 +14211,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14227,7 +14227,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14242,7 +14242,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14264,7 +14264,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14275,7 +14275,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14303,7 +14303,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14324,7 +14324,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14346,7 +14346,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14362,7 +14362,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14380,7 +14380,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14393,7 +14393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14422,7 +14422,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14441,7 +14441,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14451,7 +14451,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14474,7 +14474,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14496,7 +14496,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14509,7 +14509,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14527,7 +14527,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14565,7 +14565,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14579,7 +14579,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "serde",
  "serde_json",
@@ -14589,7 +14589,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14616,7 +14616,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "bytes",
  "futures",
@@ -14636,7 +14636,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "futures",
  "metrics",
@@ -14648,7 +14648,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14656,7 +14656,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14670,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14725,7 +14725,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14750,7 +14750,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14772,7 +14772,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14787,7 +14787,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14801,7 +14801,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14818,7 +14818,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14842,7 +14842,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14911,7 +14911,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14964,7 +14964,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -15002,7 +15002,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15026,7 +15026,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15050,7 +15050,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15071,7 +15071,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15083,7 +15083,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15104,7 +15104,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15116,7 +15116,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15136,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15146,7 +15146,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15159,7 +15159,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15207,7 +15207,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15231,7 +15231,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15244,7 +15244,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15274,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15317,7 +15317,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15345,7 +15345,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15358,7 +15358,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15377,7 +15377,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15404,7 +15404,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15417,7 +15417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15497,7 +15497,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15525,7 +15525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15564,7 +15564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15585,7 +15585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15615,7 +15615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15659,7 +15659,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15706,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15736,7 +15736,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15780,7 +15780,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15807,7 +15807,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15820,7 +15820,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15840,7 +15840,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15852,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15882,7 +15882,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15898,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15916,7 +15916,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15926,7 +15926,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15983,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16007,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16034,7 +16034,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16053,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16097,7 +16097,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16115,7 +16115,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=e75679c08b65f913e2408ca154ff949de61eaac6#e75679c08b65f913e2408ca154ff949de61eaac6"
+source = "git+https://github.com/Galxe/gravity-reth?rev=cb79bd0dce6b89960e7edba053d0d3c29852d861#cb79bd0dce6b89960e7edba053d0d3c29852d861"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ["cfg(mirai)"] }
 aptos-consensus = { path = "./aptos-core/consensus" }
 
 #  from aptos =======================
-gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", rev = "e9544c8cb3d8a5757d4c7f1b4807b312c03ba060" }
+gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", rev = "b1f68dc85781ef0d28a568d9d64604b153be9d9e" }
 aptos-executor-types = { path = "dependencies/aptos-executor-types" }
 aptos-executor = { path = "dependencies/aptos-executor" }
 api = { path = "./crates/api" }

--- a/aptos-core/consensus/src/persistent_liveness_storage.rs
+++ b/aptos-core/consensus/src/persistent_liveness_storage.rs
@@ -26,7 +26,7 @@ use gaptos::{
     aptos_storage_interface::DbReader,
     aptos_types::{
         aggregate_signature::AggregateSignature,
-        block_info::{BlockInfo, Round},
+        block_info::{BlockInfo, Round, GENESIS_ROUND},
         epoch_change::EpochChangeProof,
         ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
         on_chain_config::ValidatorSet,
@@ -112,6 +112,18 @@ impl LedgerRecoveryData {
         self.storage_ledger.commit_info().round()
     }
 
+    fn is_epoch_start_timestamp_only_mismatch(ordered: &BlockInfo, executed: &BlockInfo) -> bool {
+        ordered.epoch() == executed.epoch()
+            && ordered.round() == GENESIS_ROUND
+            && executed.round() == GENESIS_ROUND
+            && ordered.id() == executed.id()
+            && ordered.executed_state_id() == executed.executed_state_id()
+            && ordered.version() == executed.version()
+            && ordered.next_epoch_state() == executed.next_epoch_state()
+            && ordered.epoch_block_info() == executed.epoch_block_info()
+            && ordered.timestamp_usecs() != executed.timestamp_usecs()
+    }
+
     /// Finds the root (last committed block) and returns the root block, the QC to the root block
     /// and the ledger info for the root block, return an error if it can not be found.
     ///
@@ -165,15 +177,39 @@ impl LedgerRecoveryData {
                 WrappedLedgerInfo::new(VoteData::dummy(), latest_ledger_info_sig.clone());
             (root_ordered_cert.clone(), root_ordered_cert)
         } else {
-            let root_ordered_cert = quorum_certs
+            let root_commit_qc = quorum_certs
                 .iter()
                 .find(|qc| qc.commit_info().id() == root_block.id())
                 .ok_or_else(|| format_err!("No LI found for root: {}", root_id))?
-                .clone()
-                .into_wrapped_ledger_info();
-            let root_commit_cert = root_ordered_cert
-                .create_merged_with_executed_state(latest_ledger_info_sig)
-                .expect("Inconsistent commit proof and evaluation decision, cannot commit block");
+                .clone();
+            let root_ordered_cert = root_commit_qc.clone().into_wrapped_ledger_info();
+            let root_commit_cert = match root_ordered_cert
+                .create_merged_with_executed_state(latest_ledger_info_sig.clone())
+            {
+                Ok(root_commit_cert) => root_commit_cert,
+                Err(error)
+                    if Self::is_epoch_start_timestamp_only_mismatch(
+                        root_ordered_cert.commit_info(),
+                        latest_ledger_info_sig.ledger_info().commit_info(),
+                    ) =>
+                {
+                    warn!(
+                        error = ?error,
+                        ordered_commit_info = ?root_ordered_cert.commit_info(),
+                        executed_commit_info = ?latest_ledger_info_sig.ledger_info().commit_info(),
+                        "Tolerating epoch-start root timestamp mismatch during recovery"
+                    );
+                    WrappedLedgerInfo::new(
+                        root_commit_qc.vote_data().clone(),
+                        latest_ledger_info_sig,
+                    )
+                }
+                Err(error) => {
+                    panic!(
+                        "Inconsistent commit proof and evaluation decision, cannot commit block: {error:?}"
+                    );
+                }
+            };
             (root_ordered_cert, root_commit_cert)
         };
         info!("Consensus root block is {}", root_block);

--- a/aptos-core/consensus/src/persistent_liveness_storage.rs
+++ b/aptos-core/consensus/src/persistent_liveness_storage.rs
@@ -113,15 +113,15 @@ impl LedgerRecoveryData {
     }
 
     fn is_epoch_start_timestamp_only_mismatch(ordered: &BlockInfo, executed: &BlockInfo) -> bool {
-        ordered.epoch() == executed.epoch()
-            && ordered.round() == GENESIS_ROUND
-            && executed.round() == GENESIS_ROUND
-            && ordered.id() == executed.id()
-            && ordered.executed_state_id() == executed.executed_state_id()
-            && ordered.version() == executed.version()
-            && ordered.next_epoch_state() == executed.next_epoch_state()
-            && ordered.epoch_block_info() == executed.epoch_block_info()
-            && ordered.timestamp_usecs() != executed.timestamp_usecs()
+        ordered.epoch() == executed.epoch() &&
+            ordered.round() == GENESIS_ROUND &&
+            executed.round() == GENESIS_ROUND &&
+            ordered.id() == executed.id() &&
+            ordered.executed_state_id() == executed.executed_state_id() &&
+            ordered.version() == executed.version() &&
+            ordered.next_epoch_state() == executed.next_epoch_state() &&
+            ordered.epoch_block_info() == executed.epoch_block_info() &&
+            ordered.timestamp_usecs() != executed.timestamp_usecs()
     }
 
     /// Finds the root (last committed block) and returns the root block, the QC to the root block

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "cb79bd0dce6b89960e7edba053d0d3c29852d861" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "a379a86daa2db6bb109083ac9106e5de35f818dd" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "e75679c08b65f913e2408ca154ff949de61eaac6" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "cb79bd0dce6b89960e7edba053d0d3c29852d861" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }


### PR DESCRIPTION
## Summary
- bump `gaptos` to Galxe/gravity-aptos@b1f68dc for the epoch-start `BlockInfo::match_ordered_only` recovery fix
- bump `greth` to Galxe/gravity-reth@cb79bd0, which includes the matching `gravity-api-types` update from gravity-reth#376
- refresh `Cargo.lock` for the dependency rev changes

## Tests
- `RUSTFLAGS="--cfg tokio_unstable" cargo check -p gravity_node --locked`
