### PR TITLE
fix(consensus): stop reading legacy consensusAlpha epoch key from genesis

### DIFF
--- a/bin/gravity_node/src/chainspec.rs
+++ b/bin/gravity_node/src/chainspec.rs
@@ -7,8 +7,9 @@
 //! - The constructed [`ChainSpec`] (and its derived `genesis_header`, `fork_id`, `fork_filter`)
 //!   reflects the binary's authoritative values from the moment the `Arc<ChainSpec>` is built — no
 //!   post-construction mutation, no `Arc::get_mut`, no `OnceLock` timing pain.
-//! - The CL side (gaptos `ConsensusHardforks::from_genesis_extra_fields`) reads from the **same**
-//!   mutated `extra_fields`, so EL and CL see one consistent view from a single source of truth.
+//! - The CL side (main.rs `consensus_hardforks_from_genesis_extra_fields`) reads `alphaTime` from
+//!   the **same** mutated `extra_fields`, so EL and CL see one consistent view from a single source
+//!   of truth.
 //!
 //! For named chains (`mainnet` / `sepolia` / `holesky` / `hoodi` / `dev`)
 //! we delegate to upstream [`EthereumChainSpecParser`] unchanged — those
@@ -71,8 +72,8 @@ struct GravityForkOverrides {
     /// Maps to `genesis.config.prague_time` (typed field on `ChainConfig`).
     prague_time: Option<u64>,
     /// Maps to `genesis.config.extra_fields["alphaTime"]`. EL reads this in
-    /// `From<Genesis>`; the CL side reads the same key in
-    /// `ConsensusHardforks::from_genesis_extra_fields`.
+    /// `From<Genesis>`; the CL side reads the same key in main.rs's
+    /// `consensus_hardforks_from_genesis_extra_fields`.
     alpha_time: Option<u64>,
 }
 
@@ -310,8 +311,8 @@ mod tests {
     fn mainnet_forces_alpha_removed_when_genesis_supplies_alpha_time() {
         // After the parser runs, alphaTime must be removed from the
         // preserved Genesis. Both EL `From<Genesis>` and CL
-        // `from_genesis_extra_fields` read from this same `extra_fields`
-        // map, so a single removal forward-defends both layers.
+        // `consensus_hardforks_from_genesis_extra_fields` read from this same
+        // `extra_fields` map, so a single removal forward-defends both layers.
         let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, None, Some(100));
         assert!(
             cs.genesis().config.extra_fields.get("alphaTime").is_none(),

--- a/bin/gravity_node/src/main.rs
+++ b/bin/gravity_node/src/main.rs
@@ -73,10 +73,13 @@ struct ConsensusArgs<EthApi: RethEthCall> {
     pub pool: RethTransactionPool,
 }
 
+// ConsensusAlpha is activated by the genesis `alphaTime` field (seconds,
+// registered as a microsecond Timestamp). It is the only genesis field the
+// CL reads for Alpha (Galxe/gravity-audit#925).
 fn consensus_hardforks_from_genesis_extra_fields(
     get_extra_field: impl Fn(&str) -> Option<u64>,
 ) -> ConsensusHardforks {
-    let mut hardforks = ConsensusHardforks::from_genesis_extra_fields(&get_extra_field);
+    let mut hardforks = ConsensusHardforks::new();
 
     if let Some(alpha_time_secs) = get_extra_field("alphaTime") {
         hardforks.insert(
@@ -405,5 +408,42 @@ fn main() {
     if let Err(err) = coordinator_result {
         eprintln!("Reth coordinator stopped with error: {err}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards the audit fix (Galxe/gravity-audit#925): the CL builds Alpha's
+    /// activation solely from `alphaTime`. The closure below supplies a value
+    /// for every field EXCEPT `alphaTime`, so if the CL ever read any other
+    /// genesis field, Alpha would register a condition and this test would go
+    /// red.
+    #[test]
+    fn only_alpha_time_activates_consensus_alpha() {
+        let hardforks =
+            consensus_hardforks_from_genesis_extra_fields(|key| (key != "alphaTime").then_some(0));
+
+        assert_eq!(
+            hardforks.condition(ConsensusHardfork::ConsensusAlpha),
+            ForkCondition::Never,
+            "no genesis field other than alphaTime may activate Alpha",
+        );
+        assert!(!hardforks.is_active_at_epoch(ConsensusHardfork::ConsensusAlpha, 0));
+    }
+
+    /// `alphaTime` (seconds) is read as a microsecond timestamp condition.
+    #[test]
+    fn alpha_time_registers_timestamp_condition() {
+        let hardforks = consensus_hardforks_from_genesis_extra_fields(|key| match key {
+            "alphaTime" => Some(1_782_709_200),
+            _ => None,
+        });
+
+        assert_eq!(
+            hardforks.condition(ConsensusHardfork::ConsensusAlpha),
+            ForkCondition::Timestamp(1_782_709_200_000_000),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Stop reading the legacy `consensusAlpha` epoch key from genesis when
building consensus-layer hardforks.

`consensus_hardforks_from_genesis_extra_fields` seeded the hardfork set
via gaptos `ConsensusHardforks::from_genesis_extra_fields`, which read a
`consensusAlpha` field and registered `ConsensusAlpha` as a
`ForkCondition::Epoch`. That was a second activation path the chainspec
override table (`bin/gravity_node/src/chainspec.rs`) does not police: a
mainnet genesis carrying `consensusAlpha: 0` activates Alpha from epoch 0
even though the override pins Alpha off (`alpha_time: None`), producing a
silent consensus divergence (the field is in `config.extra_fields` and
does not affect genesis hash / fork_id).

Build the set from `ConsensusHardforks::new()` and read only `alphaTime`,
making this the single genesis-field → `ForkCondition` mapping. The
regression test supplies a value for every genesis field except
`alphaTime`, so any reintroduced non-`alphaTime` activation field turns
it red.

## EL/CL Alpha key alignment

This also realigns Alpha's activation key across the two layers, matching
how Prague is handled. Prague is a single-key, override-controlled fork:
`prague_time` → EL `EthereumHardfork::Prague`, no CL counterpart. After
this change Alpha has the same shape — a single genesis key `alphaTime`
read from the same post-override `extra_fields` on both layers:

- EL: greth `From<Genesis>` reads `extra_fields["alphaTime"]` →
  `GravityHardfork::Alpha` = `Timestamp(secs)` (compared against the EL
  block timestamp, in seconds).
- CL: this function reads `extra_fields["alphaTime"]` →
  `ConsensusAlpha` = `Timestamp(secs * 1_000_000)` (compared against
  `BlockInfo.timestamp_usecs`, in microseconds).

The `* 1_000_000` is the seconds→microseconds adapter for the two
timebases; both fire at the same wall-clock instant. The mainnet
override's single `alphaTime` removal (`alpha_time: None`) therefore
forward-defends both layers. The old `consensusAlpha` epoch key was the
one activation path with no EL counterpart and outside the override
table — i.e. the source of the misalignment this PR removes.

## Verification

- `RUSTFLAGS="--cfg tokio_unstable" cargo test -p gravity_node --bin gravity_node` — 23 pass (incl. 2 new).
- Confirmed red→green: against the old `from_genesis_extra_fields` base the new test fails with `left: Epoch(0)` vs `right: Never`.

## Coordination

This closes the exploit at the node regardless of the pinned gaptos rev
(the binary no longer reads `consensusAlpha`). Paired with
Galxe/gravity-aptos PR that deletes the now-unused reader; bump the gaptos
rev to that PR's merged SHA as a follow-up to drop the dead method from
the dependency graph.

Ref: Galxe/gravity-audit#925
