### PR TITLE
fix(quorum-store): guard adjacent-epoch computation against overflow

### DIFF
--- a/aptos-core/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/aptos-core/consensus/src/quorum_store/quorum_store_builder.rs
@@ -440,10 +440,10 @@ impl InnerBuilder {
                     // batch with the same digest under the adjacent epoch, so the local
                     // copy may be stored under a neighboring epoch key. Serving it is
                     // safe: the requester verifies the response against the digest.
-                    for adjacent_epoch in [req_epoch + 1, req_epoch.saturating_sub(1)] {
-                        if adjacent_epoch == req_epoch {
-                            continue;
-                        }
+                    // checked_{add,sub} keeps this network-facing path panic-free on
+                    // malformed u64::MAX / 0 requests in overflow-check builds.
+                    let adjacent_candidates = [req_epoch.checked_add(1), req_epoch.checked_sub(1)];
+                    for adjacent_epoch in adjacent_candidates.into_iter().flatten() {
                         batch_result = batch_store.get_batch_from_local(
                             &quorum_store::types::BatchKey::new(adjacent_epoch, req_digest),
                         );


### PR DESCRIPTION
## Summary

Follow-up to #779. `req_epoch` is taken from a network request, so the raw `+ 1` / `- 1` arithmetic on the adjacent-epoch batch fallback can panic in overflow-check builds if a peer sends a malformed `u64::MAX` (or `0`) request.

Compute the adjacent candidates with `checked_add(1)` / `checked_sub(1)` and flatten out `None`, keeping the network-facing `batch_serve` path panic-free.

The explicit `adjacent_epoch == req_epoch` guard is no longer needed — `checked_sub(1)` on `0` returns `None` instead of wrapping back to `req_epoch`, and `checked_add(1)` never returns `req_epoch` on the `u64` domain.

Addresses https://github.com/Galxe/gravity-sdk/pull/779#issuecomment-4999909199 (thanks @Lchangliang).

## Test plan
- [x] `cargo check` on `aptos-consensus` with `RUSTFLAGS="--cfg tokio_unstable"` — clean
- [ ] CI green