### PR TITLE
fix(consensus): tighten recovery persistence semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -7913,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 
 [[package]]
 name = "gravity-sdk"
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -13503,7 +13503,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13549,7 +13549,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13573,7 +13573,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13602,7 +13602,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13622,7 +13622,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13636,7 +13636,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13713,7 +13713,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13723,7 +13723,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13741,7 +13741,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13759,7 +13759,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13770,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13785,7 +13785,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13798,7 +13798,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13810,7 +13810,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13836,7 +13836,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13857,7 +13857,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13882,7 +13882,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13913,7 +13913,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13927,7 +13927,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13953,7 +13953,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13977,7 +13977,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -14001,7 +14001,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14031,7 +14031,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14062,7 +14062,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14084,7 +14084,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14109,7 +14109,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "futures",
  "pin-project",
@@ -14132,7 +14132,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14184,7 +14184,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14212,7 +14212,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14228,7 +14228,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14243,7 +14243,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14265,7 +14265,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14276,7 +14276,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14304,7 +14304,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14325,7 +14325,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14347,7 +14347,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14363,7 +14363,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14381,7 +14381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14394,7 +14394,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14423,7 +14423,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14442,7 +14442,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14452,7 +14452,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14510,7 +14510,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14528,7 +14528,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14566,7 +14566,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14580,7 +14580,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "serde",
  "serde_json",
@@ -14590,7 +14590,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14617,7 +14617,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "bytes",
  "futures",
@@ -14637,7 +14637,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "futures",
  "metrics",
@@ -14649,7 +14649,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14657,7 +14657,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14671,7 +14671,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14726,7 +14726,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14751,7 +14751,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14773,7 +14773,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14788,7 +14788,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14802,7 +14802,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14819,7 +14819,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14843,7 +14843,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14912,7 +14912,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14965,7 +14965,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -15003,7 +15003,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15027,7 +15027,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15051,7 +15051,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15072,7 +15072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15084,7 +15084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15117,7 +15117,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15137,7 +15137,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15147,7 +15147,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15160,7 +15160,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15207,7 +15207,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15231,7 +15231,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15244,7 +15244,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15274,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15317,7 +15317,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15345,7 +15345,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15358,7 +15358,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15377,7 +15377,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15404,7 +15404,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15417,7 +15417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15497,7 +15497,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15525,7 +15525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15564,7 +15564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15585,7 +15585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15615,7 +15615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15659,7 +15659,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15706,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15736,7 +15736,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15780,7 +15780,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15807,7 +15807,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15820,7 +15820,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15840,7 +15840,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15852,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15882,7 +15882,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15898,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15916,7 +15916,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15926,7 +15926,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15983,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16007,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16034,7 +16034,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16053,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16097,7 +16097,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16115,7 +16115,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
 dependencies = [
  "zstd",
 ]

--- a/aptos-core/consensus/src/block_storage/block_store.rs
+++ b/aptos-core/consensus/src/block_storage/block_store.rs
@@ -133,6 +133,7 @@ pub struct BlockStore {
     is_validator: bool,
     pending_blocks: Arc<Mutex<PendingBlocks>>,
     enable_randomness: bool,
+    require_block_randomness: bool,
     /// Mapping from validator address to their index in the ordered validator set.
     /// Used during recovery to compute proposer_index for blocks.
     validator_indices: HashMap<AccountAddress, usize>,
@@ -151,6 +152,7 @@ impl BlockStore {
         is_validator: bool,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
         enable_randomness: bool,
+        require_block_randomness: bool,
         validator_indices: HashMap<AccountAddress, usize>,
     ) -> Self {
         let highest_2chain_tc = initial_data.highest_2chain_timeout_certificate();
@@ -171,6 +173,7 @@ impl BlockStore {
             is_validator,
             pending_blocks,
             enable_randomness,
+            require_block_randomness,
             validator_indices,
         ));
         block_on(block_store.recover_blocks());
@@ -189,6 +192,7 @@ impl BlockStore {
         is_validator: bool,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
         enable_randomness: bool,
+        require_block_randomness: bool,
         validator_indices: HashMap<AccountAddress, usize>,
     ) -> Self {
         let highest_2chain_tc = initial_data.highest_2chain_timeout_certificate();
@@ -209,6 +213,7 @@ impl BlockStore {
             is_validator,
             pending_blocks,
             enable_randomness,
+            require_block_randomness,
             validator_indices,
         )
         .await;
@@ -308,41 +313,6 @@ impl BlockStore {
         Ok(())
     }
 
-    /// Returns the WrappedLedgerInfo for fast_forward_sync.
-    /// If a block with randomness is found on the path from ordered_root back to commit_root,
-    /// returns the highest_ordered_cert. Otherwise, returns the highest_commit_cert (or genesis).
-    pub fn has_randomness_on_path_from_ordered_to_commit(&self) -> Arc<WrappedLedgerInfo> {
-        if !self.enable_randomness {
-            return self.highest_commit_cert();
-        }
-        let ordered_root = self.ordered_root();
-        let commit_root = self.commit_root();
-        let commit_round = commit_root.round();
-        let mut cursor = ordered_root.clone();
-
-        loop {
-            if cursor.round() <= commit_round {
-                break;
-            }
-
-            if cursor.randomness().is_some() {
-                // Found randomness, get the quorum cert for this block
-                let qc = self.get_quorum_cert_for_block(cursor.id()).unwrap();
-                return Arc::new(qc.into_wrapped_ledger_info());
-            }
-
-            match self.get_block(cursor.parent_id()) {
-                Some(parent) => {
-                    cursor = parent;
-                }
-                None => break,
-            }
-        }
-
-        // No randomness found on the path, return highest_commit_cert
-        self.highest_commit_cert()
-    }
-
     /// Check if there are blocks without randomness on the path from highest_ordered_cert to
     /// highest_commit_cert
     ///
@@ -352,7 +322,7 @@ impl BlockStore {
     /// - (false, Some(cert)): All blocks on path have randomness, use highest_commit_cert
     ///
     /// Fast return conditions:
-    /// - randomness is not enabled
+    /// - block randomness is not required
     /// - in epoch 1
     /// - ledger_info round is 0
     pub fn find_missing_randomness_block_on_path(
@@ -360,7 +330,7 @@ impl BlockStore {
         ledger_info: &LedgerInfoWithSignatures,
     ) -> (bool, Option<Arc<WrappedLedgerInfo>>) {
         // Fast return: these conditions mean no special handling is needed
-        if !self.enable_randomness ||
+        if !self.require_block_randomness ||
             self.ordered_root().epoch() == 1 ||
             ledger_info.commit_info().round() == 0
         {
@@ -442,6 +412,7 @@ impl BlockStore {
         is_validator: bool,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
         enable_randomness: bool,
+        require_block_randomness: bool,
         validator_indices: HashMap<AccountAddress, usize>,
     ) -> Self {
         let RootInfo(root_block, root_qc, root_ordered_cert, root_commit_cert) = root;
@@ -479,6 +450,7 @@ impl BlockStore {
             is_validator,
             pending_blocks,
             enable_randomness,
+            require_block_randomness,
             validator_indices,
         };
 
@@ -697,7 +669,7 @@ impl BlockStore {
                 );
 
                 // In recovery mode, use existing randomness from the block
-                let randomness = if self.enable_randomness && p_block.epoch() != 1 {
+                let randomness = if self.require_block_randomness && p_block.epoch() != 1 {
                     match p_block.randomness() {
                         Some(r) => Some(Random::from_bytes(r.randomness())),
                         None => {
@@ -924,6 +896,7 @@ impl BlockStore {
             self.is_validator,
             self.pending_blocks.clone(),
             self.enable_randomness,
+            self.require_block_randomness,
             self.validator_indices.clone(),
         )
         .await;

--- a/aptos-core/consensus/src/epoch_manager.rs
+++ b/aptos-core/consensus/src/epoch_manager.rs
@@ -799,6 +799,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         payload_manager: Arc<dyn TPayloadManager>,
         rand_config: Option<RandConfig>,
         fast_rand_config: Option<RandConfig>,
+        require_block_randomness: bool,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
     ) {
         let epoch = epoch_state.epoch;
@@ -882,6 +883,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 self.is_current_epoch_validator,
                 self.pending_blocks.clone(),
                 onchain_randomness_config.randomness_enabled(),
+                require_block_randomness,
                 validator_indices,
             )
             .await,
@@ -1126,6 +1128,24 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         Ok((rand_config, None))
     }
 
+    fn should_require_block_randomness(
+        consensus_config: &OnChainConsensusConfig,
+        randomness_config: &OnChainRandomnessConfig,
+        dkg_state: &anyhow::Result<DKGState>,
+        epoch: u64,
+    ) -> bool {
+        if !consensus_config.is_vtxn_enabled() || !randomness_config.randomness_enabled() {
+            return false;
+        }
+
+        dkg_state
+            .as_ref()
+            .ok()
+            .and_then(|state| state.last_completed.as_ref())
+            .and_then(|session| session.metadata.dealer_epoch.checked_add(1))
+            .is_some_and(|target_epoch| target_epoch == epoch)
+    }
+
     async fn start_new_epoch(&mut self, payload: OnChainConfigPayload<P>) {
         info!("start to start new epoch for epoch: {:?}", payload.epoch());
         let validator_set: ValidatorSet =
@@ -1217,6 +1237,13 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             }
         };
 
+        let require_block_randomness = Self::should_require_block_randomness(
+            &consensus_config,
+            &onchain_randomness_config,
+            &dkg_state,
+            epoch_state.epoch,
+        );
+
         let rand_configs = self.try_get_rand_config_for_new_epoch(
             loaded_consensus_key.clone(),
             &epoch_state,
@@ -1296,6 +1323,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 payload_manager,
                 rand_config,
                 fast_rand_config,
+                require_block_randomness,
                 rand_msg_rx,
             )
             .await
@@ -1349,6 +1377,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         payload_manager: Arc<dyn TPayloadManager>,
         rand_config: Option<RandConfig>,
         fast_rand_config: Option<RandConfig>,
+        require_block_randomness: bool,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
     ) {
         match self.storage.start(consensus_config.order_vote_enabled(), epoch_state.epoch).await {
@@ -1368,6 +1397,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                     payload_manager,
                     rand_config,
                     fast_rand_config,
+                    require_block_randomness,
                     rand_msg_rx,
                 )
                 .await

--- a/aptos-core/consensus/src/round_manager_fuzzing.rs
+++ b/aptos-core/consensus/src/round_manager_fuzzing.rs
@@ -99,9 +99,10 @@ fn build_empty_store(
         10,
         Arc::from(DirectMempoolPayloadManager::new()),
         false,
-        false, // enable_randomness
+        false,
         Arc::new(Mutex::new(PendingBlocks::new())),
-        false,          // check_ordered_only
+        false,
+        false,
         HashMap::new(), // validator_indices: empty for fuzzing
     ))
 }

--- a/aptos-core/consensus/src/round_manager_test.rs
+++ b/aptos-core/consensus/src/round_manager_test.rs
@@ -299,6 +299,7 @@ impl NodeSetup {
             true,
             Arc::new(Mutex::new(PendingBlocks::new())),
             false,
+            false,
             HashMap::new(), // validator_indices: empty for tests
         ));
 

--- a/aptos-core/consensus/src/test_utils/mod.rs
+++ b/aptos-core/consensus/src/test_utils/mod.rs
@@ -94,6 +94,7 @@ pub async fn build_empty_tree() -> Arc<BlockStore> {
         true,
         Arc::new(Mutex::new(PendingBlocks::new())),
         false,
+        false,
         HashMap::new(), // validator_indices: empty for tests
     ))
 }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "a379a86daa2db6bb109083ac9106e5de35f818dd" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "b49b4864aeaa3c35c6871a77d7133bb9486edbf1" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -1221,10 +1221,6 @@ impl BlockBufferManager {
                     Err(_) => continue, // Timeout on the wait, retry
                 }
             } else {
-                block_state_machine.latest_finalized_block_number = std::cmp::max(
-                    block_state_machine.latest_finalized_block_number,
-                    result.last().unwrap().num,
-                );
                 return Ok(result);
             }
         }
@@ -1413,5 +1409,44 @@ mod tests {
             .expect("ready buffer should not wait for another notification");
 
         assert_eq!(epoch, 7);
+    }
+
+    #[tokio::test]
+    async fn get_committed_blocks_does_not_advance_finalized_watermark_before_persist_ack() {
+        let manager = BlockBufferManager::new(test_config());
+        manager.init(0, HashMap::new(), 1).await.unwrap();
+
+        let block_id = BlockId([1; 32]);
+        let block_key = BlockKey::new(1, 1);
+        {
+            let mut block_state_machine = manager.block_state_machine.lock().await;
+            block_state_machine.blocks.insert(
+                block_key,
+                BlockState::Committed {
+                    hash: Some([2; 32]),
+                    compute_result: StateComputeResult::with_root_hash(
+                        gaptos::aptos_crypto::HashValue::new([3; 32]),
+                    ),
+                    id: block_id,
+                    persist_notifier: None,
+                },
+            );
+        }
+
+        let committed_blocks = manager.get_committed_blocks(1, Some(1), 1).await.unwrap();
+        assert_eq!(committed_blocks.len(), 1);
+        assert_eq!(committed_blocks[0].block_id, block_id);
+
+        {
+            let block_state_machine = manager.block_state_machine.lock().await;
+            assert_eq!(block_state_machine.latest_commit_block_number, 0);
+            assert_eq!(block_state_machine.latest_finalized_block_number, 0);
+        }
+
+        manager.set_state(1, 1).await.unwrap();
+
+        let block_state_machine = manager.block_state_machine.lock().await;
+        assert_eq!(block_state_machine.latest_commit_block_number, 1);
+        assert_eq!(block_state_machine.latest_finalized_block_number, 1);
     }
 }


### PR DESCRIPTION
## Summary

- stop advancing BlockBufferManager finalized watermark when committed blocks are merely handed to reth; the watermark now advances through the persist-ack state update path
- add a regression test for the commit handoff vs persist acknowledgement boundary
- distinguish chain-level randomness enablement from epochs that actually require block randomness during recovery/rebuild
- allow recovery/rebuild to replay epochs without a completed DKG session without requiring every block to carry randomness

## Audit coverage

- fixes Galxe/gravity-audit#32
- fixes Galxe/gravity-audit#325

## Tests

- cargo +nightly fmt --all
- RUSTFLAGS='--cfg tokio_unstable' cargo check -p 'path+file:///Users/lightman/repos/gravity-sdk/aptos-core/consensus#aptos-consensus@0.1.0'
- RUSTFLAGS='--cfg tokio_unstable' cargo test -p 'path+file:///Users/lightman/repos/gravity-sdk/crates/block-buffer-manager#0.1.0' get_committed_blocks_does_not_advance_finalized_watermark_before_persist_ack
