### PR TITLE
chore(deps): bump gravity-reth dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -7913,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 
 [[package]]
 name = "gravity-sdk"
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -11542,7 +11542,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12768,7 +12768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13503,7 +13503,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13549,7 +13549,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13573,7 +13573,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13602,7 +13602,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13622,7 +13622,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13636,7 +13636,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13713,7 +13713,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13723,7 +13723,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13741,7 +13741,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13759,7 +13759,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13770,7 +13770,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13785,7 +13785,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13798,7 +13798,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13810,7 +13810,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13836,7 +13836,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13857,7 +13857,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13882,7 +13882,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13913,7 +13913,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13927,7 +13927,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13953,7 +13953,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13977,7 +13977,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -14001,7 +14001,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14031,7 +14031,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14062,7 +14062,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14084,7 +14084,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14109,7 +14109,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "futures",
  "pin-project",
@@ -14132,7 +14132,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14184,7 +14184,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14212,7 +14212,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14228,7 +14228,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14243,7 +14243,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14265,7 +14265,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14276,7 +14276,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14304,7 +14304,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14325,7 +14325,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14347,7 +14347,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14363,7 +14363,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14381,7 +14381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14394,7 +14394,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14423,7 +14423,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14442,7 +14442,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14452,7 +14452,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14497,7 +14497,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14510,7 +14510,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14528,7 +14528,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14566,7 +14566,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14580,7 +14580,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -14590,7 +14590,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14617,7 +14617,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "bytes",
  "futures",
@@ -14637,7 +14637,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "futures",
  "metrics",
@@ -14649,7 +14649,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14657,7 +14657,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14671,7 +14671,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14726,7 +14726,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14751,7 +14751,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14773,7 +14773,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14788,7 +14788,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14802,7 +14802,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14819,7 +14819,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14843,7 +14843,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14912,7 +14912,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14965,7 +14965,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -15003,7 +15003,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15027,7 +15027,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15051,7 +15051,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15072,7 +15072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15084,7 +15084,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15105,7 +15105,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15117,7 +15117,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15137,7 +15137,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15147,7 +15147,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15160,7 +15160,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15207,7 +15207,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15231,7 +15231,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15244,7 +15244,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15274,7 +15274,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15317,7 +15317,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15345,7 +15345,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15358,7 +15358,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15377,7 +15377,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15404,7 +15404,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15417,7 +15417,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15497,7 +15497,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15525,7 +15525,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15564,7 +15564,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15585,7 +15585,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15615,7 +15615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15659,7 +15659,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15706,7 +15706,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15736,7 +15736,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15780,7 +15780,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15807,7 +15807,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15820,7 +15820,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15840,7 +15840,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15852,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15882,7 +15882,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15898,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15916,7 +15916,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15926,7 +15926,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15983,7 +15983,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16007,7 +16007,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16034,7 +16034,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16053,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16097,7 +16097,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16115,7 +16115,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=a379a86daa2db6bb109083ac9106e5de35f818dd#a379a86daa2db6bb109083ac9106e5de35f818dd"
+source = "git+https://github.com/Galxe/gravity-reth?rev=c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb#c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "a379a86daa2db6bb109083ac9106e5de35f818dd" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "c7c5807433a20f1fe4009c8cf5a9adc3b2a5d5bb" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }


### PR DESCRIPTION
## Summary

Bumps `greth` from `a379a86` → `c7c58074` (Galxe/gravity-reth#385, merged).

Clean fast-forward, 2 commits ahead / 0 behind. Picks up:

- Galxe/gravity-reth#383 — read randomness from canonical headers
- Galxe/gravity-reth#385 — close EIP-7702 cross-account nonce halt + harden recoverable-error panics on the deterministic execution path

## Test plan

- [x] `cargo check -p gravity_node` (with `--cfg tokio_unstable`) passes
- [ ] CI green