### PR TITLE
build: add curl to node image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
             -t "${IMAGE_REF}" \
             -f docker/gravity_node/Dockerfile .
           docker run --rm --entrypoint /usr/local/bin/gravity_cli "${IMAGE_REF}" --version
+          docker run --rm --entrypoint /usr/bin/curl "${IMAGE_REF}" --version
           echo "--- image size ---"
           docker images --format '{{.Repository}}:{{.Tag}} {{.Size}}' | grep "^${IMAGE_REF}"
           # Don't leave the binaries in the repo working dir after the build —

--- a/docker/gravity_node/Dockerfile
+++ b/docker/gravity_node/Dockerfile
@@ -59,6 +59,7 @@ FROM ubuntu:24.04 AS runtime-base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
         jq \
         tini \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/gravity_node/README.md
+++ b/docker/gravity_node/README.md
@@ -1,7 +1,8 @@
 # gravity_node Docker Deployment
 
-Container images containing `gravity_node` and `gravity_cli` for running a
-validator or VFN and managing node identity during container startup.
+Container images containing `gravity_node`, `gravity_cli`, and `curl` for
+running a validator or VFN, managing node identity during container startup,
+and executing container health checks.
 Build the image once, ship it everywhere, mount configuration and chain data
 from the host. Upgrades are a single `docker compose up -d` against a new
 image tag — configuration and chain state persist across restarts.
@@ -10,7 +11,7 @@ image tag — configuration and chain state persist across restarts.
 
 | File | Purpose |
 |---|---|
-| `Dockerfile` | Multi-stage build (`rust:1.93-slim` → `ubuntu:24.04`). Includes `gravity_node` and `gravity_cli`. Non-root (uid `10001`). `tini` as PID 1. |
+| `Dockerfile` | Multi-stage build (`rust:1.93-slim` → `ubuntu:24.04`). Includes `gravity_node`, `gravity_cli`, and `curl`. Non-root (uid `10001`). `tini` as PID 1. |
 | `entrypoint.sh` | Reads `reth_config.json` (same schema as `cluster/templates/reth_config.json.tpl`) and `exec`s `gravity_node node` in the foreground. |
 | `docker-compose.yaml` | Single-node deployment. Intended for one host running one validator. |
 | `docker-compose.cluster.yaml` | 4 validators + 1 VFN on one host. For end-to-end image verification against `cluster/` artifacts. |
@@ -42,7 +43,7 @@ Build arguments:
 - `CARGO_PROFILE` — `release` (default) or `performance` (LTO, slower build, faster runtime).
 
 The image always builds and installs both `gravity_node` and `gravity_cli` in
-`/usr/local/bin`.
+`/usr/local/bin`. It also includes `curl` for container health checks.
 
 The `.dockerignore` at the repository root keeps `target/`, `.git/`, and other
 large directories out of the build context.


### PR DESCRIPTION
## Summary

- install `curl` in the shared `gravity_node` runtime image
- verify `curl --version` during the release image build
- document that the image includes `curl` for container health checks

## Why

QuickNode uses `curl` in its health check probe. The official image currently includes the node and CLI binaries but does not provide `curl`, requiring downstream consumers to maintain an additional image layer.

## Validation

- `git diff --check`
- parsed `.github/workflows/release.yml` with Ruby YAML

The PR-triggered release workflow will build the image and run `/usr/bin/curl --version`. A local image build was not run because the local Docker daemon is unavailable.