### PR TITLE
fix(mempool): record per-sender nonce before the in-flight filter

### DIFF
--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -215,6 +215,15 @@ impl TxPool for Mempool {
                     }
                 }
 
+                // Record the nonce for EVERY consecutive tx, BEFORE the caller's filter runs —
+                // including one the filter drops as already-in-flight (its lower nonce was already
+                // proposed in an uncommitted batch and excluded here via `exclude_transactions`).
+                // Recording only after the filter would drop this anchor: the next tx from the same
+                // sender would then find no `last_nonces` entry, be treated as first-per-sender,
+                // and bypass the consecutiveness check — letting a future-nonce tx
+                // into the batch.
+                last_nonces.insert(sender, nonce);
+
                 // transactions from poisoning nonce tracking
                 let sender_addr = convert_account(sender);
                 if let Some(ref f) = filter {
@@ -223,9 +232,6 @@ impl TxPool for Mempool {
                         return None;
                     }
                 }
-
-                // Only record nonce after filter passes
-                last_nonces.insert(sender, nonce);
 
                 let verified_txn = to_verified_txn(pool_txn.clone(), chain_id);
                 let tx_hash: [u8; 32] = pool_txn.transaction.transaction().inner().hash().0;


### PR DESCRIPTION
## What

In `Mempool::best_txns`, record the per-sender nonce in `last_nonces` **before** the
caller-supplied `filter` (the `exclude_transactions` in-flight dedup) runs, instead of only
after it passes.

## Why

`best_txns` enforces per-sender nonce consecutiveness with `last_nonces`: the first tx seen for
a sender is admitted at any nonce, and every subsequent tx must be exactly `last + 1`.

The nonce was recorded **after** the `filter` check. So when the filter drops a tx as
already-in-flight — its lower nonce was already proposed in an uncommitted batch and is excluded
here — that tx's nonce was never recorded. The next tx from the same sender then found no
`last_nonces` entry, was treated as *first-per-sender*, and skipped the consecutiveness check
entirely. A gapped / future-nonce tx could slip into the batch behind a filtered-out lower one.

Moving the `insert` to right after the consecutiveness check keeps the anchor intact for
**every** consecutive tx, including the filtered in-flight one, so the guard stays anchored to
the real per-sender sequence rather than resetting to "first" after a drop.

Order-then-execute already self-heals the downstream effect (the in-flight lower-nonce tx
commits ahead), so this is a **defense-in-depth** tightening of the mempool ordering guard, not
a liveness/safety fix. No behavior change for the common path (a sender with no filtered txs is
unaffected).

## Test

Reordered statement over `Copy` values (`Address`, `u64`) inside the existing `filter_map`;
`cargo check -p gravity_node` passes. The consecutiveness path is exercised by existing
`best_txns` selection.
