### PR TITLE
perf(mempool): hand out snapshot shards via Arc instead of deep-copying

### DIFF
--- a/aptos-core/mempool/src/core_mempool/mempool.rs
+++ b/aptos-core/mempool/src/core_mempool/mempool.rs
@@ -88,7 +88,10 @@ impl TxnCache {
 /// bucket. Amortises N peer × M bucket × 2 priority `pool.pending_*` calls
 /// down to ≈ one per `max_age` window. See impl-d §5.
 struct Snapshot {
-    shards: HashMap<MempoolSenderBucket, Vec<SnapshotEntry>>,
+    /// `Arc` so `read_timeline` can carry a shard out of the snapshot lock
+    /// with one refcount bump instead of deep-copying every `SignedTransaction`
+    /// in the bucket — the copy is paid only for the txns actually dispatched.
+    shards: HashMap<MempoolSenderBucket, Arc<Vec<SnapshotEntry>>>,
     taken_at: Instant,
     max_age: Duration,
     /// False until the first refresh runs, so `read_timeline` can tell
@@ -188,7 +191,7 @@ impl CoreMempoolTrait for Mempool {
             topo.priority_count_for_bucket(sender_bucket)
         };
 
-        let shard: Vec<SnapshotEntry> = {
+        let shard: Arc<Vec<SnapshotEntry>> = {
             let mut snap = self.snapshot.lock().unwrap();
             if !snap.initialized || snap.taken_at.elapsed() >= snap.max_age {
                 self.refresh_snapshot_locked(&mut snap);
@@ -200,7 +203,7 @@ impl CoreMempoolTrait for Mempool {
         let mut out: Vec<(SignedTransaction, u64)> = Vec::with_capacity(count.min(shard.len()));
         let mut cache = self.txn_cache.lock().unwrap();
 
-        for entry in shard {
+        for entry in shard.iter() {
             if out.len() >= count {
                 break;
             }
@@ -237,7 +240,7 @@ impl CoreMempoolTrait for Mempool {
                 }
                 continue;
             }
-            out.push((entry.txn, 0));
+            out.push((entry.txn.clone(), 0));
             cache.entries.insert(
                 entry.hash,
                 CacheEntry { last_dispatched_at: now, last_target: target_slot, dispatched: true },
@@ -366,7 +369,7 @@ impl Mempool {
             let signed: SignedTransaction = VerifiedTxn::from(txn).into();
             shards.entry(bucket).or_default().push(SnapshotEntry { hash, txn: signed });
         }
-        snap.shards = shards;
+        snap.shards = shards.into_iter().map(|(bucket, txns)| (bucket, Arc::new(txns))).collect();
         snap.taken_at = Instant::now();
         snap.initialized = true;
 
@@ -655,6 +658,47 @@ mod tests {
                 "bucket {k} should see exactly its own txn"
             );
         }
+    }
+
+    #[test]
+    fn count_truncation_leaves_remainder_untouched() {
+        // Locks the `count` cutoff invariant: once `out.len() == count` the loop
+        // breaks, and every entry past the break point must stay *completely*
+        // untouched — not dispatched, and crucially not written into the cache.
+        // A stray cache write there would suppress those txns for a full TTL
+        // even though they were never broadcast.
+        //
+        // The other tests all run with shards[0].len() < count, so this is the
+        // only one that executes the `if out.len() >= count { break; }` branch.
+        let txns = Arc::new(StdMutex::new(vec![
+            mk_txn(0, 0, 50),
+            mk_txn(0, 1, 51),
+            mk_txn(0, 2, 52),
+            mk_txn(0, 3, 53),
+            mk_txn(0, 4, 54),
+        ]));
+        let m = mempool_with(txns, Duration::from_secs(60), Duration::from_millis(20), 1);
+
+        // First read is capped at count=3 even though shards[0].len() == 5.
+        assert_eq!(
+            read(&m, 0, BroadcastPeerPriority::Primary, 3).len(),
+            3,
+            "count must cap the batch"
+        );
+        assert_eq!(
+            m.txn_cache.lock().unwrap().entries.len(),
+            3,
+            "entries skipped by the count cutoff must not enter the cache"
+        );
+
+        // Second read: the first 3 are suppressed in-TTL, so the 2 that the
+        // cutoff skipped are still eligible and come back now.
+        assert_eq!(
+            read(&m, 0, BroadcastPeerPriority::Primary, 3).len(),
+            2,
+            "the truncated remainder must be dispatched on the next call"
+        );
+        assert_eq!(m.txn_cache.lock().unwrap().entries.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`read_timeline` cloned the whole sender-bucket shard out of the snapshot on every call — a heap copy of every `SignedTransaction` in that bucket, `GTxnBytes` payload included — and it did so **before** any filtering ran. In steady state nearly every entry is suppressed by the TTL cache, so the copy was paid for transactions that were never broadcast.

That clone existed only to carry the shard out of the snapshot mutex before the filter loop, so an `Arc` serves the same purpose: shards are stored as `Arc<Vec<SnapshotEntry>>` and `read_timeline` takes one refcount bump instead. The per-txn copy now happens only for entries actually dispatched, bounded by `count` (`shared_mempool_batch_size`, default 300) rather than by shard length.

## Why it matters

This sits on a hot serialized path. `determine_broadcast_batch` takes the global `smp.mempool` mutex and holds it across every `read_timeline` call, so the copy was contending with consensus `get_batch` and inbound `add_txn`.

Call-rate arithmetic from config defaults (`num_sender_buckets = 4`, `default_failovers = 1`, `shared_mempool_tick_interval_ms = 10`):

```
slots        = num_sender_buckets × (1 + default_failovers) = 8
read_timeline calls/s = 8 × (1000 / 10) = 800
```

Each call previously deep-copied `shards[k].len() ≈ N_pending / 4` transactions:

| `N_pending` | copies/s (before) | copies/s (after) |
|---:|---:|---:|
| 1,000 | 200 K | ≤ `out.len()` per call — 0 when everything is TTL-suppressed |
| 10,000 | 2 M | same |
| 100,000 | 20 M | same |

> These are derived from config defaults, **not** a measured benchmark. The point is the scaling: the old cost was `O(shards[k].len())` per call regardless of how many transactions were actually broadcast; the new cost is `O(out.len())`.

## Changes

`aptos-core/mempool/src/core_mempool/mempool.rs` only (+49 / −5):

| | |
|---|---|
| `Snapshot.shards` | `HashMap<_, Vec<SnapshotEntry>>` → `HashMap<_, Arc<Vec<SnapshotEntry>>>` |
| `refresh_snapshot_locked` | buckets still accumulate into `Vec`; wrapped in `Arc` on write-back |
| `read_timeline` | local binding is now `Arc<Vec<SnapshotEntry>>`; the `.cloned().unwrap_or_default()` line is unchanged (`Arc<Vec<T>>: Default` holds, so the empty-bucket path still works) |
| `read_timeline` | `for entry in shard` → `for entry in shard.iter()` |
| `read_timeline` | `out.push((entry.txn, 0))` → `out.push((entry.txn.clone(), 0))` |

No ownership churn elsewhere: `TxnHash` is `Copy`, so the three cache `get` / `entry` / `insert` sites read it straight off `&SnapshotEntry` unchanged.

Behaviour is unchanged — same four-state filter, same TTL semantics, same lazy GC, same return shape.

### Residual cost

Entries that *are* dispatched still get a full `SignedTransaction` clone. That is unavoidable here: `CoreMempoolTrait::read_timeline` returns owned `Vec<(SignedTransaction, u64)>`, and the broadcast message (`MempoolSyncMsg::BroadcastTransactionsRequest`) owns them too.

## Test coverage

Adds `count_truncation_leaves_remainder_untouched`. Every pre-existing test in this module runs with `shards[0].len() < count`, so the `if out.len() >= count { break; }` branch had **no** coverage. The new test pins the invariant that entries skipped by the cutoff are neither dispatched nor written into the cache — a stray cache write there would suppress them for a full TTL despite never having been sent.

## Test plan

```
RUSTFLAGS="--cfg tokio_unstable" cargo test -p aptos-mempool core_mempool::mempool
```

```
running 12 tests
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

- [x] 12/12 pass (11 pre-existing + 1 new)
- [ ] Reviewer: confirm no behavioural drift under load — this change is argued from the type system (the only semantic delta is *when* the copy happens), and is not covered by a throughput benchmark.
