### PR TITLE
feat(tools/gnode): per-instance isolation for concurrent audits

### DIFF
--- a/tools/gnode/README.md
+++ b/tools/gnode/README.md
@@ -18,6 +18,17 @@ gnode 自持配置在 `presets/<name>/`，base_dir / 端口独立，避免与他
 | `1node` | 8645    | `/tmp/gnode-1node`  | 否       |
 | `prague`| 8647    | `/tmp/gnode-prague` | 是（7702-halt 必需）|
 
+### 多实例并发隔离（instance）
+并发审计时,多个 agent 各自起集群会抢同一个 base_dir/端口。用 `--instance N`(或环境变量
+`GNODE_INSTANCE`)隔离:instance N 的所有端口 = 基准 + N*100、base_dir 带 `-N` 后缀。**所有 instance
+共享同一份 genesis+identity**(单验证者节点不校验对端口,实测可行),所以只有 instance 首次不存在时
+才 deploy+start,genesis 只生成一次 → 每个 instance 都很快。
+
+- `gnode up --preset prague`(不带 --instance 且未设 GNODE_INSTANCE)→ **自动分配**空闲实例,打印 `inst=N`。
+- 之后对该实例的所有命令带 `--instance N`(或让 Coacker 给每个 agent 预设 `GNODE_INSTANCE`)。
+- `gnode status`(不带参数)列出所有 preset 下**已存在 base_dir 的实例**及其存活/区块。
+- 攻击某个 instance 只打停它自己,不影响其它 instance(已验证)。
+
 ## 命令
 ```bash
 gnode up   --preset 1node|prague [--fresh]   # 拉起集群（--fresh 重新 genesis）

--- a/tools/gnode/gnodelib/cli.py
+++ b/tools/gnode/gnodelib/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
+import os
 import sys
 
 from . import ops
@@ -16,6 +16,18 @@ def _add_preset(p: argparse.ArgumentParser, default: str = "1node") -> None:
         help="集群档位（1node|prague，或数字 1=1node；默认 %(default)s。prague 启用 EIP-7702。"
              "status 不带该参数时列出所有档位）",
     )
+    p.add_argument(
+        "--instance", dest="instance", default=os.environ.get("GNODE_INSTANCE"),
+        help="实例号（并发隔离：端口+N*100、base_dir 带 -N；缺省读 GNODE_INSTANCE，"
+             "未设时 up 自动分配空闲号、其它命令用 0）。所有 instance 共享同一份 genesis。",
+    )
+
+
+def _inst(args, default=0):
+    v = getattr(args, "instance", None)
+    if v is None:
+        return default
+    return "auto" if str(v) == "auto" else int(v)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -117,20 +129,22 @@ def main(argv: list[str]) -> int:
 
 def _dispatch(args, argv: list[str]) -> int:
     if args.cmd == "up":
-        return ops.cmd_up(args.preset, fresh=args.fresh)
+        # 未指定 instance 且未设 GNODE_INSTANCE → 自动分配空闲实例
+        return ops.cmd_up(args.preset, instance=_inst(args, "auto"), fresh=args.fresh)
     if args.cmd == "down":
-        return ops.cmd_down(args.preset)
+        return ops.cmd_down(args.preset, instance=_inst(args))
     if args.cmd == "status":
-        # 没显式指定档位时，列出所有 preset 的状态（避免默认 1node 让人误以为集群没起）
-        return ops.cmd_status(args.preset, show_all=("--preset" not in argv and "--nodes" not in argv))
+        # 没显式指定档位时，列出所有 preset/instance 的状态（避免默认档让人误以为集群没起）
+        return ops.cmd_status(args.preset, instance=_inst(args),
+                              show_all=("--preset" not in argv and "--nodes" not in argv))
     if args.cmd == "logs":
-        return ops.cmd_logs(args.preset, args.which, args.follow, args.lines)
+        return ops.cmd_logs(args.preset, args.which, args.follow, args.lines, instance=_inst(args))
     if args.cmd == "state":
-        return ops.cmd_state(args.preset, args.addr)
+        return ops.cmd_state(args.preset, args.addr, instance=_inst(args))
     if args.cmd == "deploy":
-        return ops.cmd_deploy(args.preset, args.artifact, args_json=args.args)
+        return ops.cmd_deploy(args.preset, args.artifact, args_json=args.args, instance=_inst(args))
     if args.cmd == "send":
-        return ops.cmd_send(args.preset, args.tx, no_wait=args.no_wait)
+        return ops.cmd_send(args.preset, args.tx, no_wait=args.no_wait, instance=_inst(args))
     if args.cmd == "scenarios":
         for name, desc in registry.list_scenarios():
             print(f"{name:<16} {desc}")
@@ -150,7 +164,7 @@ def _dispatch(args, argv: list[str]) -> int:
         for kv in args.param:
             k, _, v = kv.partition("=")
             params[k.strip()] = v.strip()
-        result = registry.run(args.scenario, preset=args.preset, params=params)
+        result = registry.run(args.scenario, preset=args.preset, instance=_inst(args), params=params)
         if args.json:
             print(json.dumps(result, indent=2, ensure_ascii=False))
         else:

--- a/tools/gnode/gnodelib/env.py
+++ b/tools/gnode/gnodelib/env.py
@@ -4,6 +4,8 @@
 """
 from __future__ import annotations
 
+import re
+import socket
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,6 +35,29 @@ PRESETS = {
 # --nodes 的数字别名（向后兼容；目前只有 1node，3node 档未接入）
 NODE_ALIASES = {1: "1node"}
 
+# 多实例隔离：instance N 的所有端口 = 基准端口 + N*STRIDE，base_dir 带 -N 后缀。
+# 所有 instance 共享同一份 genesis+identity（单验证者节点不校验对端口，实测可行），
+# 因此只有 instance 首次不存在时 deploy+start，genesis 只生成一次 → 每个 instance 都很快。
+PORT_STRIDE = 100
+MAX_INSTANCES = 32
+GNODE_WORK = Path("/tmp/gnode-work")  # 每个 instance 的物化 cluster.toml 放这里
+_PORT_KEYS = ["validator_port", "vfn_port", "rpc_port", "metrics_port",
+              "inspection_port", "https_port", "authrpc_port", "reth_p2p_port"]
+
+
+def _apply_port_offset(text: str, offset: int) -> str:
+    """把 cluster.toml 里各端口字段整体 +offset（只动已知端口键，避免误伤其它数字）。"""
+    if offset == 0:
+        return text
+    for k in _PORT_KEYS:
+        text = re.sub(rf"({k}\s*=\s*)(\d+)", lambda m: f"{m.group(1)}{int(m.group(2)) + offset}", text)
+    return text
+
+
+def _port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("127.0.0.1", port)) != 0
+
 # genesis.toml 里的 faucet = Anvil dev #0，私钥公开可用（本地 devnet）
 FAUCET_PRIVKEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
@@ -49,6 +74,7 @@ class ClusterPaths:
     artifacts_dir: Path
     chain_id: int
     prague: bool = False
+    instance: int = 0
 
     def node_ids(self) -> list[str]:
         cfg = _load_toml(self.cluster_toml)
@@ -81,8 +107,7 @@ def _load_toml(path: Path) -> dict:
         return tomllib.load(f)
 
 
-def resolve_cluster(preset) -> ClusterPaths:
-    """把档位名（"1node"/"prague"）或数字别名（1 / "1"）解析成 ClusterPaths。"""
+def _preset_name(preset) -> str:
     if isinstance(preset, int):
         preset = NODE_ALIASES.get(preset, str(preset))
     name = str(preset)
@@ -90,27 +115,64 @@ def resolve_cluster(preset) -> ClusterPaths:
         name = NODE_ALIASES.get(int(name), name)
     if name not in PRESETS:
         raise ValueError(f"未知档位 '{name}'（支持: {sorted(PRESETS)}；4-validator docker 档暂未接入）")
+    return name
+
+
+def resolve_cluster(preset, instance: int = 0) -> ClusterPaths:
+    """把档位名 + instance 号解析成 ClusterPaths。
+
+    instance 0 = 基准端口 + base_dir /tmp/gnode-<name>；instance N = 端口 +N*STRIDE、
+    base_dir /tmp/gnode-<name>-N。所有 instance 共享 preset 的 genesis+identity(artifacts/)，
+    只物化一份带偏移端口的 cluster.toml 到 /tmp/gnode-work/<name>-N/。
+    """
+    name = _preset_name(preset)
+    if not (0 <= instance < MAX_INSTANCES):
+        raise ValueError(f"instance 需在 [0,{MAX_INSTANCES}) 内，得到 {instance}")
     preset_dir = PRESETS_DIR / name
-    cluster_toml = preset_dir / "cluster.toml"
+    tmpl = preset_dir / "cluster.toml"
     genesis_toml = preset_dir / "genesis.toml"
-    if not cluster_toml.exists():
-        raise FileNotFoundError(f"cluster.toml 不存在: {cluster_toml}（先生成 gnode preset）")
-    ccfg = _load_toml(cluster_toml)
-    base_dir = Path(ccfg["cluster"]["base_dir"])
+    if not tmpl.exists():
+        raise FileNotFoundError(f"cluster.toml 模板不存在: {tmpl}")
+    shared_artifacts = preset_dir / "artifacts"  # genesis+identity 全 instance 共享
+
+    suffix = "" if instance == 0 else f"-{instance}"
+    base_dir = Path(f"/tmp/gnode-{name}{suffix}")
+
+    # 物化本 instance 的 cluster.toml：偏移端口 + 独立 base_dir + genesis_source 指向共享 artifacts
+    text = _apply_port_offset(tmpl.read_text(), instance * PORT_STRIDE)
+    text = re.sub(r'base_dir\s*=\s*"[^"]*"', f'base_dir = "{base_dir}"', text)
+    text = re.sub(r'genesis_path\s*=\s*"[^"]*"', f'genesis_path = "{shared_artifacts}/genesis.json"', text)
+    text = re.sub(r'waypoint_path\s*=\s*"[^"]*"', f'waypoint_path = "{shared_artifacts}/waypoint.txt"', text)
+    work = GNODE_WORK / f"{name}-{instance}"
+    work.mkdir(parents=True, exist_ok=True)
+    cluster_toml = work / "cluster.toml"
+    cluster_toml.write_text(text)
+
     chain_id = 1337
     if genesis_toml.exists():
-        gcfg = _load_toml(genesis_toml)
-        chain_id = int(gcfg.get("genesis", {}).get("chain_id", 1337))
+        chain_id = int(_load_toml(genesis_toml).get("genesis", {}).get("chain_id", 1337))
     return ClusterPaths(
         name=name,
         preset_dir=preset_dir,
         cluster_toml=cluster_toml,
         genesis_toml=genesis_toml,
         base_dir=base_dir,
-        artifacts_dir=preset_dir / "artifacts",
+        artifacts_dir=shared_artifacts,
         chain_id=chain_id,
         prague=PRESETS[name]["prague"],
+        instance=instance,
     )
+
+
+def alloc_instance(preset) -> int:
+    """自动分配一个空闲 instance：base_dir 不存在且 RPC 端口空闲的最小号。"""
+    name = _preset_name(preset)
+    base_rpc = int(_load_toml(PRESETS_DIR / name / "cluster.toml")["nodes"][0]["rpc_port"])
+    for i in range(MAX_INSTANCES):
+        suffix = "" if i == 0 else f"-{i}"
+        if not Path(f"/tmp/gnode-{name}{suffix}").exists() and _port_free(base_rpc + i * PORT_STRIDE):
+            return i
+    raise RuntimeError(f"没有空闲 instance（0..{MAX_INSTANCES} 都被占用）")
 
 
 def make_web3(rpc_url: str, timeout: int = 15) -> Web3:

--- a/tools/gnode/gnodelib/ops.py
+++ b/tools/gnode/gnodelib/ops.py
@@ -120,35 +120,40 @@ def _ensure_binaries() -> None:
 # 命令实现
 # ----------------------------------------------------------------------------
 
-def cmd_up(preset, *, fresh: bool = False) -> int:
-    cp = resolve_cluster(preset)
+def cmd_up(preset, *, instance: int = 0, fresh: bool = False) -> int:
+    from .env import alloc_instance
+    if instance == "auto" or instance is None:
+        instance = alloc_instance(preset)
+        log(f"自动分配 instance={instance}")
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     env = _script_env(cp)
-    cfg = str(cp.cluster_toml)
+    cfg = str(cp.cluster_toml)                    # 本 instance（偏移端口/独立 base_dir）
+    tmpl_cfg = str(cp.preset_dir / "cluster.toml")  # 模板（genesis.toml 同目录）供 init/genesis
     gen = str(cp.genesis_toml)
 
     node_ids = cp.node_ids()
     already = all(_pid_alive(cp.pid_file(nid)) for nid in node_ids) and _rpc_up(w3)
     if already and not fresh:
-        log(f"集群已在运行（{cp.name}, base_dir={cp.base_dir}），RPC={cp.rpc_url()} block={w3.eth.block_number}")
+        log(f"集群已在运行（{cp.name} inst={cp.instance}, base_dir={cp.base_dir}），RPC={cp.rpc_url()} block={w3.eth.block_number}")
         return 0
 
     _ensure_binaries()
-
     genesis_json = cp.artifacts_dir / "genesis.json"
     identity = cp.artifacts_dir / node_ids[0] / "config" / "identity.yaml"
 
-    if fresh:
-        log("--fresh：停止并清理 artifacts/ 与 base_dir，重新 genesis")
-        _run_script("stop.sh", ["--config", cfg], env=env, check=False)
-        subprocess.run(["rm", "-rf", str(cp.artifacts_dir), str(cp.base_dir)])
-    else:
-        # base_dir 可能残留旧部署（deploy.sh 会交互式询问是否清理，无 stdin 时默认 N）；
-        # gnode 独占该 base_dir，直接清理以保证干净部署。
-        subprocess.run(["rm", "-rf", str(cp.base_dir)])
+    _run_script("stop.sh", ["--config", cfg], env=env, check=False)  # 停本 instance 旧进程
+    subprocess.run(["rm", "-rf", str(cp.base_dir)])                   # 只清本 instance base_dir
+    if fresh and cp.instance == 0:
+        # 共享 genesis 由 instance 0 “拥有”，--fresh 才重建；instance>0 的 --fresh 不动共享 genesis
+        log("--fresh (instance 0)：清理共享 artifacts，重新 genesis")
+        subprocess.run(["rm", "-rf", str(cp.artifacts_dir)])
+    elif fresh:
+        log(f"--fresh (instance {cp.instance})：只重置本实例 base_dir，共享 genesis 保留")
 
+    # 共享 genesis/identity 只生成一次（用模板配置，端口无关）；多 instance 复用
     if not identity.exists():
-        _run_script("init.sh", [cfg], env=env)
+        _run_script("init.sh", [tmpl_cfg], env=env)
     if not genesis_json.exists():
         _run_script("genesis.sh", [gen], env=env)
     _run_script("deploy.sh", [cfg], env=env)
@@ -156,43 +161,45 @@ def cmd_up(preset, *, fresh: bool = False) -> int:
 
     log(f"等待 RPC 就绪 {cp.rpc_url()} ...")
     if not _wait_rpc(w3, timeout=90):
-        log(f"RPC 未在 90s 内就绪，请检查日志: gnode logs --preset {cp.name} --which reth")
+        log(f"RPC 未在 90s 内就绪，请检查日志: gnode logs --preset {cp.name} --instance {cp.instance} --which reth")
         return 1
-    log(f"集群已就绪：{cp.name} RPC={cp.rpc_url()} chainId={w3.eth.chain_id} block={w3.eth.block_number} prague={cp.prague}")
+    log(f"集群已就绪：{cp.name} inst={cp.instance} RPC={cp.rpc_url()} chainId={w3.eth.chain_id} block={w3.eth.block_number} prague={cp.prague}")
     return 0
 
 
-def cmd_down(preset) -> int:
-    cp = resolve_cluster(preset)
+def cmd_down(preset, *, instance: int = 0) -> int:
+    cp = resolve_cluster(preset, int(instance))
     _run_script("stop.sh", ["--config", str(cp.cluster_toml)], env=_script_env(cp), check=False)
-    log("已发送停止命令")
+    log(f"已发送停止命令（{cp.name} inst={cp.instance}）")
     return 0
 
 
-def cmd_status(preset, *, show_all: bool = False) -> int:
-    from .env import PRESETS
+def cmd_status(preset, *, instance: int = 0, show_all: bool = False) -> int:
+    from .env import PRESETS, MAX_INSTANCES
     names = list(PRESETS) if show_all else [preset]
     for name in names:
-        cp = resolve_cluster(name)
-        print(f"# cluster {cp.name}  base_dir={cp.base_dir}  chainId={cp.chain_id}  prague={cp.prague}")
-        print(f"{'node':<8} {'rpc':<28} {'proc':<6} {'block':<10}")
-        for nid in cp.node_ids():
-            url = cp.rpc_url(nid)
-            w3 = make_web3(url, timeout=3)
-            alive = _pid_alive(cp.pid_file(nid))
-            block = "-"
-            try:
-                block = str(int(w3.eth.block_number))
-            except Exception:
-                pass
-            print(f"{nid:<8} {url:<28} {('up' if alive else 'down'):<6} {block:<10}")
-        if show_all and name != names[-1]:
-            print()
+        # 指定 --instance 时只看那一个；否则（含 show_all）列出所有 base_dir 存在的 instance（0 号始终列）
+        if not show_all and instance:
+            insts = [int(instance)]
+        else:
+            insts = [i for i in range(MAX_INSTANCES)
+                     if i == 0 or Path(f"/tmp/gnode-{resolve_cluster(name).name}{'' if i == 0 else f'-{i}'}").exists()]
+        for inst in insts:
+            cp = resolve_cluster(name, inst)
+            for nid in cp.node_ids():
+                w3 = make_web3(cp.rpc_url(nid), timeout=3)
+                alive = _pid_alive(cp.pid_file(nid))
+                block = "-"
+                try:
+                    block = str(int(w3.eth.block_number))
+                except Exception:
+                    pass
+                print(f"{cp.name:<8} inst={inst:<3} {cp.rpc_url(nid):<28} {('up' if alive else 'down'):<6} block={block}")
     return 0
 
 
-def cmd_logs(preset, which: str, follow: bool, lines: int) -> int:
-    cp = resolve_cluster(preset)
+def cmd_logs(preset, which: str, follow: bool, lines: int, *, instance: int = 0) -> int:
+    cp = resolve_cluster(preset, int(instance))
     # 默认第一个节点
     nid = cp.node_ids()[0]
     files = cp.log_files(nid)
@@ -208,8 +215,8 @@ def cmd_logs(preset, which: str, follow: bool, lines: int) -> int:
     return subprocess.run(cmd).returncode
 
 
-def cmd_state(preset, addr: str) -> int:
-    cp = resolve_cluster(preset)
+def cmd_state(preset, addr: str, *, instance: int = 0) -> int:
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     try:
         addr = Web3.to_checksum_address(addr)
@@ -298,8 +305,8 @@ def _checksum_addrs(v):
     return v
 
 
-def cmd_deploy(preset, artifact_path: str, *, args_json: Optional[str] = None) -> int:
-    cp = resolve_cluster(preset)
+def cmd_deploy(preset, artifact_path: str, *, args_json: Optional[str] = None, instance: int = 0) -> int:
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     rc = _require_rpc(cp, w3)
     if rc is not None:
@@ -326,10 +333,10 @@ def cmd_deploy(preset, artifact_path: str, *, args_json: Optional[str] = None) -
     return 0 if res["status"] == 1 else 2
 
 
-def cmd_send(preset, tx_path: str, *, no_wait: bool = False) -> int:
+def cmd_send(preset, tx_path: str, *, no_wait: bool = False, instance: int = 0) -> int:
     """tx.json 规格见 `gnode send --help`。支持 type(2/1/4)、accessList、authorizationList、
     raw(已签名原始交易) 与 --no-wait（不等回执，用于同块/连发）。缺省用 faucet 签名。"""
-    cp = resolve_cluster(preset)
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     rc = _require_rpc(cp, w3)
     if rc is not None:

--- a/tools/gnode/gnodelib/scenarios/accesslist_probe.py
+++ b/tools/gnode/gnodelib/scenarios/accesslist_probe.py
@@ -25,8 +25,8 @@ SSTORE_INITCODE = "0x6006600c60003960066000f3600160005500"
 PARAMS = {"window": float}  # 观察窗口秒数
 
 
-def run(*, preset, params: dict) -> dict:
-    cp = resolve_cluster(preset)
+def run(*, preset, instance: int = 0, params: dict) -> dict:
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     node_id = cp.node_ids()[0]
     pid_alive = lambda: _pid_alive(cp.pid_file(node_id))

--- a/tools/gnode/gnodelib/scenarios/halt_7702.py
+++ b/tools/gnode/gnodelib/scenarios/halt_7702.py
@@ -118,8 +118,8 @@ def _inject_race(w3: Web3, faucet, A, chain_id: int) -> dict:
     return {"N": N, "head_before": head_before, "tx0_faucet_to_A": tx0_hash, "tx1_from_A_stale": tx1_hash}
 
 
-def run(*, preset, params: dict) -> dict:
-    cp = resolve_cluster(preset)
+def run(*, preset, instance: int = 0, params: dict) -> dict:
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     faucet = faucet_account()
     node_id = cp.node_ids()[0]

--- a/tools/gnode/gnodelib/scenarios/registry.py
+++ b/tools/gnode/gnodelib/scenarios/registry.py
@@ -28,7 +28,7 @@ def list_scenarios() -> list[tuple[str, str]]:
     return [(name, desc) for name, (desc, _fn) in _SCENARIOS.items()]
 
 
-def run(name: str, *, preset, params: dict) -> dict:
+def run(name: str, *, preset, instance: int = 0, params: dict) -> dict:
     if name not in _SCENARIOS:
         avail = ", ".join(_SCENARIOS)
         return {"scenario": name, "verdict": "error", "detail": f"未知场景 '{name}'。可用: {avail}"}
@@ -54,7 +54,7 @@ def run(name: str, *, preset, params: dict) -> dict:
     # 兜底：场景内部任何异常（如注入到一半节点被打挂、RPC 断开）都转成结构化结果，
     # 而不是抛 traceback，保证 --json 契约永远成立。
     try:
-        return fn(preset=preset, params=params)
+        return fn(preset=preset, instance=instance, params=params)
     except Exception as e:  # noqa: BLE001 —— 面向 agent 的工具，任何异常都要给结构化输出
         import traceback
         return {

--- a/tools/gnode/gnodelib/scenarios/revert_probe.py
+++ b/tools/gnode/gnodelib/scenarios/revert_probe.py
@@ -26,8 +26,8 @@ REVERT_INITCODE = "0x6005600c60003960056000f360006000fd"
 PARAMS = {"window": float}  # 观察窗口秒数
 
 
-def run(*, preset, params: dict) -> dict:
-    cp = resolve_cluster(preset)
+def run(*, preset, instance: int = 0, params: dict) -> dict:
+    cp = resolve_cluster(preset, int(instance))
     w3 = make_web3(cp.rpc_url())
     node_id = cp.node_ids()[0]
     pid_alive = lambda: _pid_alive(cp.pid_file(node_id))


### PR DESCRIPTION
## What
Adds `--instance N` (and `GNODE_INSTANCE` env) to `gnode` so multiple audit agents can each drive their own local cluster concurrently without base_dir/port collisions — needed to run Coacker audits with `parallelism > 1` while agents use gnode to live-reproduce halts.

## How
- Instance N offsets all node ports by `N*100` and uses `base_dir=/tmp/gnode-<preset>-N`.
- **All instances share one genesis+identity.** A single-validator devnet doesn't verify peer ports (validated empirically), so only an instance's first bringup runs deploy+start; genesis is generated once and reused → every instance comes up in ~1 min (no re-genesis).
- `gnode up` with neither `--instance` nor `GNODE_INSTANCE` **auto-allocates** the lowest free slot (base_dir absent + RPC port free) and prints `inst=N`. Follow-up commands take `--instance N` or inherit `GNODE_INSTANCE`.
- `gnode status` lists every preset/instance that has a base_dir, with liveness + block height.

## Verified
Brought up two `prague` instances concurrently (`:8647` and `:8747`, sharing one genesis); attacking instance 1 with `7702-halt` halted **only** instance 1 (verdict `panic`) while instance 0 kept producing blocks. Self-contained under `tools/gnode/`; default (instance 0) behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)