### PR TITLE
chore(deps): [v1.7] bump gravity-reth dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4607,7 +4607,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "reth-evm",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 
 [[package]]
 name = "gravity-sdk"
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -11539,7 +11539,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12764,7 +12764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13499,7 +13499,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -13545,7 +13545,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13569,7 +13569,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13598,7 +13598,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13618,7 +13618,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13632,7 +13632,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -13709,7 +13709,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13719,7 +13719,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13737,7 +13737,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13755,7 +13755,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
@@ -13766,7 +13766,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -13781,7 +13781,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -13794,7 +13794,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13806,7 +13806,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13832,7 +13832,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -13853,7 +13853,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13878,7 +13878,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -13909,7 +13909,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13923,7 +13923,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13949,7 +13949,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13973,7 +13973,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -13997,7 +13997,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14027,7 +14027,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14058,7 +14058,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14080,7 +14080,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14105,7 +14105,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "futures",
  "pin-project",
@@ -14128,7 +14128,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14180,7 +14180,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -14208,7 +14208,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14224,7 +14224,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -14239,7 +14239,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14261,7 +14261,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14272,7 +14272,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14300,7 +14300,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14321,7 +14321,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14343,7 +14343,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14359,7 +14359,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14377,7 +14377,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14390,7 +14390,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14419,7 +14419,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14438,7 +14438,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14448,7 +14448,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14471,7 +14471,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14493,7 +14493,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14506,7 +14506,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14524,7 +14524,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14562,7 +14562,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -14576,7 +14576,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "serde",
  "serde_json",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14613,7 +14613,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "bytes",
  "futures",
@@ -14633,7 +14633,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "futures",
  "metrics",
@@ -14645,7 +14645,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
 ]
@@ -14653,7 +14653,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -14667,7 +14667,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14722,7 +14722,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14747,7 +14747,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14769,7 +14769,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14784,7 +14784,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14798,7 +14798,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14815,7 +14815,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14839,7 +14839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14908,7 +14908,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14961,7 +14961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14999,7 +14999,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15023,7 +15023,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15047,7 +15047,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -15068,7 +15068,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15080,7 +15080,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15101,7 +15101,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15113,7 +15113,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15133,7 +15133,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -15143,7 +15143,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15156,7 +15156,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15204,7 +15204,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15228,7 +15228,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -15241,7 +15241,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15271,7 +15271,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15314,7 +15314,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15342,7 +15342,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -15355,7 +15355,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15374,7 +15374,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -15401,7 +15401,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -15414,7 +15414,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15494,7 +15494,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -15522,7 +15522,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -15561,7 +15561,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -15582,7 +15582,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15612,7 +15612,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -15656,7 +15656,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15703,7 +15703,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15717,7 +15717,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15733,7 +15733,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15777,7 +15777,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15804,7 +15804,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15817,7 +15817,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15837,7 +15837,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -15849,7 +15849,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15879,7 +15879,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -15895,7 +15895,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -15913,7 +15913,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15923,7 +15923,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15938,7 +15938,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -15980,7 +15980,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -16004,7 +16004,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -16031,7 +16031,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16050,7 +16050,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16075,7 +16075,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16094,7 +16094,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16112,7 +16112,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=3fd603db5b156e4d6b0daab615e55fa07586f091#3fd603db5b156e4d6b0daab615e55fa07586f091"
+source = "git+https://github.com/Galxe/gravity-reth?rev=416f551640ed2e9dec91f770f83a1b009e331589#416f551640ed2e9dec91f770f83a1b009e331589"
 dependencies = [
  "zstd",
 ]

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -32,7 +32,7 @@ serde = "^1.0.226"
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "3fd603db5b156e4d6b0daab615e55fa07586f091" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "416f551640ed2e9dec91f770f83a1b009e331589" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "^1.0.37", default-features = false }


### PR DESCRIPTION
## Summary

Bumps `greth` on branch-v1.7 from `3fd603db` → `416f5516` (Galxe/gravity-reth#386, merged; backport of #385 onto greth `branch-v1.7`).

Picks up:
- Galxe/gravity-reth#386 (backport of #385) — close EIP-7702 cross-account nonce halt + harden recoverable-error panics on the deterministic execution path

## Test plan

- [x] `cargo check -p gravity_node` (with `--cfg tokio_unstable`) passes
- [ ] CI green