### PR TITLE
fix(mempool): enforce byte budget in get_batch_inner

### DIFF
--- a/aptos-core/mempool/src/core_mempool/mempool.rs
+++ b/aptos-core/mempool/src/core_mempool/mempool.rs
@@ -442,11 +442,21 @@ impl Mempool {
             !exclude_transactions.contains_key(&summary)
         });
         let mut transactions = vec![];
+        let mut total_bytes: u64 = 0;
         let best_txns = self.pool.best_txns(Some(filter), max_txns as usize);
         for txn in best_txns {
-            let signed_txn = VerifiedTxn::from(txn).into();
+            let signed_txn: SignedTransaction = VerifiedTxn::from(txn).into();
+            let txn_bytes = signed_txn.raw_txn_bytes_len() as u64;
+            // Enforce the byte budget so proposers don't build payloads that exceed
+            // max_receiving_block_bytes, which receivers reject in process_proposal.
+            // Always include at least one transaction to avoid stalling on a single
+            // large txn (single-txn size is already bounded at mempool admission).
+            if !transactions.is_empty() && total_bytes + txn_bytes > max_bytes {
+                break;
+            }
+            total_bytes += txn_bytes;
             transactions.push(signed_txn);
-            if transactions.len() >= max_txns as usize || transactions.len() >= max_bytes as usize {
+            if transactions.len() >= max_txns as usize {
                 break;
             }
         }
@@ -713,5 +723,70 @@ mod tests {
             0,
             "lazy GC should drop entries whose hashes are no longer in the pool"
         );
+    }
+
+    // A TxPool that hands back a fixed set of txns, honoring the `limit` argument
+    // (like the real reth pool) so get_batch_inner's own capping can be exercised.
+    fn batch_mempool(txns: Vec<ApiVerifiedTxn>) -> Mempool {
+        install_hasher();
+        struct BatchPool(Vec<ApiVerifiedTxn>);
+        impl TxPool for BatchPool {
+            fn best_txns(
+                &self,
+                _f: Option<Box<dyn Fn((ExternalAccountAddress, u64, TxnHash)) -> bool>>,
+                l: usize,
+            ) -> Box<dyn Iterator<Item = ApiVerifiedTxn>> {
+                Box::new(self.0.clone().into_iter().take(l))
+            }
+            fn get_broadcast_txns(
+                &self,
+                _f: Option<Box<dyn Fn((ExternalAccountAddress, u64, TxnHash)) -> bool>>,
+            ) -> Box<dyn Iterator<Item = ApiVerifiedTxn>> {
+                Box::new(std::iter::empty())
+            }
+            fn add_external_txn(&self, _t: ApiVerifiedTxn) -> bool {
+                false
+            }
+            fn remove_txns(&self, _t: Vec<ApiVerifiedTxn>) {}
+        }
+        Mempool {
+            pool: Box::new(BatchPool(txns)),
+            txn_cache: Arc::new(Mutex::new(TxnCache::new(100_000, Duration::from_secs(60)))),
+            snapshot: Arc::new(Mutex::new(Snapshot {
+                shards: HashMap::new(),
+                taken_at: Instant::now(),
+                max_age: Duration::from_millis(20),
+                initialized: false,
+            })),
+            topology: Arc::new(Mutex::new(ObservedTopology::new(Duration::from_secs(10)))),
+            num_sender_buckets: 1,
+        }
+    }
+
+    #[test]
+    fn get_batch_enforces_byte_budget() {
+        let txns: Vec<_> = (0..10u8).map(|i| mk_txn(0, i as u64, i + 40)).collect();
+        let m = batch_mempool(txns);
+
+        // Baseline: with generous limits all txns come back; every txn here has an
+        // identical serialized size, so per_txn is a clean unit for the budget math.
+        let all = m.get_batch_inner(100, u64::MAX, true, BTreeMap::new());
+        assert_eq!(all.len(), 10);
+        let per_txn = all[0].raw_txn_bytes_len() as u64;
+        assert!(per_txn > 0);
+
+        // A byte budget sized for exactly 3 txns must cap the batch at 3 — this is
+        // the behavior that was dead code before (max_bytes compared to txn count).
+        let batch = m.get_batch_inner(100, per_txn * 3, true, BTreeMap::new());
+        assert_eq!(batch.len(), 3, "byte budget must cap the batch");
+
+        // max_txns still caps independently of the byte budget.
+        let capped = m.get_batch_inner(2, u64::MAX, true, BTreeMap::new());
+        assert_eq!(capped.len(), 2, "max_txns must still cap the batch");
+
+        // At least one txn is always returned, even when it alone exceeds the budget,
+        // so a single large txn can never stall block production.
+        let tiny = m.get_batch_inner(100, 1, true, BTreeMap::new());
+        assert_eq!(tiny.len(), 1, "at least one txn must be returned");
     }
 }

--- a/aptos-core/mempool/src/core_mempool/mempool.rs
+++ b/aptos-core/mempool/src/core_mempool/mempool.rs
@@ -443,15 +443,18 @@ impl Mempool {
         });
         let mut transactions = vec![];
         let mut total_bytes: u64 = 0;
-        let best_txns = self.pool.best_txns(Some(filter), max_txns as usize);
+        let best_txns = self.pool.best_txns(Some(filter), max_txns as usize, max_bytes);
         for txn in best_txns {
             let signed_txn: SignedTransaction = VerifiedTxn::from(txn).into();
             let txn_bytes = signed_txn.raw_txn_bytes_len() as u64;
-            // Enforce the byte budget so proposers don't build payloads that exceed
-            // max_receiving_block_bytes, which receivers reject in process_proposal.
-            // Always include at least one transaction to avoid stalling on a single
-            // large txn (single-txn size is already bounded at mempool admission).
-            if !transactions.is_empty() && total_bytes + txn_bytes > max_bytes {
+            // Authoritatively enforce the byte budget so proposers never build a
+            // payload that exceeds max_receiving_block_bytes, which receivers reject
+            // in round_manager::process_proposal. max_bytes may already have been
+            // reduced by validator transactions (MixedPayloadClient), so it can be
+            // smaller than a single txn; in that case we return fewer (possibly zero)
+            // user txns this round rather than overflow the block — the remainder is
+            // pulled in a later round.
+            if total_bytes + txn_bytes > max_bytes {
                 break;
             }
             total_bytes += txn_bytes;
@@ -513,6 +516,7 @@ mod tests {
                 &self,
                 _f: Option<Box<dyn Fn((ExternalAccountAddress, u64, TxnHash)) -> bool>>,
                 _l: usize,
+                _max_bytes: u64,
             ) -> Box<dyn Iterator<Item = ApiVerifiedTxn>> {
                 Box::new(std::iter::empty())
             }
@@ -735,7 +739,10 @@ mod tests {
                 &self,
                 _f: Option<Box<dyn Fn((ExternalAccountAddress, u64, TxnHash)) -> bool>>,
                 l: usize,
+                _max_bytes: u64,
             ) -> Box<dyn Iterator<Item = ApiVerifiedTxn>> {
+                // Ignore max_bytes here (it's a prefetch hint); return all
+                // candidates so get_batch_inner's authoritative cap is exercised.
                 Box::new(self.0.clone().into_iter().take(l))
             }
             fn get_broadcast_txns(
@@ -784,9 +791,10 @@ mod tests {
         let capped = m.get_batch_inner(2, u64::MAX, true, BTreeMap::new());
         assert_eq!(capped.len(), 2, "max_txns must still cap the batch");
 
-        // At least one txn is always returned, even when it alone exceeds the budget,
-        // so a single large txn can never stall block production.
+        // When the remaining budget is too small for even one txn (e.g. validator
+        // txns already consumed most of the block via MixedPayloadClient), no user
+        // txn is admitted — the batch must never overflow the byte budget.
         let tiny = m.get_batch_inner(100, 1, true, BTreeMap::new());
-        assert_eq!(tiny.len(), 1, "at least one txn must be returned");
+        assert!(tiny.is_empty(), "a txn exceeding the budget must not be admitted");
     }
 }

--- a/bin/gravity_node/src/consensus/mock_consensus/mempool.rs
+++ b/bin/gravity_node/src/consensus/mock_consensus/mempool.rs
@@ -30,7 +30,7 @@ impl Mempool {
             let next_nonce = *next_txns.get(&txn.0).unwrap_or(&0);
             next_nonce <= txn.1
         });
-        for txn in self.pool_txns.best_txns(Some(filter), max_block_size) {
+        for txn in self.pool_txns.best_txns(Some(filter), max_block_size, u64::MAX) {
             let account = txn.sender();
             let nonce = txn.seq_number();
             self.next_sequence_numbers.insert(account.clone(), nonce + 1);

--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -201,55 +201,53 @@ impl TxPool for Mempool {
         let chain_id = self.chain_id;
         // Take last_nonces out to avoid borrow conflict with best_txns iterator
         let mut last_nonces = std::mem::take(&mut best_txns.last_nonces);
+        // Drive the cached iterator by hand so the byte budget is checked *before*
+        // pulling the next item. An adapter like `take_while` would consume (and
+        // record the nonce of) one extra txn past the budget, dropping it until the
+        // cache TTL and letting a later pull propose its successor nonce without it.
+        let iter = best_txns.best_txns.as_mut().unwrap();
+        let mut result: Vec<VerifiedTxn> = Vec::new();
         let mut total_bytes: u64 = 0;
-        let result: Vec<_> = best_txns
-            .best_txns
-            .as_mut()
-            .unwrap()
-            .filter_map(|pool_txn| {
-                let sender = pool_txn.sender();
-                let nonce = pool_txn.nonce();
+        while result.len() < limit && total_bytes < max_bytes {
+            let pool_txn = match iter.next() {
+                Some(txn) => txn,
+                None => break,
+            };
+            let sender = pool_txn.sender();
+            let nonce = pool_txn.nonce();
 
-                // Enforce nonce ordering: skip transactions that are not consecutive
-                if let Some(&last) = last_nonces.get(&sender) {
-                    if nonce != last + 1 {
-                        return None;
-                    }
+            // Enforce nonce ordering: skip transactions that are not consecutive
+            if let Some(&last) = last_nonces.get(&sender) {
+                if nonce != last + 1 {
+                    continue;
                 }
+            }
 
-                // transactions from poisoning nonce tracking
-                let sender_addr = convert_account(sender);
-                if let Some(ref f) = filter {
-                    let hash = TxnHash::from_bytes(pool_txn.hash().as_slice());
-                    if !f((sender_addr.clone(), nonce, hash)) {
-                        return None;
-                    }
+            // transactions from poisoning nonce tracking
+            let sender_addr = convert_account(sender);
+            if let Some(ref f) = filter {
+                let hash = TxnHash::from_bytes(pool_txn.hash().as_slice());
+                if !f((sender_addr.clone(), nonce, hash)) {
+                    continue;
                 }
+            }
 
-                // Only record nonce after filter passes
-                last_nonces.insert(sender, nonce);
+            // Only record nonce after filter passes
+            last_nonces.insert(sender, nonce);
 
-                let verified_txn = to_verified_txn(pool_txn.clone(), chain_id);
-                let tx_hash: [u8; 32] = pool_txn.transaction.transaction().inner().hash().0;
-                // Record the insertion time so the background sweeper can evict entries
-                // that stay uncommitted past the TTL.
-                txn_cache.insert(tx_hash, (Instant::now(), pool_txn));
-                Some(verified_txn)
-            })
-            .take(limit)
-            .take_while(|verified_txn| {
-                // Prefetch hint: stop draining the cached iterator once the
-                // cumulative payload size reaches max_bytes, so a byte-bounded
-                // batch doesn't consume (and drop until TTL) thousands of
-                // over-fetched txns. The authoritative byte cap is applied by
-                // the caller on the fully-serialized txn; payload bytes
-                // under-count that size, so this keeps the crossing txn and
-                // errs toward extra candidates rather than starving the block.
-                let within = total_bytes < max_bytes;
-                total_bytes += verified_txn.bytes().len() as u64;
-                within
-            })
-            .collect();
+            let verified_txn = to_verified_txn(pool_txn.clone(), chain_id);
+            let tx_hash: [u8; 32] = pool_txn.transaction.transaction().inner().hash().0;
+            // max_bytes is a prefetch hint: it caps how far we drain the cached
+            // iterator. It measures payload bytes, which under-count the fully
+            // serialized size the caller (get_batch_inner) enforces authoritatively,
+            // so we keep the txn that crosses the budget and err toward extra
+            // candidates rather than starving the block.
+            total_bytes += verified_txn.bytes().len() as u64;
+            // Record the insertion time so the background sweeper can evict entries
+            // that stay uncommitted past the TTL.
+            txn_cache.insert(tx_hash, (Instant::now(), pool_txn));
+            result.push(verified_txn);
+        }
         // Put last_nonces back
         best_txns.last_nonces = last_nonces;
         if result.is_empty() {

--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -187,6 +187,7 @@ impl TxPool for Mempool {
         &self,
         filter: Option<Box<dyn Fn((ExternalAccountAddress, u64, TxnHash)) -> bool>>,
         limit: usize,
+        max_bytes: u64,
     ) -> Box<dyn Iterator<Item = VerifiedTxn>> {
         let mut best_txns = self.cached_best.lock().unwrap();
         if best_txns.is_expired() || best_txns.best_txns.is_none() {
@@ -200,6 +201,7 @@ impl TxPool for Mempool {
         let chain_id = self.chain_id;
         // Take last_nonces out to avoid borrow conflict with best_txns iterator
         let mut last_nonces = std::mem::take(&mut best_txns.last_nonces);
+        let mut total_bytes: u64 = 0;
         let result: Vec<_> = best_txns
             .best_txns
             .as_mut()
@@ -235,6 +237,18 @@ impl TxPool for Mempool {
                 Some(verified_txn)
             })
             .take(limit)
+            .take_while(|verified_txn| {
+                // Prefetch hint: stop draining the cached iterator once the
+                // cumulative payload size reaches max_bytes, so a byte-bounded
+                // batch doesn't consume (and drop until TTL) thousands of
+                // over-fetched txns. The authoritative byte cap is applied by
+                // the caller on the fully-serialized txn; payload bytes
+                // under-count that size, so this keeps the crossing txn and
+                // errs toward extra candidates rather than starving the block.
+                let within = total_bytes < max_bytes;
+                total_bytes += verified_txn.bytes().len() as u64;
+                within
+            })
             .collect();
         // Put last_nonces back
         best_txns.last_nonces = last_nonces;

--- a/crates/block-buffer-manager/src/block_buffer_manager.rs
+++ b/crates/block-buffer-manager/src/block_buffer_manager.rs
@@ -41,10 +41,19 @@ pub struct TxnItem {
 }
 
 pub trait TxPool: Send + Sync + 'static {
+    /// Return the best transactions to include in a block.
+    ///
+    /// `limit` bounds the number of transactions; `max_bytes` bounds their
+    /// cumulative payload size. `max_bytes` is a prefetch hint used to avoid
+    /// eagerly draining a cached iterator far past the byte budget — the
+    /// consensus-facing byte limit is enforced authoritatively by the caller
+    /// (`Mempool::get_batch_inner`), which measures the fully-serialized
+    /// transaction rather than just the payload bytes.
     fn best_txns(
         &self,
         filter: Option<TxFilterFn>,
         limit: usize,
+        max_bytes: u64,
     ) -> Box<dyn Iterator<Item = VerifiedTxn>>;
 
     fn get_broadcast_txns(
@@ -71,6 +80,7 @@ impl TxPool for EmptyTxPool {
         &self,
         _filter: Option<TxFilterFn>,
         _limit: usize,
+        _max_bytes: u64,
     ) -> Box<dyn Iterator<Item = VerifiedTxn>> {
         Box::new(vec![].into_iter())
     }


### PR DESCRIPTION
Closes Galxe/gravity-audit#862 (GSDK-026)

> Cross-repo reference — GitHub only auto-closes same-repo issues, so #862 must be closed manually on merge.

## Summary

`Mempool::get_batch_inner` accepts a `max_bytes` byte budget but compares it against the **transaction count** instead of cumulative serialized size:

```rust
if transactions.len() >= max_txns as usize || transactions.len() >= max_bytes as usize {
    break;
}
```

Since `max_bytes` (`max_sending_block_bytes` ≈ 30 MB) is orders of magnitude larger than any realistic transaction count, the `>= max_bytes` branch is **dead code** — batches are bounded only by `max_txns`.

## Impact

With `max_sending_block_txns = 15000` and transactions carrying large calldata, a proposer can assemble a payload that exceeds `max_receiving_block_bytes` (30 MB). Receivers reject such proposals in `round_manager::process_proposal`:

```rust
ensure!(
    validator_txns_total_bytes + payload_size as u64 <= self.local_config.max_receiving_block_bytes,
    "Payload size {} exceeds the limit {}", ...
);
```

so the oversized block is never committed (no safety/state issue), but the round is wasted. Under sustained large-transaction load this degrades **liveness/throughput** as successive proposers keep producing rejected blocks.

## Fix

Enforce the byte budget authoritatively in `get_batch_inner` by accumulating `SignedTransaction::raw_txn_bytes_len()` — the same measure `round_manager` uses for `Payload::size()` (`consensus-types/src/common.rs`), so sending-side and receiving-side accounting match exactly — and stop before exceeding `max_bytes`. `max_txns` still caps the batch independently.

Two refinements from review:

- **Never overflow the budget (P1).** Via `MixedPayloadClient`, `max_bytes` is first reduced by validator-txn bytes (`payload_client/mixed.rs`), so it can be smaller than a single txn. `get_batch_inner` therefore does **not** force-include a first txn that exceeds the remaining budget — it returns fewer (possibly zero) user txns and they are pulled in a later round, rather than pushing `validator_txns_bytes + payload_size` past the receiver check.
- **Avoid over-fetch (P2).** The production `TxPool::best_txns` eagerly `.take(limit)`s from a cached reth `BestTransactions` iterator, so a byte-bounded batch used to drain and drop thousands of over-fetched txns until the cache TTL. `max_bytes` is now threaded into `best_txns` as a prefetch hint that stops draining near the budget. It's non-authoritative (payload bytes under-count the fully-serialized size), so it keeps the crossing txn and errs toward extra candidates rather than starving the block; `get_batch_inner` remains the authoritative cap.

## Test

Adds `get_batch_enforces_byte_budget`, covering: the byte budget caps the batch, `max_txns` still caps independently, and a txn exceeding the remaining budget is not admitted (no overflow).

Built with `RUSTFLAGS="--cfg tokio_unstable"`; the mempool unit test and `cargo check --bin gravity_node` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
