### PR TITLE
fix(consensus): temporarily disable ledger info retrieval check

### DIFF
--- a/aptos-core/consensus/src/network.rs
+++ b/aptos-core/consensus/src/network.rs
@@ -257,14 +257,22 @@ impl NetworkSender {
             ConsensusMsg::BlockRetrievalResponse(resp) => *resp,
             _ => return Err(anyhow!("Invalid response to request")),
         };
-        response.verify_ledger_infos(&retrieval_request, &self.validators).map_err(|e| {
-            error!(
-                SecurityEvent::InvalidRetrievedBlock,
-                request_block_response = response,
-                error = ?e,
-            );
-            e
-        })?;
+        // TODO(next release): Re-enable this after LedgerInfo exposes the committed suffix block
+        // number separately from the epoch-change anchor number. For an epoch-change suffix LI,
+        // `LedgerInfo::block_number()` intentionally returns `EpochBlockInfo::block_number`, while
+        // the retrieval response associates the LI's commit block ID with the suffix block number.
+        // The current verifier therefore rejects valid responses (for example, suffix block 2557
+        // carrying epoch-change anchor 2556), which prevents nodes from catching up across an epoch
+        // boundary during a rolling upgrade.
+        //
+        // response.verify_ledger_infos(&retrieval_request, &self.validators).map_err(|e| {
+        //     error!(
+        //         SecurityEvent::InvalidRetrievedBlock,
+        //         request_block_response = response,
+        //         error = ?e,
+        //     );
+        //     e
+        // })?;
         if retrieval_request.block_id() != HashValue::zero() {
             response.verify(retrieval_request, &self.validators).map_err(|e| {
                 error!(


### PR DESCRIPTION
## Summary

- temporarily disable the `verify_ledger_infos()` call during block retrieval
- keep the verifier implementation in place for a follow-up fix
- document the epoch-change suffix block mismatch and the condition for re-enabling validation

## Root cause

For an epoch-change suffix LedgerInfo, `LedgerInfo::block_number()` intentionally returns the `EpochBlockInfo` anchor height. The block retrieval response associates the LedgerInfo's commit block ID with the suffix block height instead. Comparing those values rejects a valid response, for example suffix block 2557 carrying epoch-change anchor 2556.

A restarted or lagging node then cannot retrieve blocks across the epoch boundary and remains stuck while peers continue advancing.

## Impact

This temporary compatibility change allows v1.7 rolling upgrades and catch-up across epoch boundaries. LedgerInfo verification is intentionally left implemented but disabled at its call site until the next release can expose and validate the raw committed suffix block number.

## Validation

- `cargo +nightly fmt --all -- --check`
- `RUSTFLAGS='--cfg tokio_unstable' cargo check -p 'path+file:///Users/lightman/repos/gravity-sdk/aptos-core/consensus#aptos-consensus@0.1.0' --lib`
