### PR TITLE
fix(mempool): anchor per-sender nonce before the in-flight filter

### DIFF
--- a/bin/gravity_node/src/mempool.rs
+++ b/bin/gravity_node/src/mempool.rs
@@ -223,6 +223,15 @@ impl TxPool for Mempool {
                 }
             }
 
+            // Anchor the per-sender nonce for EVERY consecutive tx, BEFORE the
+            // caller's filter runs — including one the filter drops as already
+            // in-flight (its lower nonce was already proposed in an uncommitted
+            // batch and is excluded here via exclude_transactions). Recording only
+            // after the filter would drop this anchor: the next tx from the same
+            // sender would find no last_nonces entry, be treated as first-per-sender,
+            // and bypass the consecutiveness check — letting a future-nonce tx in.
+            last_nonces.insert(sender, nonce);
+
             // transactions from poisoning nonce tracking
             let sender_addr = convert_account(sender);
             if let Some(ref f) = filter {
@@ -231,9 +240,6 @@ impl TxPool for Mempool {
                     continue;
                 }
             }
-
-            // Only record nonce after filter passes
-            last_nonces.insert(sender, nonce);
 
             let verified_txn = to_verified_txn(pool_txn.clone(), chain_id);
             let tx_hash: [u8; 32] = pool_txn.transaction.transaction().inner().hash().0;


### PR DESCRIPTION
## What

In `Mempool::best_txns`, record the per-sender nonce in `last_nonces` **before** the caller-supplied `filter` (the `exclude_transactions` in-flight dedup) runs, instead of only after it passes.

## Why

`best_txns` enforces per-sender nonce consecutiveness with `last_nonces`: the first tx seen for a sender is admitted at any nonce, every subsequent tx must be exactly `last + 1`.

The nonce was recorded **after** the `filter` check. So when the filter drops a tx as already-in-flight — its lower nonce was already proposed in an uncommitted batch and is excluded here via `exclude_transactions` — that tx's nonce was never recorded. The next tx from the same sender then found no `last_nonces` entry, was treated as *first-per-sender*, and skipped the consecutiveness check entirely, letting a gapped / future-nonce tx slip into the batch behind a filtered-out lower one.

Moving the `insert` to right after the consecutiveness check keeps the anchor intact for **every** consecutive tx, including the filtered in-flight one.

Order-then-execute already self-heals the downstream effect (the in-flight lower-nonce tx commits ahead, and execution enforces nonce order), and reth's `best_transactions()` yields per-sender nonces consecutively, so this is a **defense-in-depth** tightening of the mempool ordering guard, not a liveness/safety fix. No behavior change on the common path (a sender with no filtered txs is unaffected).

## Relationship to #777 / #788

This re-applies #777 on top of the `best_txns` while-loop rewrite that landed in #788. #788 restructured the function (`filter_map` → explicit `while` loop) but preserved the original insert-after-filter ordering, so #777's one-line diff no longer applies cleanly. This PR carries the same fix, rebased onto the current `best_txns`, with credit to @Richard1048576. #777 can be closed as superseded.

## Test

`RUSTFLAGS="--cfg tokio_unstable" cargo check --bin gravity_node` passes. The consecutiveness path is exercised by existing `best_txns` selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)