### PR TITLE
build: include gravity_cli in node image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,12 +119,12 @@ jobs:
 
       - name: Build gravity_node docker image
         # Uses the `runtime-host-binary` target of docker/gravity_node/Dockerfile,
-        # which COPYs the binary the previous cargo step just produced. BuildKit
+        # which COPYs the binaries the previous cargo step just produced. BuildKit
         # stage pruning skips the `builder` stage entirely — no double compile.
         # Runs on both PR (build-only, no push) and tag pushes.
         #
         # Note: the repo's .dockerignore excludes `target/` from the build
-        # context, so we stage the binary into docker/gravity_node/bin/ (a path
+        # context, so we stage the binaries into docker/gravity_node/bin/ (a path
         # that IS in the context) before invoking `docker build`. This matches
         # the pre-existing pattern used by regression/pfn_chain_stress/run.sh.
         shell: bash
@@ -134,16 +134,19 @@ jobs:
           set -euo pipefail
           mkdir -p docker/gravity_node/bin
           cp -f target/quick-release/gravity_node docker/gravity_node/bin/gravity_node
+          cp -f target/quick-release/gravity_cli docker/gravity_node/bin/gravity_cli
           DOCKER_BUILDKIT=1 docker build \
             --target runtime-host-binary \
             --build-arg HOST_BINARY=docker/gravity_node/bin/gravity_node \
+            --build-arg HOST_CLI_BINARY=docker/gravity_node/bin/gravity_cli \
             -t "${IMAGE_REF}" \
             -f docker/gravity_node/Dockerfile .
+          docker run --rm --entrypoint /usr/local/bin/gravity_cli "${IMAGE_REF}" --version
           echo "--- image size ---"
           docker images --format '{{.Repository}}:{{.Tag}} {{.Size}}' | grep "^${IMAGE_REF}"
-          # Don't leave the binary in the repo working dir after the build —
+          # Don't leave the binaries in the repo working dir after the build —
           # the runner reuses the checkout between jobs.
-          rm -f docker/gravity_node/bin/gravity_node
+          rm -f docker/gravity_node/bin/gravity_node docker/gravity_node/bin/gravity_cli
 
       - name: Resolve tag
         id: tag

--- a/docker/gravity_node/Dockerfile
+++ b/docker/gravity_node/Dockerfile
@@ -2,17 +2,18 @@
 #
 # Two build targets:
 #
-#   1. `runtime` (default) — compile gravity_node from source inside the
-#      container's `builder` stage:
+#   1. `runtime` (default) — compile gravity_node and gravity_cli from source
+#      inside the container's `builder` stage:
 #        docker build -t gravity_node:src \
 #                     -f docker/gravity_node/Dockerfile .
 #
-#   2. `runtime-host-binary` — skip the cargo build; copy a pre-built
-#      binary from the host build context. Used by the release pipeline so
+#   2. `runtime-host-binary` — skip the cargo build; copy pre-built
+#      binaries from the host build context. Used by the release pipeline so
 #      we don't recompile after the runner has already produced a native
-#      binary, and by regression/pfn_chain_stress for the same reason:
+#      binaries, and by regression/pfn_chain_stress for the same reason:
 #        docker build --target runtime-host-binary \
 #                     --build-arg HOST_BINARY=target/quick-release/gravity_node \
+#                     --build-arg HOST_CLI_BINARY=target/quick-release/gravity_cli \
 #                     -t gravity_node:rel \
 #                     -f docker/gravity_node/Dockerfile .
 #
@@ -23,7 +24,6 @@
 FROM rust:1.93-slim-bookworm AS builder
 
 ARG CARGO_PROFILE=release
-ARG CARGO_BIN=gravity_node
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         clang \
@@ -47,12 +47,13 @@ ENV RUSTFLAGS="--cfg tokio_unstable"
 RUN --mount=type=cache,target=/build/target,id=gravity-target \
     --mount=type=cache,target=/usr/local/cargo/registry,id=gravity-cargo-registry \
     --mount=type=cache,target=/usr/local/cargo/git,id=gravity-cargo-git \
-    cargo build --bin "${CARGO_BIN}" --profile "${CARGO_PROFILE}" \
+    cargo build --bin gravity_node --bin gravity_cli --profile "${CARGO_PROFILE}" \
     && mkdir -p /out \
-    && cp "target/${CARGO_PROFILE}/${CARGO_BIN}" /out/gravity_node
+    && cp "target/${CARGO_PROFILE}/gravity_node" /out/gravity_node \
+    && cp "target/${CARGO_PROFILE}/gravity_cli" /out/gravity_cli
 
 # ─── Stage 2: runtime-base (shared apt + user setup + entrypoint) ────
-# Common to both leaf targets. The binary itself is added in the leaves
+# Common to both leaf targets. The binaries are added in the leaves
 # so we can pick the source (builder vs build context) per target.
 FROM ubuntu:24.04 AS runtime-base
 
@@ -79,12 +80,14 @@ ENV GRAVITY_CONFIG_DIR=/gravity/config \
 # COPY can happen as root (default user in runtime-base) before dropping
 # to `gravity`.
 
-# ─── Stage 3a: runtime-host-binary — copy a pre-built host binary ────
+# ─── Stage 3a: runtime-host-binary — copy pre-built host binaries ───
 # Used by the release pipeline and regression/pfn_chain_stress.
 FROM runtime-base AS runtime-host-binary
 
 ARG HOST_BINARY=docker/gravity_node/bin/gravity_node
+ARG HOST_CLI_BINARY=docker/gravity_node/bin/gravity_cli
 COPY --chmod=755 ${HOST_BINARY} /usr/local/bin/gravity_node
+COPY --chmod=755 ${HOST_CLI_BINARY} /usr/local/bin/gravity_cli
 
 USER gravity
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
@@ -96,6 +99,7 @@ CMD ["node"]
 FROM runtime-base AS runtime
 
 COPY --from=builder --chmod=755 /out/gravity_node /usr/local/bin/gravity_node
+COPY --from=builder --chmod=755 /out/gravity_cli /usr/local/bin/gravity_cli
 
 USER gravity
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/docker/gravity_node/README.md
+++ b/docker/gravity_node/README.md
@@ -1,6 +1,7 @@
 # gravity_node Docker Deployment
 
-Binary-only container images for running a `gravity_node` validator or VFN.
+Container images containing `gravity_node` and `gravity_cli` for running a
+validator or VFN and managing node identity during container startup.
 Build the image once, ship it everywhere, mount configuration and chain data
 from the host. Upgrades are a single `docker compose up -d` against a new
 image tag — configuration and chain state persist across restarts.
@@ -9,7 +10,7 @@ image tag — configuration and chain state persist across restarts.
 
 | File | Purpose |
 |---|---|
-| `Dockerfile` | Multi-stage build (`rust:1.93-slim` → `debian:12-slim`). Binary only. Non-root (uid `10001`). `tini` as PID 1. |
+| `Dockerfile` | Multi-stage build (`rust:1.93-slim` → `ubuntu:24.04`). Includes `gravity_node` and `gravity_cli`. Non-root (uid `10001`). `tini` as PID 1. |
 | `entrypoint.sh` | Reads `reth_config.json` (same schema as `cluster/templates/reth_config.json.tpl`) and `exec`s `gravity_node node` in the foreground. |
 | `docker-compose.yaml` | Single-node deployment. Intended for one host running one validator. |
 | `docker-compose.cluster.yaml` | 4 validators + 1 VFN on one host. For end-to-end image verification against `cluster/` artifacts. |
@@ -39,7 +40,9 @@ DOCKER_BUILDKIT=1 docker build --network=host \
 Build arguments:
 
 - `CARGO_PROFILE` — `release` (default) or `performance` (LTO, slower build, faster runtime).
-- `CARGO_BIN` — binary name; defaults to `gravity_node`.
+
+The image always builds and installs both `gravity_node` and `gravity_cli` in
+`/usr/local/bin`.
 
 The `.dockerignore` at the repository root keeps `target/`, `.git/`, and other
 large directories out of the build context.

--- a/regression/pfn_chain_stress/README.md
+++ b/regression/pfn_chain_stress/README.md
@@ -91,12 +91,12 @@ cd regression/pfn_chain_stress
 
 ## How it works
 
-1. **Build on host, wrap in Docker.** `run.sh` first runs
-   `cargo build --bin gravity_node --profile quick-release` on the host
+1. **Build on host, wrap in Docker.** `run.sh` first builds `gravity_node` and
+   `gravity_cli` with the `quick-release` profile on the host
    (incremental — only seconds when sources unchanged), then stages the
-   binary at `docker/gravity_node/bin/gravity_node`. The Docker image is
+   binaries under `docker/gravity_node/bin/`. The Docker image is
    built with `docker/gravity_node/Dockerfile` using `--target
-   runtime-host-binary`, which `COPY`s that binary into an ubuntu:24.04
+   runtime-host-binary`, which `COPY`s both binaries into an ubuntu:24.04
    runtime — image build is ~12s after first time.
 
    In-container builds from source were tried and abandoned: ~65 min

--- a/regression/pfn_chain_stress/run.sh
+++ b/regression/pfn_chain_stress/run.sh
@@ -181,14 +181,16 @@ else
     NODE_SERVICES=(node1 vfn1 pfn1)
 fi
 
-# ── 1. Build host binary + stage into Docker ctx ───────────────────────────
+# ── 1. Build host binaries + stage into Docker ctx ─────────────────────────
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOST_BINARY="$REPO_ROOT/target/quick-release/gravity_node"
+HOST_CLI_BINARY="$REPO_ROOT/target/quick-release/gravity_cli"
 STAGED_BINARY="$REPO_ROOT/docker/gravity_node/bin/gravity_node"
+STAGED_CLI_BINARY="$REPO_ROOT/docker/gravity_node/bin/gravity_cli"
 
-echo "[run] cargo build gravity_node (host, profile=quick-release)…"
+echo "[run] cargo build gravity_node and gravity_cli (host, profile=quick-release)…"
 (cd "$REPO_ROOT" && RUSTFLAGS="--cfg tokio_unstable" \
-    cargo build --bin gravity_node --profile quick-release) \
+    cargo build --bin gravity_node --bin gravity_cli --profile quick-release) \
     || { echo "[run] cargo build failed"; exit 1; }
 
 mkdir -p "$REPO_ROOT/docker/gravity_node/bin"
@@ -197,6 +199,12 @@ if ! cmp -s "$HOST_BINARY" "$STAGED_BINARY" 2>/dev/null; then
     echo "[run] staged binary -> $STAGED_BINARY ($(stat -c %s "$STAGED_BINARY") bytes)"
 else
     echo "[run] staged binary already up-to-date"
+fi
+if ! cmp -s "$HOST_CLI_BINARY" "$STAGED_CLI_BINARY" 2>/dev/null; then
+    cp -f "$HOST_CLI_BINARY" "$STAGED_CLI_BINARY"
+    echo "[run] staged binary -> $STAGED_CLI_BINARY ($(stat -c %s "$STAGED_CLI_BINARY") bytes)"
+else
+    echo "[run] staged CLI binary already up-to-date"
 fi
 
 # Build gravity_node image (shared by all clusters).


### PR DESCRIPTION
## Summary

- build and install `gravity_cli` alongside `gravity_node` in both Docker build targets
- stage both binaries in the release workflow and smoke-test `gravity_cli --version`
- keep the PFN stress image build path compatible and update its documentation

## Why

QuickNode needs `gravity_cli` inside the official node image to generate node identity during container startup. The release pipeline already compiled the CLI artifact, but the Docker packaging step only copied `gravity_node`.

## Validation

- `git diff --check`
- `bash -n regression/pfn_chain_stress/run.sh`
- parsed `.github/workflows/release.yml` with Ruby YAML

A local Docker image build was not run because the local Docker daemon is unavailable. The PR-triggered release workflow performs the image build and CLI smoke test.