### PR TITLE
fix(consensus): return Result from IncrementalProofState::take instead of panicking (audit #67)

### DIFF
--- a/aptos-core/consensus/consensus-types/src/proof_of_store.rs
+++ b/aptos-core/consensus/consensus-types/src/proof_of_store.rs
@@ -274,6 +274,7 @@ pub enum SignedBatchInfoError {
     NotFound,
     AlreadyCommitted,
     NoTimeStamps,
+    UnableToAggregate,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/aptos-core/consensus/src/quorum_store/proof_coordinator.rs
+++ b/aptos-core/consensus/src/quorum_store/proof_coordinator.rs
@@ -117,17 +117,25 @@ impl IncrementalProofState {
         }
     }
 
-    fn take(&mut self, validator_verifier: &ValidatorVerifier) -> ProofOfStore {
+    fn take(
+        &mut self,
+        validator_verifier: &ValidatorVerifier,
+    ) -> Result<ProofOfStore, SignedBatchInfoError> {
         if self.completed {
             panic!("Cannot call take twice, unexpected issue occurred");
         }
-        self.completed = true;
 
         match validator_verifier.aggregate_signatures(
             PartialSignatures::new(self.aggregated_signature.clone()).signatures_iter(),
         ) {
-            Ok(sig) => ProofOfStore::new(self.info.clone(), sig),
-            Err(e) => unreachable!("Cannot aggregate signatures on digest err = {:?}", e),
+            Ok(sig) => {
+                self.completed = true;
+                Ok(ProofOfStore::new(self.info.clone(), sig))
+            }
+            Err(e) => {
+                error!("Cannot aggregate signatures on digest err = {:?}", e);
+                Err(SignedBatchInfoError::UnableToAggregate)
+            }
         }
     }
 
@@ -216,7 +224,7 @@ impl ProofCoordinator {
         if let Some(value) = self.batch_info_to_proof.get_mut(signed_batch_info.batch_info()) {
             value.add_signature(&signed_batch_info, validator_verifier)?;
             if !value.completed && value.ready(validator_verifier) {
-                let proof = value.take(validator_verifier);
+                let proof = value.take(validator_verifier)?;
                 txn_metrics::TxnLifeTime::get_txn_life_time().record_proof(proof.info().batch_id());
                 // proof validated locally, so adding to cache
                 self.proof_cache.insert(proof.info().clone(), proof.multi_signature().clone());


### PR DESCRIPTION
Closes Galxe/gravity-audit#67

## Summary

Single surgical fix, extracted from #732 (commit 1 of 2) so it can ship independently. Supersedes #732; also see disposition of #723 below.

`IncrementalProofState::take()` panicked via `unreachable!()` when BLS signature aggregation failed — legitimately reachable after a validator-set rotation — crashing the `ProofCoordinator` task and halting quorum-store proof generation. This is the release-blocking half of the audit backlog: it needs no attacker, just normal validator rotation.

**Change:** `take()` now returns `Result<ProofOfStore, SignedBatchInfoError>` with a new `SignedBatchInfoError::UnableToAggregate` variant; the sole caller (`add_signature`) propagates with `?`, and the command loop already logs-and-continues. On error the entry stays pending (`completed` remains false, timeout/expire path intact), so later signatures retry aggregation — same semantics as upstream aptos-core#14644's `aggregate_and_verify`, without its ~466-line signature-aggregator refactor (unnecessary here: this fork verifies every `SignedBatchInfo` BLS signature eagerly at message reception, so invalid-signature filtering is not needed).

## Why this PR replaces #723 / #732

Independent review of both PRs concluded:

- **#732 commit 2** (audit #41/#43, `PendingOrderVotes` equivocation map + round-jump guard) introduces a cross-round false-equivocation regression: `PendingOrderVotes` is long-lived across rounds (unlike per-round `PendingVotes` it mirrors), so any missed order-vote quorum causes all honest next-round order votes to be rejected as equivocation. Will be redone following upstream aptos-core#14637's design. The underlying issues don't block release — the fork's existing QC↔vote binding already closes most of #41, and #43's residual exposure is DoS-shaped.
- **#723's audit #53 fix** is already on `main` (superseded by #735's hardfork-gated `use_corrected_commit_timestamp` — the correct approach, since the unconditional version would split consensus with un-upgraded nodes). Its remaining three fixes (#54/#517/#522) reviewed correct but are not release-critical and will be re-raised on top of current main.

## Verification

- `RUSTFLAGS="--cfg tokio_unstable" cargo check --manifest-path aptos-core/consensus/Cargo.toml` ✓ on this branch (rebased on current main)

## Test plan

- [ ] CI green
- [ ] Follow-up (with the #41/#43 rework): unit test for the aggregation-failure retry path

🤖 Generated with [Claude Code](https://claude.com/claude-code)