### PR TITLE
feat(oracle): wire generic relayer runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "abstract-domain-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -50,7 +50,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -62,7 +62,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -151,15 +151,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "num_enum",
+ "phf 0.14.0",
  "serde",
- "strum 0.27.2",
 ]
 
 [[package]]
@@ -168,13 +168,40 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59094911f05dbff1cf5b29046a00ef26452eccc8d47136d50a47c0cf22f00c85"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.0.37",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
  "alloy-trie",
- "alloy-tx-macros",
+ "alloy-tx-macros 1.0.37",
  "auto_impl",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
+dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "alloy-trie",
+ "alloy-tx-macros 2.0.5",
+ "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
@@ -194,11 +221,25 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903cb8f728107ca27c816546f15be38c688df3c381d7bd1a4a9f215effc1ddb4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.0.37",
+ "alloy-eips 1.0.37",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -208,16 +249,16 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03df5cb3b428ac96b386ad64c11d5c6e87a5505682cf1fbd6f8f773e9eda04f6"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.0.37",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-network 1.0.37",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
+ "alloy-provider 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.0.41",
  "futures",
  "futures-util",
  "serde_json",
@@ -226,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -238,7 +279,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -256,26 +297,56 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "k256",
  "serde",
  "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
  "thiserror 2.0.18",
 ]
 
@@ -290,8 +361,32 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
  "auto_impl",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928 0.3.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
@@ -300,50 +395,48 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.21.3"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1bfade4de9f464719b5aca30cf5bb02b9fda7036f0cf43addc3a0e66a0340c"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.1.1",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1421f6c9d15e5b86afbfe5865ca84dea3b9f77173a0963c1a2ee4e626320ada9"
+checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
+ "borsh",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.3.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889eb3949b58368a09d4f16931c660275ef5fb08e5fbd4a96573b19c7085c41f"
+checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -355,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -381,21 +474,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f59a869fa4b4c3a7f08b1c8cb79aec61c29febe6e24a24fe0fcfded8a9b5703"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.37",
+ "alloy-consensus-any 1.0.37",
+ "alloy-eips 1.0.37",
+ "alloy-json-rpc 1.0.41",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
+ "alloy-rpc-types-any 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-serde 1.0.37",
+ "alloy-signer 1.0.41",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-consensus-any 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types-any 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "alloy-signer 2.0.5",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -412,27 +546,41 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e9374c667c95c41177602ebe6f6a2edd455193844f011d973d374b65501b38"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.0.37",
+ "alloy-eips 1.0.37",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 1.0.37",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9485c56de23438127a731a6b4c87803d49faf1a7068dcd1d8768aca3a9edb9"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 2.1.1",
- "foldhash 0.1.5",
- "getrandom 0.3.4",
- "hashbrown 0.15.5",
+ "fixed-cache",
+ "foldhash 0.2.0",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "itoa",
  "k256",
@@ -440,11 +588,12 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.9.2",
+ "rapidhash",
  "ruint",
  "rustc-hash 2.1.1",
+ "secp256k1 0.31.1",
  "serde",
- "sha3 0.10.8",
- "tiny-keccak",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -454,25 +603,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77818b7348bd5486491a5297579dbfe5f706a81f8e1f5976393025f1e22a7c7d"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.37",
+ "alloy-eips 1.0.37",
+ "alloy-json-rpc 1.0.41",
+ "alloy-network 1.0.37",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
- "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-client 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-signer 1.0.41",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
+ "alloy-transport 1.0.41",
+ "alloy-transport-http 1.0.37",
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -490,14 +636,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-pubsub"
-version = "1.0.41"
+name = "alloy-provider"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e45a68423e732900a0c824b8e22237db461b79d2e472dd68b7547c16104427"
+checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-chains",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-network-primitives 2.0.5",
  "alloy-primitives",
- "alloy-transport",
+ "alloy-pubsub",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types-debug",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-rpc-types-trace",
+ "alloy-signer 2.0.5",
+ "alloy-sol-types",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.5",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap 6.2.1",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "pin-project",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd85cfea1fa8ebd20d3475e961fe3a3624c0eb4659ea137715c0c83c8aeaff0"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
+ "alloy-primitives",
+ "alloy-transport 2.0.5",
  "auto_impl",
  "bimap",
  "futures",
@@ -539,16 +729,39 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2430d5623e428dd012c6c2156ae40b7fe638d6fca255e3244e0fba51fa698e93"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.0.41",
+ "alloy-primitives",
+ "alloy-transport 1.0.41",
+ "alloy-transport-http 1.0.37",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.5",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
@@ -566,17 +779,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e131624d08a25cfc40557041e7dc42e1182fa1153e7592d120f769a1edce56"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-serde 1.0.37",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
+dependencies = [
+ "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59407723b1850ebaa49e46d10c2ba9c10c10b3aedf2f7e97015ee23c3f4e639"
+checksum = "ef669b370940e7945a3a384cc4024038cd69ee658b71270d59c20b78dd8d20d4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -586,13 +811,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65e3266095e6d8e8028aab5f439c6b8736c5147314f7e606c61597e014cb8a0"
+checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -602,20 +827,36 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07429a1099cd17227abcddb91b5e38c960aaeb02a6967467f5bb561fbe716ac6"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-consensus-any 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-serde 1.0.37",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
+dependencies = [
+ "alloy-consensus-any 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e0e876b20eb9debf316d3e875536f389070635250f22b5a678cf4632a3e0cf"
+checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
@@ -628,11 +869,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.41"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388cf910e66bd4f309a81ef746dcf8f9bca2226e3577890a8d56c5839225cf46"
+checksum = "5ff0a296b58194c7464aa56f2bdad065c5a24b43a6de5d62b8a985ae3969ecd0"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more 2.1.1",
  "serde",
  "serde_with",
@@ -640,19 +882,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ecadcea6aac65e75e32b6735635ee98517aa63b111849ee01ae988a71d685"
+checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken 10.4.0",
  "rand 0.8.5",
  "serde",
  "strum 0.27.2",
@@ -664,13 +906,34 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db46b0901ee16bbb68d986003c66dcb74a12f9d9b3c44f8e85d51974f2458f0f"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.37",
+ "alloy-consensus-any 1.0.37",
+ "alloy-eips 1.0.37",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-consensus-any 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -681,28 +944,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a60d4baadd3f278faa4e2305cca095dfd4ab286e071b768ff09181d8ae215"
+checksum = "ed1004c1d68bfaee001712f83356f88031ab74a727b8560fb7fc738d1281ebe5"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f10620724bd45f80c79668a8cdbacb6974f860686998abce28f6196ae79444"
+checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -710,13 +973,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864f41befa90102d4e02327679699a7e9510930e2924c529e31476086609fa89"
+checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -725,6 +988,17 @@ name = "alloy-serde"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5413814be7a22fbc81e0f04a2401fcc3eb25e56fd53b04683e8acecc6e1fe01b"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -747,15 +1021,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alloy-signer-local"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6006c4cbfa5d08cadec1fcabea6cb56dc585a30a9fce40bcf81e307d6a71c8e"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.0.37",
+ "alloy-network 1.0.37",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 1.0.41",
  "async-trait",
  "k256",
  "rand 0.8.5",
@@ -763,14 +1052,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-macro"
-version = "1.5.4"
+name = "alloy-signer-local"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
+checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-primitives",
+ "alloy-signer 2.0.5",
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -778,27 +1086,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.4"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
+checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.13.0",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "sha3 0.10.8",
+ "sha3 0.11.0",
  "syn 2.0.114",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.4"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
 dependencies = [
  "const-hex",
  "dunce",
@@ -812,19 +1120,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.4"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b91b13181d3bcd23680fd29d7bc861d1f33fbe90fdd0af67162434aeba902d"
+checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -838,8 +1146,31 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "025a940182bddaeb594c26fe3728525ae262d0806fe6a4befdf5d7bc13d54bce"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.0.41",
  "alloy-primitives",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more 2.1.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "auto_impl",
  "base64 0.22.1",
  "derive_more 2.1.1",
@@ -862,8 +1193,8 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f8a6338d594f6c6481292215ee8f2fd7b986c80aba23f3f44e761a8658de78"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 1.0.41",
+ "alloy-transport 1.0.41",
  "reqwest 0.12.28",
  "serde_json",
  "tower 0.5.3",
@@ -872,14 +1203,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ipc"
-version = "1.0.41"
+name = "alloy-transport-http"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47962f3f1d9276646485458dc842b4e35675f42111c9d814ae4711c664c8300"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 2.0.5",
+ "alloy-transport 2.0.5",
+ "itertools 0.14.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "reqwest 0.13.1",
+ "serde_json",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-opentelemetry",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb89df168b24773ef603af14f2449c05a7d3f27d05d3eceaea6bf96cccae168"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "bytes",
  "futures",
  "interprocess",
@@ -893,31 +1243,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.41"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9476a36a34e2fb51b6746d009c53d309a186a825aa95435407f0e07149f4ad2d"
+checksum = "33e32e0b47d3b3bf5770b7c132090c614b008d307c5e1544f1925f5b7e9e9af6"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "futures",
  "http 1.4.0",
  "rustls 0.23.36",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec 0.7.6",
  "derive_more 2.1.1",
  "nybbles",
  "serde",
@@ -933,6 +1283,18 @@ source = "git+https://github.com/alloy-rs/alloy?tag=v1.0.37#8f6c1489f89e90649dac
 dependencies = [
  "alloy-primitives",
  "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
+dependencies = [
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1074,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "api-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1094,9 +1456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -1109,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "aptos-accumulator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1119,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "aptos-aggregator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-types",
  "bcs 0.1.4",
@@ -1132,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "aptos-api"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -1143,7 +1514,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-global-constants",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-sdk",
@@ -1173,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "aptos-api-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1203,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "aptos-bcs-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "hex",
@@ -1212,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "aptos-bitvec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "proptest",
  "serde",
@@ -1222,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1260,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "aptos-block-partitioner"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -1283,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "aptos-bounded-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "futures",
  "rustversion",
@@ -1293,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "aptos-build-info"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "shadow-rs",
 ]
@@ -1301,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "aptos-cached-packages"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -1315,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "aptos-channels"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -1326,12 +1697,12 @@ dependencies = [
 [[package]]
 name = "aptos-collections"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 
 [[package]]
 name = "aptos-compression"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -1343,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "aptos-config"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1436,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -1445,25 +1816,25 @@ dependencies = [
  "aptos-collections",
  "aptos-config",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-schemadb",
  "aptos-secure-storage",
  "aptos-short-hex-str",
@@ -1514,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-runtimes",
@@ -1552,13 +1923,13 @@ dependencies = [
 [[package]]
 name = "aptos-consensus-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-short-hex-str",
@@ -1580,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "aptos-crash-handler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-logger",
  "backtrace",
@@ -1592,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1646,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "aptos-crypto-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1656,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-config",
  "aptos-crypto",
@@ -1687,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "aptos-data-streaming-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -1713,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "aptos-db"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-accumulator",
@@ -1721,7 +2092,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-db-indexer",
  "aptos-db-indexer-schemas",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-jellyfish-merkle",
@@ -1759,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -1781,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "aptos-db-indexer-schemas"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1798,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "aptos-dkg"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -1830,13 +2201,13 @@ dependencies = [
 [[package]]
 name = "aptos-dkg-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-enum-conversion-derive",
@@ -1847,7 +2218,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -1869,7 +2240,7 @@ dependencies = [
 [[package]]
 name = "aptos-drop-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-infallible",
  "aptos-metrics-core",
@@ -1880,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "aptos-enum-conversion-derive"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1889,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "aptos-event-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "api-types",
@@ -1919,15 +2290,15 @@ dependencies = [
 [[package]]
 name = "aptos-executor"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-block-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-drop-helper",
  "aptos-executor-service",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-experimental-runtimes",
  "aptos-indexer-grpc-table-info",
  "aptos-infallible",
@@ -1950,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-block-executor",
  "aptos-block-partitioner",
@@ -1981,16 +2352,16 @@ dependencies = [
 [[package]]
 name = "aptos-executor-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-db",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-sdk",
  "aptos-storage-interface",
  "aptos-temppath",
@@ -2014,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "aptos-executor-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2039,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-layered-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "ahash 0.8.12",
  "aptos-crypto",
@@ -2054,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "aptos-experimental-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-runtimes",
  "core_affinity",
@@ -2067,7 +2438,7 @@ dependencies = [
 [[package]]
 name = "aptos-fallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2075,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "aptos-framework"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2146,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-algebra"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "either",
  "move-core-types",
@@ -2155,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-meter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2170,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-profiling"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-gas-algebra",
@@ -2190,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "aptos-gas-schedule"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-global-constants",
@@ -2203,17 +2574,17 @@ dependencies = [
 [[package]]
 name = "aptos-global-constants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 
 [[package]]
 name = "aptos-id-generator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 
 [[package]]
 name = "aptos-indexer-grpc-fullnode"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2222,7 +2593,7 @@ dependencies = [
  "aptos-config",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-metrics-core",
  "aptos-moving-average",
  "aptos-protos",
@@ -2242,14 +2613,14 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tonic-reflection",
 ]
 
 [[package]]
 name = "aptos-indexer-grpc-table-info"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-api",
@@ -2259,7 +2630,7 @@ dependencies = [
  "aptos-indexer-grpc-fullnode",
  "aptos-indexer-grpc-utils",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-metrics-core",
  "aptos-runtimes",
  "aptos-storage-interface",
@@ -2281,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-grpc-utils"
 version = "1.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-metrics-core",
@@ -2300,7 +2671,7 @@ dependencies = [
  "lz4",
  "once_cell",
  "prometheus",
- "prost",
+ "prost 0.13.5",
  "redis",
  "redis-test",
  "ripemd",
@@ -2308,7 +2679,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
  "url",
  "warp",
@@ -2317,12 +2688,12 @@ dependencies = [
 [[package]]
 name = "aptos-infallible"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 
 [[package]]
 name = "aptos-inspection-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-build-info",
@@ -2348,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "aptos-jellyfish-merkle"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -2376,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-consensus"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "api-types",
@@ -2384,7 +2755,7 @@ dependencies = [
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
@@ -2395,7 +2766,7 @@ dependencies = [
  "aptos-network",
  "aptos-reliable-broadcast",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-time-service",
  "aptos-types",
  "aptos-validator-transaction-pool",
@@ -2414,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "aptos-jwk-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2429,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "aptos-keygen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2439,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "aptos-language-e2e-tests"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-abstract-gas-usage",
@@ -2485,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "aptos-ledger"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-types",
@@ -2498,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "aptos-log-derive"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2508,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "aptos-logger"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -2534,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "aptos-memory-usage-tracker"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-meter",
@@ -2575,13 +2946,13 @@ dependencies = [
 [[package]]
 name = "aptos-mempool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
  "aptos-channels",
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-event-notifications",
  "aptos-infallible",
@@ -2616,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "aptos-mempool-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-types",
  "async-trait",
@@ -2629,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "aptos-memsocket"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-infallible",
  "bytes",
@@ -2640,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "aptos-metrics-core"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -2649,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "aptos-move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -2674,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "aptos-mvhashmap"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -2695,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "aptos-native-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
@@ -2712,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "aptos-netcore"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-memsocket",
  "aptos-proxy",
@@ -2729,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "aptos-network"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
@@ -2778,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-channels",
  "aptos-config",
@@ -2801,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "aptos-network-discovery"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-channels",
@@ -2826,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "aptos-node-resource-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-build-info",
  "aptos-infallible",
@@ -2843,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "aptos-num-variants"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2853,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "aptos-openapi"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "percent-encoding",
  "poem",
@@ -2865,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "aptos-package-builder"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-framework",
@@ -2878,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "aptos-peer-monitoring-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-config",
  "aptos-types",
@@ -2890,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "aptos-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "crossbeam",
  "proptest",
@@ -2900,18 +3271,18 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "pbjson",
- "prost",
+ "prost 0.13.5",
  "serde",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
 name = "aptos-proxy"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "ipnet",
 ]
@@ -2919,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "aptos-push-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -2931,11 +3302,11 @@ dependencies = [
 [[package]]
 name = "aptos-reliable-broadcast"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-bounded-executor",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-enum-conversion-derive",
  "aptos-infallible",
  "aptos-logger",
@@ -2953,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "aptos-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -2968,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "aptos-rest-client"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -2991,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "aptos-rocksdb-options"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-config",
  "rocksdb",
@@ -3000,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "aptos-runtimes"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "rayon",
  "tokio",
@@ -3028,10 +3399,10 @@ dependencies = [
 [[package]]
 name = "aptos-safety-rules"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-config",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-infallible",
@@ -3052,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "aptos-schemadb"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-drop-helper",
@@ -3069,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "aptos-scratchpad"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-drop-helper",
@@ -3089,7 +3460,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-cached-packages",
@@ -3115,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "aptos-sdk-builder"
 version = "0.2.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -3133,7 +3504,7 @@ dependencies = [
 [[package]]
 name = "aptos-secure-net"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
@@ -3144,14 +3515,14 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "tonic-reflection",
 ]
 
 [[package]]
 name = "aptos-secure-storage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-infallible",
@@ -3172,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "aptos-short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "mirai-annotations",
  "serde",
@@ -3183,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "aptos-speculative-state-helper"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-infallible",
@@ -3194,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "aptos-state-sync-driver"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3203,7 +3574,7 @@ dependencies = [
  "aptos-data-client",
  "aptos-data-streaming-service",
  "aptos-event-notifications",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-infallible",
  "aptos-logger",
  "aptos-mempool-notifications",
@@ -3227,7 +3598,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-interface"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-crypto",
@@ -3255,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-config",
  "aptos-network",
@@ -3266,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-notifications"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-channels",
  "async-trait",
@@ -3278,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "aptos-storage-service-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-compression",
  "aptos-config",
@@ -3294,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "aptos-table-natives"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
@@ -3312,17 +3683,17 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-api",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crypto",
  "aptos-db",
  "aptos-infallible",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-metrics-core",
  "aptos-network",
  "aptos-node-resource-metrics",
@@ -3351,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "aptos-telemetry-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-config",
@@ -3391,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "aptos-temppath"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "hex",
  "rand 0.7.3",
@@ -3400,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "aptos-time-service"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-infallible",
  "enum_dispatch",
@@ -3413,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "aptos-transaction-filter"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-protos",
@@ -3421,7 +3792,7 @@ dependencies = [
  "derive_builder",
  "memchr",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3431,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "aptos-types"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "api-types",
@@ -3495,12 +3866,12 @@ dependencies = [
 [[package]]
 name = "aptos-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 
 [[package]]
 name = "aptos-validator-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-channels",
  "aptos-crypto",
@@ -3513,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "aptos-vault-client"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "base64 0.13.1",
@@ -3529,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-aggregator",
@@ -3581,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-environment"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-framework",
  "aptos-gas-algebra",
@@ -3604,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-genesis"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-cached-packages",
  "aptos-crypto",
@@ -3628,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-logging"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "aptos-crypto",
  "aptos-logger",
@@ -3643,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-types"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -3666,7 +4037,7 @@ dependencies = [
 [[package]]
 name = "aptos-vm-validator"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "aptos-logger",
@@ -3714,6 +4085,12 @@ checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
@@ -4181,9 +4558,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "asn1_der"
@@ -4248,15 +4622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4302,24 +4667,26 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4516,6 +4883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bellpepper"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,7 +4978,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -4613,7 +4986,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.1",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.114",
 ]
 
@@ -4656,9 +5029,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -4671,6 +5044,12 @@ checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -4739,6 +5118,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.6",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,6 +5148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4826,11 +5228,11 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -4841,84 +5243,92 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
+ "aligned-vec",
  "arrayvec 0.7.6",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "boa_ast",
  "boa_gc",
  "boa_interner",
  "boa_macros",
  "boa_parser",
- "boa_profiler",
  "boa_string",
  "bytemuck",
  "cfg-if",
- "dashmap 6.1.0",
+ "cow-utils",
+ "dashmap 6.2.1",
+ "dynify",
  "fast-float2",
- "hashbrown 0.15.5",
- "icu_normalizer 1.5.0",
+ "float16",
+ "futures-channel",
+ "futures-concurrency",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
  "indexmap 2.13.0",
  "intrusive-collections",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "num_enum",
- "once_cell",
- "pollster",
+ "paste",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regress",
  "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
- "sptr",
+ "small_btree",
  "static_assertions",
+ "tag_ptr",
  "tap",
  "thin-vec",
  "thiserror 2.0.18",
  "time",
+ "xsum",
 ]
 
 [[package]]
 name = "boa_gc"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
 dependencies = [
  "boa_macros",
- "boa_profiler",
  "boa_string",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "once_cell",
- "phf 0.11.3",
+ "phf 0.13.1",
  "rustc-hash 2.1.1",
  "static_assertions",
 ]
 
 [[package]]
 name = "boa_macros"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
 dependencies = [
+ "cfg-if",
+ "cow-utils",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -4927,17 +5337,16 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "boa_ast",
  "boa_interner",
  "boa_macros",
- "boa_profiler",
  "fast-float2",
- "icu_properties 1.5.1",
+ "icu_properties",
  "num-bigint 0.4.6",
  "num-traits",
  "regress",
@@ -4945,22 +5354,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "boa_profiler"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
-
-[[package]]
 name = "boa_string"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
 dependencies = [
  "fast-float2",
+ "itoa",
  "paste",
  "rustc-hash 2.1.1",
- "sptr",
+ "ryu-js",
  "static_assertions",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4999,6 +5427,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -5051,6 +5480,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-slice-cast"
@@ -5117,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -5214,14 +5649,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -5250,6 +5685,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -5336,7 +5782,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -5499,6 +5945,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "k256",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec 1.0.1",
+ "coins-bip32",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5511,7 +6008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5541,9 +6038,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -5610,7 +6107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -5670,15 +6167,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -5774,6 +6262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5787,6 +6281,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -5947,31 +6450,19 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "mio 1.1.1",
- "parking_lot 0.12.5",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
+ "derive_more 2.1.1",
  "document-features",
+ "mio 1.2.2",
  "parking_lot 0.12.5",
  "rustix 1.1.3",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi 0.3.9",
 ]
 
@@ -6021,6 +6512,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -6104,7 +6604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -6204,6 +6704,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim 0.11.1",
  "syn 2.0.114",
 ]
@@ -6255,9 +6756,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -6528,8 +7029,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -6576,9 +7087,8 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b4e7798d2ff74e29cee344dc490af947ae657d6ab5273dde35d58ce06a4d71"
+version = "0.10.4"
+source = "git+https://github.com/sigp/discv5?rev=7663c00#7663c00ee0837ea98547caaedede95d9d6736f4d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -6594,13 +7104,12 @@ dependencies = [
  "hkdf 0.12.4",
  "lazy_static",
  "libp2p-identity",
- "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -6613,7 +7122,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -6674,6 +7183,26 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dynify"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
+dependencies = [
+ "dynify-macros",
+]
+
+[[package]]
+name = "dynify-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "ecdsa"
@@ -6766,9 +7295,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -6827,18 +7356,6 @@ dependencies = [
  "serde",
  "sha3 0.10.8",
  "zeroize",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -6947,7 +7464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6961,11 +7478,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_hashing"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
+checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring 0.17.14",
  "sha2 0.10.9",
 ]
@@ -6985,13 +7502,13 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.9.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "smallvec",
@@ -7000,11 +7517,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.9.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -7015,6 +7532,17 @@ name = "ethnum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
 
 [[package]]
 name = "eyre"
@@ -7157,6 +7685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+ "typeid",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7181,6 +7720,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-map"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed19add84e8cb9e8cc5f7074de0324247149ffef0b851e215fb0edc50c229b"
+dependencies = [
+ "fixed-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "fixed-map-derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7191,6 +7751,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -7242,6 +7808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "float16"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
+dependencies = [
+ "cfg-if",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -7361,6 +7937,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7382,6 +7971,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -7452,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "gaptos"
 version = "0.0.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "api-types",
  "aptos-bitvec",
@@ -7463,9 +8065,9 @@ dependencies = [
  "aptos-collections",
  "aptos-compression",
  "aptos-config",
- "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-consensus-notifications",
- "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-consensus-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-crash-handler",
  "aptos-crypto",
  "aptos-crypto-derive",
@@ -7473,9 +8075,9 @@ dependencies = [
  "aptos-dkg-runtime",
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
- "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-executor-test-helpers",
- "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-executor-types 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-experimental-runtimes",
  "aptos-fallible",
  "aptos-global-constants",
@@ -7486,7 +8088,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-log-derive",
  "aptos-logger",
- "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-mempool 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-mempool-notifications",
  "aptos-memsocket",
  "aptos-metrics-core",
@@ -7502,7 +8104,7 @@ dependencies = [
  "aptos-reliable-broadcast",
  "aptos-rest-client",
  "aptos-runtimes",
- "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e)",
+ "aptos-safety-rules 0.1.0 (git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b)",
  "aptos-schemadb",
  "aptos-secure-net",
  "aptos-secure-storage",
@@ -7548,12 +8150,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
  "zeroize",
@@ -7616,9 +8232,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7643,7 +8271,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -7675,7 +8303,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -7724,16 +8352,6 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7804,7 +8422,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-retry2",
- "tonic",
+ "tonic 0.12.3",
  "tower 0.4.13",
  "tracing",
 ]
@@ -7815,9 +8433,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886aa8ec755382a1fdf4651f6e6ec01f2f3bf49f2cb0f068b9a74cafd574a715"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "prost-types",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -7900,8 +8518,8 @@ dependencies = [
 
 [[package]]
 name = "gravity-precompiles"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -7912,8 +8530,8 @@ dependencies = [
 
 [[package]]
 name = "gravity-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 
 [[package]]
 name = "gravity-sdk"
@@ -7926,8 +8544,8 @@ dependencies = [
 
 [[package]]
 name = "gravity-storage"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7953,17 +8571,17 @@ dependencies = [
 name = "gravity_cli"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.0.37",
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.0.37",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-provider 1.0.37",
+ "alloy-rpc-types 1.0.37",
+ "alloy-signer 1.0.41",
+ "alloy-signer-local 1.0.37",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport-http",
+ "alloy-transport-http 1.0.37",
  "anyhow",
  "aptos-consensus 0.1.0",
  "async-trait",
@@ -7998,13 +8616,13 @@ dependencies = [
 name = "gravity_node"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-transport-http",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "alloy-transport-http 2.0.5",
  "anyhow",
  "api",
  "async-trait",
@@ -8048,13 +8666,13 @@ dependencies = [
 
 [[package]]
 name = "greth"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "async-trait",
  "gravity-primitives",
  "gravity-storage",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -8090,13 +8708,12 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=2a42859a56f03197fce5be4ceb475d9f1a7d7c3d#2a42859a56f03197fce5be4ceb475d9f1a7d7c3d"
+source = "git+https://github.com/Galxe/grevm?rev=dcd1460b20d9f3d793c8309c28b0b7401be91523#dcd1460b20d9f3d793c8309c28b0b7401be91523"
 dependencies = [
  "ahash 0.8.12",
  "alloy-evm",
- "atomic",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures",
  "lazy_static",
  "metrics",
@@ -8196,6 +8813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8232,7 +8855,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -8247,12 +8869,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.9.1"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "hashbrown 0.14.5",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -8378,24 +9013,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna 1.1.0",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring 0.17.14",
- "serde",
+ "jni 0.22.4",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -8404,22 +9037,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna 1.1.0",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring 0.17.14",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.2",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8621,6 +9280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8761,7 +9429,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -8781,7 +9449,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -8795,27 +9463,15 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke 0.7.5",
- "zerofrom",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -8825,146 +9481,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
- "litemap 0.8.1",
- "tinystr 0.8.2",
- "writeable 0.6.2",
- "zerovec 0.11.5",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap 0.7.5",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
  "displaydoc",
- "icu_collections 1.5.0",
- "icu_normalizer_data 1.5.1",
- "icu_properties 1.5.1",
- "icu_provider 1.5.0",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
  "smallvec",
  "utf16_iter",
- "utf8_iter",
  "write16",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections 2.1.1",
- "icu_normalizer_data 2.1.1",
- "icu_properties 2.1.2",
- "icu_provider 2.1.1",
- "smallvec",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
  "displaydoc",
- "icu_collections 1.5.0",
- "icu_locid_transform",
- "icu_properties_data 1.5.1",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections 2.1.1",
+ "icu_collections",
  "icu_locale_core",
- "icu_properties_data 2.1.2",
- "icu_provider 2.1.1",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
  "zerotrie",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "yoke 0.7.5",
- "zerofrom",
- "zerovec 0.10.4",
-]
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -8974,22 +9541,13 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "writeable 0.6.2",
- "yoke 0.8.1",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
  "zerofrom",
  "zerotrie",
- "zerovec 0.11.5",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "zerovec",
 ]
 
 [[package]]
@@ -9025,15 +9583,15 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "icu_normalizer 2.1.1",
- "icu_properties 2.1.2",
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -9061,12 +9619,38 @@ version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
- "bitmaps",
+ "bitmaps 2.1.0",
  "rand_core 0.6.4",
  "rand_xoshiro 0.6.0",
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "imbl"
+version = "7.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
+dependencies = [
+ "archery",
+ "bitmaps 3.2.1",
+ "equivalent",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.7.0",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps 3.2.1",
 ]
 
 [[package]]
@@ -9204,7 +9788,7 @@ dependencies = [
  "clap 4.5.57",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "env_logger 0.11.8",
  "indexmap 2.13.0",
  "is-terminal",
@@ -9234,7 +9818,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -9298,9 +9882,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -9308,7 +9892,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring 1.2.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9348,6 +9932,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -9367,7 +9954,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9433,7 +10020,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -9441,10 +10028,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "jobserver"
@@ -9505,7 +10141,7 @@ dependencies = [
  "pin-project",
  "rustls 0.23.36",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 2.0.18",
  "tokio",
@@ -9557,7 +10193,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustls 0.23.36",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9688,6 +10324,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem 3.0.6",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "simple_asn1 0.6.3",
+ "zeroize",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9703,12 +10357,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -9788,10 +10463,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "left-right"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "8bc015ded5d9b3054dbbdb63332cdd6ee42352ccef19e911e25117490e2f48ee"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
@@ -9857,7 +10543,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -9938,6 +10624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "linemux"
 version = "0.3.0"
 source = "git+https://github.com/Galxe/linemux.git?rev=0194e0222134c587dcd50039a1ff9c8a14fae550#0194e0222134c587dcd50039a1ff9c8a14fae550"
@@ -9972,21 +10667,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litemap"
@@ -10020,6 +10703,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "lru"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10030,20 +10726,29 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -10073,9 +10778,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 
 [[package]]
 name = "mach"
@@ -10088,15 +10793,24 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10171,19 +10885,19 @@ version = "3.0.0"
 source = "git+https://github.com/aptos-labs/merlin#3454ccc85e37355c729ba40e6dac6e867ddf59f5"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.5",
  "rand_core 0.6.4",
  "zeroize",
 ]
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash 0.8.12",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -10199,16 +10913,17 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
+ "evmap",
  "indexmap 2.13.0",
  "metrics",
  "metrics-util",
  "quanta 0.12.6",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10219,27 +10934,28 @@ checksum = "4268d87f64a752f5a651314fc683f04da10be65701ea3e721ba4d74f79163cac"
 dependencies = [
  "libc",
  "libproc",
- "mach2",
+ "mach2 0.6.0",
  "metrics",
  "once_cell",
  "procfs 0.18.0",
  "rlimit 0.11.0",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta 0.12.6",
  "rand 0.9.2",
  "rand_xoshiro 0.7.0",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -10304,9 +11020,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -10349,9 +11065,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+checksum = "2956e537fc68236d2aa048f55704f231cc93f1c4de42fe1ecb5bd7938061fc4a"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -10359,13 +11075,13 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -10394,7 +11110,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10411,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -10426,12 +11142,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10446,7 +11162,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-spec"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "once_cell",
  "quote",
@@ -10456,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -10468,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "fail",
  "move-binary-format",
@@ -10482,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10497,7 +11213,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10527,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "difference",
@@ -10544,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10567,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "move-compiler-v2"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10601,7 +11317,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10627,7 +11343,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10646,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10663,7 +11379,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10682,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -10694,7 +11410,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",
@@ -10710,7 +11426,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -10728,7 +11444,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "hex",
@@ -10741,7 +11457,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -10754,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "codespan",
@@ -10781,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "clap 4.5.57",
@@ -10815,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "atty",
@@ -10842,7 +11558,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10871,7 +11587,7 @@ dependencies = [
 [[package]]
 name = "move-prover-bytecode-pipeline"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10887,7 +11603,7 @@ dependencies = [
 [[package]]
 name = "move-prover-lab"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -10905,7 +11621,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "hex",
@@ -10918,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "abstract-domain-derive",
  "anyhow",
@@ -10940,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "hex",
@@ -10963,7 +11679,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "once_cell",
  "serde",
@@ -10972,7 +11688,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "better_any",
  "bytes",
@@ -10987,7 +11703,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "better_any",
@@ -11019,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "move-vm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "once_cell",
  "prometheus",
@@ -11028,7 +11744,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "ambassador",
  "better_any",
@@ -11053,7 +11769,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11070,7 +11786,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
+source = "git+https://github.com/Galxe/gravity-aptos.git?rev=a64f8adc274bf2681df796766ef9a5b195fee44b#a64f8adc274bf2681df796766ef9a5b195fee44b"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
@@ -11200,6 +11916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "neptune"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11235,7 +11957,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -11261,6 +11983,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -11292,13 +12023,13 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify 0.11.1",
  "kqueue",
  "libc",
  "log",
- "mio 1.1.1",
+ "mio 1.2.2",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -11310,7 +12041,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -11337,7 +12068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11581,10 +12312,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -11597,9 +12347,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -11618,53 +12368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a501241474c3118833d6195312ae7eb7cc90bbb0d5f524cbb0b06619e49ff67"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e50c94013a1d036a529df259151991dbbd6cf8dc215e3b68b784f95eec60e6"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "derive_more 2.1.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "op-alloy-consensus",
- "snap",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "10.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826f43a5b1613c224f561847c152bfbaefcb593a9ae2c612ff4dc4661c6e625f"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11676,7 +12379,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -11731,6 +12434,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11781,12 +12564,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -11843,6 +12669,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -11907,7 +12739,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "499cff8432e71c5f8784d9645aac0f9fca604d67f59b68a606170b5e229c6538"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "ciborium",
  "coset",
  "data-encoding",
@@ -11960,6 +12792,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
  "crypto-mac 0.8.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -12095,9 +12937,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
  "phf_shared 0.11.3",
- "serde",
 ]
 
 [[package]]
@@ -12110,12 +12950,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -12130,13 +12990,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_macros"
-version = "0.11.3"
+name = "phf_generator"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_generator",
- "phf_shared 0.11.3",
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12161,19 +13031,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.10"
+name = "phf_shared"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12369,19 +13257,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -12428,7 +13310,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -12498,6 +13380,17 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -12606,12 +13499,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
  "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
+dependencies = [
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12655,38 +13569,15 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
-dependencies = [
- "bitflags 2.10.0",
- "chrono",
- "flate2",
- "hex",
- "procfs-core 0.17.0",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.10.0",
- "procfs-core 0.18.0",
- "rustix 1.1.3",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "chrono",
- "hex",
+ "flate2",
+ "procfs-core",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -12695,7 +13586,8 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
+ "chrono",
  "hex",
 ]
 
@@ -12729,7 +13621,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -12758,7 +13650,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -12775,12 +13677,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -12830,7 +13745,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -12934,7 +13849,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12947,6 +13862,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -12971,9 +13887,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12990,6 +13906,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -13038,6 +13960,17 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -13099,6 +14032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13153,23 +14092,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rapidhash"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
- "bitflags 2.10.0",
- "cassowary",
- "compact_str",
- "crossterm 0.28.1",
- "indoc 2.0.7",
+ "getrandom 0.3.4",
+ "rustversion",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
  "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.1",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.18.1",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "indoc 2.0.7",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -13188,7 +14182,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -13276,7 +14270,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -13285,7 +14279,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -13444,6 +14438,47 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -13502,10 +14537,11 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-rpc-types",
+ "alloy-primitives",
+ "alloy-rpc-types 2.0.5",
  "aquamarine",
  "clap 4.5.57",
  "eyre",
@@ -13528,7 +14564,7 @@ dependencies = [
  "reth-node-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-ress-protocol",
  "reth-ress-provider",
@@ -13548,16 +14584,17 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "futures-core",
  "futures-util",
  "metrics",
  "reth-chain-state",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -13566,17 +14603,19 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
+ "reth-trie-parallel",
+ "serde",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-chain-state"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "derive_more 2.1.1",
  "metrics",
@@ -13601,12 +14640,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -13621,8 +14660,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13630,23 +14669,23 @@ dependencies = [
  "reth-cli-runner",
  "reth-db",
  "serde_json",
- "shellexpand",
 ]
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
+ "blake3",
  "clap 4.5.57",
  "comfy-table",
- "crossterm 0.28.1",
+ "crossterm 0.29.0",
  "eyre",
  "fdlimit",
  "futures",
@@ -13656,7 +14695,8 @@ dependencies = [
  "itertools 0.14.0",
  "lz4",
  "ratatui",
- "reqwest 0.12.28",
+ "rayon",
+ "reqwest 0.13.1",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -13692,10 +14732,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
+ "reth-prune-types",
  "reth-revm",
  "reth-stages",
+ "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
+ "reth-storage-api",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
@@ -13705,15 +14749,16 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-stream",
- "toml 0.8.23",
+ "toml 0.9.11+spec-1.1.0",
  "tracing",
+ "url",
  "zstd",
 ]
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13722,10 +14767,10 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -13735,22 +14780,24 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
+ "tikv-jemalloc-sys",
  "tikv-jemallocator",
 ]
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c37bb4d1bac98661bf9128e1141b969034640d68697b22f70377e492fd332c"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "parity-scale-codec 3.7.5",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -13758,10 +14805,10 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceeb8dab90194305d3f7e3f043a22d2db1fb54b6dcf5d8e75c5a4fa8540e1f57"
 dependencies = [
- "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13769,25 +14816,27 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "eyre",
  "humantime-serde",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
+ "reth-static-file-types",
  "serde",
- "toml 0.8.23",
+ "toml 0.9.11+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
+ "alloy-eip7928 0.4.5",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -13797,11 +14846,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -13809,23 +14859,22 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 2.0.5",
  "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "auto_impl",
  "derive_more 2.1.1",
  "eyre",
  "futures",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth-node-api",
- "reth-primitives-traits",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -13835,31 +14884,34 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
  "eyre",
+ "libc",
  "metrics",
+ "page_size",
  "parking_lot 0.12.5",
  "reth-db-api",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
  "rocksdb",
- "sysinfo 0.33.1",
+ "sysinfo 0.38.4",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-db-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "bytes",
@@ -13877,14 +14929,15 @@ dependencies = [
  "reth-trie-common",
  "roaring",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-db-common"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
@@ -13912,10 +14965,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
@@ -13926,14 +14979,13 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "discv5",
  "enr",
- "generic-array",
  "itertools 0.14.0",
  "parking_lot 0.12.5",
  "rand 0.8.5",
@@ -13952,8 +15004,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13976,15 +15028,15 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
+ "dashmap 6.2.1",
  "data-encoding",
  "enr",
  "hickory-resolver",
  "linked_hash_set",
- "parking_lot 0.12.5",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-tokio-util",
@@ -14000,13 +15052,14 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
+ "async-compression",
  "futures",
  "futures-util",
  "itertools 0.14.0",
@@ -14030,8 +15083,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14043,28 +15096,25 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "generic-array",
  "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
- "sha3 0.10.8",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
- "typenum",
 ]
 
 [[package]]
 name = "reth-engine-local"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
@@ -14074,7 +15124,8 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-provider",
+ "reth-primitives-traits",
+ "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -14083,11 +15134,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -14107,44 +15158,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-engine-service"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
-dependencies = [
- "futures",
- "pin-project",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-engine-tree",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-network-p2p",
- "reth-node-types",
- "reth-payload-builder",
- "reth-provider",
- "reth-prune",
- "reth-stages-api",
- "reth-tasks",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "reth-engine-tree"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
+ "crossbeam-channel",
  "derive_more 2.1.1",
  "futures",
  "gravity-primitives",
+ "indexmap 2.13.0",
  "metrics",
  "mini-moka",
+ "moka",
  "parking_lot 0.12.5",
  "rayon",
  "reth-chain-state",
@@ -14183,10 +15214,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -14211,30 +15244,31 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "reth-ethereum-primitives",
+ "sha2 0.10.9",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
+ "reth-era",
  "reth-fs-util",
  "sha2 0.10.9",
  "tokio",
@@ -14242,10 +15276,10 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures-util",
@@ -14264,8 +15298,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14275,8 +15309,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14303,12 +15337,13 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eip7928 0.4.5",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -14324,8 +15359,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14340,17 +15375,18 @@ dependencies = [
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-rpc-server-types",
+ "reth-tasks",
  "reth-tracing",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -14362,26 +15398,24 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14393,11 +15427,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -14408,6 +15442,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-execution-cache",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -14422,27 +15457,22 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "modular-bitfield",
+ "alloy-rpc-types-eth 2.0.5",
  "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
- "serde_with",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14451,17 +15481,19 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eip7928 0.4.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more 2.1.1",
  "futures-util",
  "metrics",
+ "rayon",
  "reth-execution-errors",
  "reth-execution-types",
  "reth-metrics",
@@ -14474,14 +15506,16 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-sol-types",
+ "derive_more 2.1.1",
  "gravity-primitives",
  "grevm",
  "reth-chainspec",
@@ -14492,12 +15526,31 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-errors",
  "revm",
+ "tracing",
+]
+
+[[package]]
+name = "reth-execution-cache"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+dependencies = [
+ "alloy-primitives",
+ "fixed-cache",
+ "metrics",
+ "parking_lot 0.12.5",
+ "reth-errors",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-trie",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14509,13 +15562,14 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more 2.1.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -14527,11 +15581,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -14565,10 +15619,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -14579,8 +15633,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "serde",
  "serde_json",
@@ -14589,10 +15643,10 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -14608,6 +15662,7 @@ dependencies = [
  "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
+ "revm",
  "revm-bytecode",
  "revm-database",
  "serde",
@@ -14616,8 +15671,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "bytes",
  "futures",
@@ -14635,33 +15690,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-libmdbx"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+dependencies = [
+ "bitflags 2.13.1",
+ "byteorder",
+ "crossbeam-queue",
+ "dashmap 6.2.1",
+ "derive_more 2.1.1",
+ "parking_lot 0.12.5",
+ "reth-mdbx-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-mdbx-sys"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
 name = "reth-metrics"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
+ "reth-primitives-traits",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
+ "ipnet",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -14670,11 +15753,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -14689,6 +15772,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "rand 0.9.2",
+ "rayon",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -14716,6 +15800,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -14725,13 +15810,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-admin",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "auto_impl",
  "derive_more 2.1.1",
  "enr",
@@ -14750,11 +15835,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "auto_impl",
  "derive_more 2.1.1",
@@ -14772,8 +15857,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14787,8 +15872,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14801,8 +15886,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14818,8 +15903,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14842,14 +15927,14 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types 2.0.5",
  "alloy-rpc-types-engine",
  "aquamarine",
  "eyre",
@@ -14857,11 +15942,11 @@ dependencies = [
  "futures",
  "gravity-primitives",
  "jsonrpsee 0.26.0",
+ "parking_lot 0.12.5",
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
- "reth-cli-util",
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
@@ -14871,7 +15956,6 @@ dependencies = [
  "reth-downloaders",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
  "reth-evm",
@@ -14902,6 +15986,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -14911,11 +15996,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap 4.5.57",
@@ -14925,6 +16010,7 @@ dependencies = [
  "futures",
  "gravity-primitives",
  "humantime",
+ "ipnet",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
@@ -14936,6 +16022,7 @@ dependencies = [
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
+ "reth-net-banlist",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
@@ -14948,14 +16035,15 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-tracing",
+ "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "shellexpand",
  "strum 0.27.2",
  "thiserror 2.0.18",
- "toml 0.8.23",
+ "toml 0.9.11+spec-1.1.0",
  "tracing",
  "url",
  "vergen",
@@ -14964,14 +16052,19 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
- "alloy-network",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
+ "ethereum_ssz",
  "eyre",
+ "http-body-util",
+ "jsonrpsee 0.26.0",
  "reth-chainspec",
  "reth-engine-local",
  "reth-engine-primitives",
@@ -14984,6 +16077,7 @@ dependencies = [
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
+ "reth-node-core",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
@@ -14997,15 +16091,18 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "revm",
+ "serde",
+ "serde_json",
  "tokio",
+ "tower 0.5.3",
 ]
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "chrono",
  "futures-util",
@@ -15019,18 +16116,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more 2.1.1",
@@ -15050,17 +16147,20 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
+ "bytes",
  "eyre",
  "http 1.4.0",
+ "http-body-util",
  "jsonrpsee-server",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "procfs 0.17.0",
+ "procfs 0.18.0",
+ "reqwest 0.13.1",
  "reth-metrics",
  "reth-tasks",
  "tikv-jemalloc-ctl",
@@ -15071,8 +16171,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15083,20 +16183,23 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 2.0.5",
+ "derive_more 2.1.1",
  "futures-util",
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-trie-parallel",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -15104,8 +16207,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15116,38 +16219,41 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
  "either",
- "op-alloy-rpc-types-engine",
- "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
+ "reth-execution-types",
  "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15159,13 +16265,13 @@ dependencies = [
 
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-sol-macro",
  "alloy-sol-types",
  "api-types",
@@ -15206,21 +16312,21 @@ dependencies = [
 
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-network",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types 2.0.5",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "anyhow",
  "api-types",
  "async-trait",
  "chrono",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
@@ -15230,10 +16336,10 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "once_cell",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -15243,23 +16349,23 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.1"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-trie",
- "auto_impl",
  "byteorder",
  "bytes",
+ "dashmap 6.2.1",
  "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
+ "quanta 0.12.6",
  "rayon",
  "reth-codecs",
  "revm-bytecode",
@@ -15273,14 +16379,14 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "eyre",
  "gravity-primitives",
  "itertools 0.14.0",
@@ -15316,11 +16422,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -15344,23 +16450,25 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
  "modular-bitfield",
  "reth-codecs",
  "serde",
+ "strum 0.27.2",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
@@ -15376,10 +16484,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -15403,10 +16511,12 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -15416,42 +16526,38 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
- "alloy-network",
+ "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types 2.0.5",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-serde 2.0.5",
+ "alloy-signer 2.0.5",
+ "alloy-signer-local 2.0.5",
  "async-trait",
  "derive_more 2.1.1",
  "dyn-clone",
  "futures",
  "gravity-precompiles",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
  "itertools 0.14.0",
  "jsonrpsee 0.26.0",
  "jsonrpsee-types",
- "jsonwebtoken 9.3.1",
  "parking_lot 0.12.5",
  "pin-project",
  "reth-chain-state",
@@ -15460,6 +16566,8 @@ dependencies = [
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -15489,46 +16597,47 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
  "tracing",
  "tracing-futures",
 ]
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
- "alloy-json-rpc",
+ "alloy-json-rpc 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 2.0.5",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "jsonrpsee 0.26.0",
  "reth-chain-state",
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-network",
- "alloy-provider",
+ "alloy-network 2.0.5",
+ "alloy-provider 2.0.5",
  "dyn-clone",
  "http 1.4.0",
  "jsonrpsee 0.26.0",
@@ -15537,20 +16646,24 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
  "reth-metrics",
  "reth-network-api",
  "reth-node-core",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
+ "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
+ "reth-tokio-util",
  "reth-transaction-pool",
  "serde",
  "thiserror 2.0.18",
@@ -15563,41 +16676,42 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-consensus 2.0.5",
+ "alloy-evm",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-types-eth 2.0.5",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
- "revm-context",
+ "reth-rpc-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "parking_lot 0.12.5",
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-metrics",
+ "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -15614,20 +16728,21 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eip7928 0.4.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -15642,6 +16757,7 @@ dependencies = [
  "reth-network-api",
  "reth-node-api",
  "reth-primitives-traits",
+ "reth-prune-types",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -15658,18 +16774,20 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-chains",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
- "alloy-network",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "derive_more 2.1.1",
  "futures",
  "itertools 0.14.0",
@@ -15677,7 +16795,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -15701,12 +16819,13 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15719,10 +16838,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -15734,20 +16853,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-stages"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+name = "reth-rpc-traits"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947a4e5cec5166505ea078c9164f06bf691fd83d3850e72851b58a9f1900cb6d"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "bincode",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-signer 2.0.5",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-stages"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -15770,6 +16903,7 @@ dependencies = [
  "reth-stages-api",
  "reth-static-file-types",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-parallel",
  "thiserror 2.0.18",
@@ -15779,15 +16913,16 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
  "futures-util",
  "metrics",
+ "reth-codecs",
  "reth-consensus",
  "reth-errors",
  "reth-metrics",
@@ -15806,8 +16941,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15819,8 +16954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15839,27 +16974,29 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
  "derive_more 2.1.1",
+ "fixed-map",
  "serde",
  "strum 0.27.2",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "gravity-primitives",
  "metrics",
  "metrics-derive",
@@ -15881,33 +17018,38 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.1.1",
+ "reth-codecs",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
+ "revm-state",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "auto_impl",
- "dyn-clone",
+ "crossbeam-utils",
+ "dashmap 6.2.1",
  "futures-util",
+ "libc",
  "metrics",
+ "parking_lot 0.12.5",
  "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",
+ "thread-priority",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -15915,8 +17057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15925,33 +17067,55 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "clap 4.5.57",
  "eyre",
+ "reth-tracing-otlp",
  "rolling-file",
  "tracing",
  "tracing-appender",
+ "tracing-chrome",
  "tracing-journald",
  "tracing-logfmt",
+ "tracing-samply",
  "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
-name = "reth-transaction-pool"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+name = "reth-tracing-otlp"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "base64 0.22.1",
+ "clap 4.5.57",
+ "eyre",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.22",
+ "url",
+]
+
+[[package]]
+name = "reth-transaction-pool"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "futures-util",
  "gravity-primitives",
+ "imbl",
  "metrics",
  "parking_lot 0.12.5",
  "pin-project",
@@ -15960,6 +17124,8 @@ dependencies = [
  "reth-chainspec",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
@@ -15967,6 +17133,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
+ "revm",
  "revm-interpreter",
  "revm-primitives",
  "rustc-hash 2.1.1",
@@ -15982,17 +17149,18 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
+ "parking_lot 0.12.5",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -16006,14 +17174,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "bytes",
  "derive_more 2.1.1",
@@ -16033,8 +17201,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16052,11 +17220,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
+ "alloy-eip7928 0.4.5",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
+ "crossbeam-channel",
  "derive_more 2.1.1",
  "itertools 0.14.0",
  "metrics",
@@ -16070,6 +17241,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "reth-trie-sparse",
+ "revm-state",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -16077,8 +17249,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16090,14 +17262,16 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
+ "serde",
+ "serde_json",
  "smallvec",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16114,8 +17288,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e86cf594718932d42cebce1fa48292fb7b92721f7c914631add1ca970e814"
 dependencies = [
  "zstd",
 ]
@@ -16133,9 +17308,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "29.0.1"
+version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718d90dce5f07e115d0e66450b1b8aa29694c1cf3f89ebddaddccc2ccbd2f13e"
+checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -16152,21 +17327,21 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.2.2"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
 dependencies = [
  "bitvec 1.0.1",
- "phf 0.11.3",
+ "phf 0.13.1",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "9.1.0"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a20c98e7008591a6f012550c2a00aa36cba8c14cc88eb88dec32eb9102554b4"
+checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
 dependencies = [
  "bitvec 1.0.1",
  "cfg-if",
@@ -16181,9 +17356,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "10.2.0"
+version = "19.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d241ed1ce647b94caf174fcd0239b7651318b2c4c06b825b59b973dfb8495"
+checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -16197,11 +17372,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.5"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
+ "derive_more 2.1.1",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -16211,22 +17387,23 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.5"
+version = "12.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
  "revm-state",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "10.0.1"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550331ea85c1d257686e672081576172fe3d5a10526248b663bbf54f1bef226a"
+checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -16243,9 +17420,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "10.0.1"
+version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0a6e9ccc2ae006f5bed8bd80cd6f8d3832cd55c5e861b9402fdd556098512f"
+checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
@@ -16261,12 +17438,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.30.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de23199c4b6181a6539e4131cf7e31cde4df05e1192bcdce491c34a511241588"
+checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -16281,21 +17458,22 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "25.0.3"
+version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575dc51b1d8f5091daa12a435733a90b4a132dca7ccee0666c7db3851bc30c"
+checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "27.0.0"
+version = "36.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b57d4bd9e6b5fe469da5452a8a137bc2d030a3cd47c46908efc615bbc699da"
+checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-bn254 0.5.0",
@@ -16304,38 +17482,39 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
- "libsecp256k1",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
- "rug",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "20.2.1"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
 dependencies = [
  "alloy-primitives",
- "num_enum",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "7.0.5"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
 dependencies = [
- "bitflags 2.10.0",
+ "alloy-eip7928 0.4.5",
+ "bitflags 2.13.1",
+ "nonmax",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -16400,9 +17579,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
 
 [[package]]
 name = "ripemd"
@@ -16462,9 +17641,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -16546,18 +17725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rug"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
-]
-
-[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16620,6 +17787,15 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -16652,28 +17828,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16778,7 +17941,7 @@ checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.36",
@@ -16788,6 +17951,27 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.6",
  "windows-sys 0.59.0",
 ]
 
@@ -16859,6 +18043,15 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -17003,7 +18196,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -17016,7 +18209,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -17035,11 +18228,20 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
@@ -17051,6 +18253,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -17078,11 +18286,11 @@ name = "sentinel"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
+ "alloy-provider 1.0.37",
+ "alloy-rpc-types 1.0.37",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport-http",
+ "alloy-transport-http 1.0.37",
  "anyhow",
  "chrono",
  "csv",
@@ -17243,6 +18451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17327,7 +18544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -17345,7 +18562,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -17357,7 +18574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -17369,7 +18586,7 @@ checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
- "keccak",
+ "keccak 0.1.5",
  "opaque-debug",
 ]
 
@@ -17380,7 +18597,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -17418,19 +18645,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -17450,7 +18674,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.1.1",
+ "mio 1.2.2",
  "signal-hook",
 ]
 
@@ -17485,6 +18709,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -17558,7 +18798,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
- "bitmaps",
+ "bitmaps 2.1.0",
  "typenum",
 ]
 
@@ -17597,6 +18837,15 @@ checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
 dependencies = [
  "deunicode",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "small_btree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+dependencies = [
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -17672,12 +18921,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17736,12 +18985,6 @@ dependencies = [
  "base64ct",
  "der 0.7.10",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -17824,20 +19067,20 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -17868,22 +19111,21 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -17927,6 +19169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17949,10 +19197,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn-solidity"
-version = "1.5.4"
+name = "syn"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -18003,15 +19262,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -18031,7 +19291,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -18057,6 +19317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tag_ptr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18070,9 +19336,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -18098,7 +19364,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -18225,6 +19491,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2e834949be5111506bb252643498af1514f600d9e1dceedaa42afae155b67f"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18281,7 +19561,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -18316,7 +19595,7 @@ dependencies = [
  "anyhow",
  "hmac 0.8.1",
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash 1.1.0",
  "sha2 0.9.9",
@@ -18337,22 +19616,13 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "zerovec 0.11.5",
+ "serde_core",
+ "zerovec",
 ]
 
 [[package]]
@@ -18382,30 +19652,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio 1.2.2",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -18507,9 +19778,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -18518,7 +19789,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite 0.26.2",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -18544,7 +19815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.19.15",
 ]
@@ -18556,9 +19827,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -18587,7 +19873,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -18600,7 +19886,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.14",
@@ -18634,6 +19920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18654,7 +19946,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rustls-native-certs 0.8.3",
  "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
@@ -18670,16 +19962,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
 name = "tonic-reflection"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -18736,7 +20065,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -18785,11 +20114,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.22",
@@ -18804,6 +20134,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -18867,6 +20208,38 @@ checksum = "a250055a3518b5efba928a18ffac8d32d42ea607a9affff4532144cd5b2e378e"
 dependencies = [
  "time",
  "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.22",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-samply"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c175f7ecc002b6ef04776a39f440503e4e788790ddbdbfac8259b7a069526334"
+dependencies = [
+ "cfg-if",
+ "itoa",
+ "libc",
+ "mach2 0.5.0",
+ "memmap2",
+ "smallvec",
  "tracing-core",
  "tracing-subscriber 0.3.22",
 ]
@@ -18941,9 +20314,9 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -18954,11 +20327,11 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -19034,9 +20407,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -19065,6 +20438,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -19206,13 +20585,13 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -19239,7 +20618,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -19682,6 +21061,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19727,7 +21116,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -19738,22 +21127,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -19764,19 +21143,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -19785,10 +21152,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -19798,20 +21165,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -19819,17 +21175,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -19859,7 +21204,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -19870,17 +21215,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -20226,6 +21562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20246,12 +21591,6 @@ name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "writeable"
@@ -20316,6 +21655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xsum"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20341,37 +21686,13 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive 0.7.5",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive 0.8.1",
+ "yoke-derive",
  "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "synstructure",
 ]
 
 [[package]]
@@ -20492,19 +21813,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke 0.7.5",
- "zerofrom",
- "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -20513,20 +21823,10 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "yoke 0.8.1",
+ "serde",
+ "yoke",
  "zerofrom",
- "zerovec-derive 0.11.2",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "zerovec-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ["cfg(mirai)"] }
 aptos-consensus = { path = "./aptos-core/consensus" }
 
 #  from aptos =======================
-gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", rev = "b1f68dc85781ef0d28a568d9d64604b153be9d9e" }
+gaptos = { git = "https://github.com/Galxe/gravity-aptos.git", rev = "a64f8adc274bf2681df796766ef9a5b195fee44b" }
 aptos-executor-types = { path = "dependencies/aptos-executor-types" }
 aptos-executor = { path = "dependencies/aptos-executor" }
 api = { path = "./crates/api" }
@@ -496,6 +496,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "53a9df97145c24f81f3281e5eac78593c93545cf" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }
@@ -507,4 +508,3 @@ alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.37" }
 # into a `continue` via `unwrap_or_continue!`, producing a pure-user-space
 # 100% CPU spin). Upstream issue: https://github.com/jmagnuson/linemux/issues/57
 linemux = { git = "https://github.com/Galxe/linemux.git", rev = "0194e0222134c587dcd50039a1ff9c8a14fae550" }
-

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = "0.3.30"
 clap = { version = "4.5.17", features = ["derive", "env"] }
 futures = "0.3.30"
 dirs = "5.0.1"
-tokio = "1.40.0"
+tokio = { version = "=1.52.3", features = ["taskdump"] }
 tokio-stream = "0.1.16"
 eyre = "0.6.12"
 tracing = "0.1.40"
@@ -33,15 +33,15 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "b49b4864aeaa3c35c6871a77d7133bb9486edbf1" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "53a9df97145c24f81f3281e5eac78593c93545cf" }
 reqwest = "0.12.9"
-alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
-alloy-eips = { version = "^1.0.37", default-features = false }
-alloy-consensus = { version = "=1.0.37" }
-alloy-genesis = { version = "=1.0.37", default-features = false }
-alloy-serde = { version = "=1.0.37" }
-alloy-transport-http = "=1.0.37"
-alloy-rpc-types-eth = "=1.0.37"
+alloy-primitives = { version = "=1.6.0", default-features = false, features = ["map-foldhash"] }
+alloy-eips = { version = "=2.0.5", default-features = false }
+alloy-consensus = { version = "=2.0.5" }
+alloy-genesis = { version = "=2.0.5", default-features = false }
+alloy-serde = { version = "=2.0.5" }
+alloy-transport-http = "=2.0.5"
+alloy-rpc-types-eth = "=2.0.5"
 async-trait.workspace = true
 api.workspace = true
 gaptos = { workspace = true, features = ["gcp-secret-manager"] }

--- a/bin/gravity_node/src/cli.rs
+++ b/bin/gravity_node/src/cli.rs
@@ -12,7 +12,7 @@ use greth::{
     reth_node_builder::{NodeBuilder, WithLaunchContext},
     reth_node_core::args::LogArgs,
     reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNode},
-    reth_tracing::FileWorkerGuard,
+    reth_tracing::TracingGuards,
 };
 use std::{
     collections::BTreeMap,
@@ -159,6 +159,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
         debug!(target: "reth::cli", "Initialized tracing, log directory: {}, log level {:?}", self.logs.log_file_directory, self.logs.verbosity);
 
         let runner = CliRunner::try_default_runtime()?;
+        let runtime = runner.runtime();
         let components = |spec: Arc<C::ChainSpec>| {
             (EthEvmConfig::ethereum(spec.clone()), Arc::new(EthBeaconConsensus::new(spec)))
         };
@@ -171,18 +172,20 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
             }
             Commands::Init(command) => {
                 println!("Running init command");
-                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
+                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>(runtime))
             }
             Commands::InitState(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
+                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>(runtime))
             }
             Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::Db(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
+                runner.run_blocking_command_until_exit(|ctx| command.execute::<EthereumNode>(ctx))
             }
             Commands::P2P(command) => runner.run_until_ctrl_c(command.execute::<EthereumNode>()),
             Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
-            Commands::Prune(command) => runner.run_until_ctrl_c(command.execute::<EthereumNode>()),
+            Commands::Prune(command) => {
+                runner.run_command_until_exit(|ctx| command.execute::<EthereumNode>(ctx))
+            }
             Commands::Stage(command) => {
                 println!("Running stage command");
                 runner.run_command_until_exit(|ctx| {
@@ -197,7 +200,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
     ///
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
+    pub fn init_tracing(&self) -> eyre::Result<TracingGuards> {
         let guard = self.logs.init_tracing()?;
         Ok(guard)
     }

--- a/bin/gravity_node/src/relayer.rs
+++ b/bin/gravity_node/src/relayer.rs
@@ -9,7 +9,7 @@ use gaptos::api_types::{
     relayer::{PollResult, Relayer},
     ExecError,
 };
-use greth::reth_pipe_exec_layer_relayer::OracleRelayerManager;
+use greth::reth_pipe_exec_layer_relayer::{parse_oracle_uri, OracleRelayerManager};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
@@ -37,19 +37,17 @@ impl RelayerConfig {
     }
 }
 
-/// Sanitize a URL for safe logging: keep only scheme://host[:port], redact path and query.
-/// e.g. "https://mainnet.infura.io/v3/SECRET_KEY" → "https://mainnet.infura.io/***"
+/// Keep only scheme and host for logging; redact userinfo, path, query, and fragment.
 fn sanitize_url(url: &str) -> String {
-    if let Some(scheme_end) = url.find("://") {
-        let scheme = &url[..scheme_end];
-        let rest = &url[scheme_end + 3..];
-        // Host ends at the first '/' or '?' or end of string
-        let host_end = rest.find('/').or_else(|| rest.find('?')).unwrap_or(rest.len());
-        let host_port = &rest[..host_end];
-        format!("{scheme}://{host_port}/***")
-    } else {
-        "***".to_string()
-    }
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return "***".to_string();
+    };
+    let Some(host) = parsed.host_str() else {
+        return "***".to_string();
+    };
+    let host = if host.contains(':') { format!("[{host}]") } else { host.to_string() };
+    let port = parsed.port().map(|value| format!(":{value}")).unwrap_or_default();
+    format!("{}://{}{} /***", parsed.scheme(), host, port)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -100,7 +98,10 @@ impl RelayerWrapper {
         let config = config_path
             .and_then(|path| match RelayerConfig::from_file(&path) {
                 Ok(cfg) => {
-                    info!("Loaded relayer config from {:?}", path);
+                    info!(
+                        file = %path.file_name().and_then(|name| name.to_str()).unwrap_or("<config>"),
+                        "Loaded relayer config"
+                    );
                     Some(cfg)
                 }
                 Err(e) => {
@@ -113,67 +114,61 @@ impl RelayerWrapper {
             info!("relayer config: URI {} -> {}", uri, sanitize_url(url));
         }
 
-        // update reth commit and use
         let manager = OracleRelayerManager::new(datadir);
         Self { manager, tracker: ProviderProgressTracker::new(), config }
     }
 
     /// Fetch oracle source states from on-chain storage
-    async fn get_oracle_source_states() -> Vec<OracleSourceState> {
+    async fn get_oracle_source_states() -> Result<Vec<OracleSourceState>, ExecError> {
         let block_number = get_block_buffer_manager().latest_commit_block_number().await;
         info!("get_oracle_source_states latest commit block number: {}", block_number);
 
-        let config_bytes = match GLOBAL_CONFIG_STORAGE
-            .get()
-            .expect("GLOBAL_CONFIG_STORAGE not initialized")
+        let config_storage = GLOBAL_CONFIG_STORAGE.get().ok_or_else(|| {
+            ExecError::Other("GLOBAL_CONFIG_STORAGE is not initialized".to_string())
+        })?;
+
+        let config_bytes = match config_storage
             .fetch_config_bytes(OnChainConfig::OracleState, block_number.into())
         {
             Some(bytes) => bytes,
             None => {
-                warn!("Failed to fetch OracleState config");
-                return vec![];
+                let message = format!("OracleState unavailable at committed block {block_number}");
+                warn!("{message}");
+                return Err(ExecError::Other(message));
             }
         };
 
         let bytes: Bytes = match config_bytes.try_into() {
             Ok(b) => b,
             Err(e) => {
-                warn!("Failed to convert OracleState config bytes: {:?}", e);
-                return vec![];
+                let message = format!("Failed to convert OracleState config bytes: {e:?}");
+                warn!("{message}");
+                return Err(ExecError::Other(message));
             }
         };
 
-        match bcs::from_bytes::<Vec<OracleSourceState>>(&bytes) {
-            Ok(states) => {
-                info!("Fetched {} oracle source states", states.len());
-                states
-            }
-            Err(e) => {
-                warn!("Failed to deserialize OracleSourceStates: {:?}", e);
-                vec![]
-            }
-        }
+        let states = Self::decode_oracle_source_states(&bytes).map_err(|error| {
+            warn!("{error:?}");
+            error
+        })?;
+        info!("Fetched {} oracle source states", states.len());
+        Ok(states)
     }
 
-    /// Parse URI to extract source_type and source_id
-    /// URI format: gravity://<source_type>/<source_id>/<task_type>?<params>
+    fn decode_oracle_source_states(bytes: &[u8]) -> Result<Vec<OracleSourceState>, ExecError> {
+        bcs::from_bytes(bytes).map_err(|error| {
+            ExecError::Other(format!("Failed to deserialize OracleSourceStates: {error}"))
+        })
+    }
+
+    /// Parse only the source identity used to reconcile on-chain state.
+    ///
+    /// The reth relayer validates the task type and provider-specific parameters when the URI is
+    /// added. Keeping this helper limited to `(source_type, source_id)` avoids duplicating those
+    /// rules in the SDK wrapper.
     fn parse_source_from_uri(uri: &str) -> Option<(u32, u64)> {
-        if !uri.starts_with("gravity://") {
-            return None;
-        }
-
-        let rest = &uri[10..]; // len("gravity://") = 10
-        let parts: Vec<&str> = rest.split('/').collect();
-        if parts.len() < 2 {
-            return None;
-        }
-
-        let source_type: u32 = parts[0].parse().ok()?;
-        // Remove query string from source_id if present
-        let source_id_str = parts[1].split('?').next()?;
-        let source_id: u64 = source_id_str.parse().ok()?;
-
-        Some((source_type, source_id))
+        let task = parse_oracle_uri(uri).ok()?;
+        Some((task.source_type, task.source_id))
     }
 
     /// Find oracle state for a URI by matching source_type and source_id
@@ -185,24 +180,34 @@ impl RelayerWrapper {
         states.iter().find(|s| s.source_type == source_type && s.source_id == source_id)
     }
 
-    /// Block poll if we returned data and on-chain hasn't caught up
-    fn should_block_poll(state: &ProviderState, onchain_nonce: Option<u128>) -> bool {
-        if let Some(fetched) = state.fetched_nonce {
-            if let Some(onchain) = onchain_nonce {
-                // Block if we returned data and on-chain nonce hasn't caught up
-                return state.last_had_update && fetched > onchain;
-            }
-        }
-        false
+    fn require_oracle_state_for_uri<'a>(
+        uri: &str,
+        states: &'a [OracleSourceState],
+    ) -> Result<&'a OracleSourceState, ExecError> {
+        Self::find_oracle_state_for_uri(uri, states).ok_or_else(|| {
+            let available_sources = states
+                .iter()
+                .map(|state| format!("{}:{}", state.source_type, state.source_id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            ExecError::Other(format!(
+                "Oracle state not found for URI: {uri}. Available source identities: [{available_sources}]"
+            ))
+        })
     }
 
-    /// Submission-side dedup guard (gravity-audit subtask 2). Returns true when the observed
+    /// Block poll if we returned data and on-chain hasn't caught up
+    fn should_block_poll(state: &ProviderState, onchain_nonce: u128) -> bool {
+        state.last_had_update && state.fetched_nonce.is_some_and(|fetched| fetched > onchain_nonce)
+    }
+
+    /// Submission-side dedup guard. Returns true when the observed
     /// oracle nonce is already committed on-chain (`observed <= onchain`), so surfacing it as an
     /// update would inject a `recordBatch` system-tx that re-submits an already-recorded nonce
     /// (provided <= currentNonce) and NECESSARILY reverts (NonceNotSequential). The revert is
-    /// benign (logged, block proceeds) but wastes a full propose/certify/execute round
-    /// (~2.5x/day on mainnet). A legitimately-needed observation always carries `observed >
-    /// onchain`, so suppressing this never stalls a real update. Missing data is never suppressed.
+    /// benign (logged, block proceeds) but wastes a full propose/certify/execute round. A
+    /// legitimately-needed observation always carries `observed > onchain`, so suppressing this
+    /// never stalls a real update. Missing data is never suppressed.
     fn is_already_committed(observed_nonce: Option<u128>, onchain_nonce: Option<u128>) -> bool {
         matches!(
             (observed_nonce, onchain_nonce),
@@ -210,7 +215,7 @@ impl RelayerWrapper {
         )
     }
 
-    /// Apply the subtask-2 submission-side guard to a freshly polled result: if the observation's
+    /// Apply the submission-side guard to a freshly polled result: if the observation's
     /// nonce is already committed on-chain, mark it not-updated so `JWKObserver` drops it and the
     /// doomed `recordBatch` vtxn is never proposed. A genuinely-new observation (nonce > onchain)
     /// passes through untouched.
@@ -233,18 +238,18 @@ impl RelayerWrapper {
         &self,
         uri: &str,
         onchain_nonce: Option<u128>,
-        onchain_block_number: Option<u64>,
+        onchain_position: Option<u128>,
         state: &ProviderState,
     ) -> Result<PollResult, ExecError> {
         info!(
-            "Polling uri: {} (onchain_nonce: {:?}, onchain_block: {:?}, fetched_nonce: {:?}, last_had_update: {})",
-            uri, onchain_nonce, onchain_block_number, state.fetched_nonce, state.last_had_update
+            "Polling uri: {} (onchain_nonce: {:?}, onchain_position: {:?}, fetched_nonce: {:?}, last_had_update: {})",
+            uri, onchain_nonce, onchain_position, state.fetched_nonce, state.last_had_update
         );
 
         // Pass onchain state to poll_uri for reconciliation
         let result = self
             .manager
-            .poll_uri(uri, onchain_nonce, onchain_block_number)
+            .poll_uri(uri, onchain_nonce, onchain_position)
             .await
             .map_err(|e| ExecError::Other(e.to_string()))?;
 
@@ -263,38 +268,31 @@ impl RelayerWrapper {
 #[async_trait]
 impl Relayer for RelayerWrapper {
     async fn add_uri(&self, uri: &str, _rpc_url: &str) -> Result<(), ExecError> {
-        // Use local config URL if available, otherwise fall back to the provided rpc_url
+        // Provider endpoints are validator-local and never sourced from consensus data.
         let actual_url = self
             .config
             .get_url(uri)
             .ok_or_else(|| ExecError::Other(format!("Provider {uri} not found in local config")))?;
 
         // Get onchain state for this URI using source_type/source_id from URI
-        let oracle_states = Self::get_oracle_source_states().await;
-        info!("Oracle states: {:?}", oracle_states);
-        let oracle_state =
-            Self::find_oracle_state_for_uri(uri, &oracle_states).ok_or_else(|| {
-                ExecError::Other(format!(
-                    "Oracle state not found for URI: {uri}. Available states: {oracle_states:?}"
-                ))
-            })?;
+        let oracle_states = Self::get_oracle_source_states().await?;
+        let oracle_state = Self::require_oracle_state_for_uri(uri, &oracle_states)?;
 
-        // Extract nonce and block_number from oracle state
+        // Extract fixed-size progress from the authoritative oracle snapshot.
         let onchain_nonce = oracle_state.latest_nonce;
-        let onchain_block_number =
-            oracle_state.latest_record.as_ref().map(|r| r.block_number).unwrap_or(0);
+        let onchain_position = oracle_state.latest_position;
 
         info!(
-            "Adding URI: {}, RPC URL: {}, onchain_nonce: {}, onchain_block: {}",
+            "Adding URI: {}, RPC URL: {}, onchain_nonce: {}, onchain_position: {}",
             uri,
             sanitize_url(actual_url),
             onchain_nonce,
-            onchain_block_number
+            onchain_position
         );
 
         // Pass onchain state to manager for warm-start
         self.manager
-            .add_uri(uri, actual_url, onchain_nonce, onchain_block_number)
+            .add_uri(uri, actual_url, onchain_nonce, onchain_position)
             .await
             .map_err(|e| ExecError::Other(e.to_string()))
     }
@@ -302,23 +300,18 @@ impl Relayer for RelayerWrapper {
     // All URIs starting with gravity:// are definitely UnsupportedJWK
     async fn get_last_state(&self, uri: &str) -> Result<PollResult, ExecError> {
         // Get onchain state for this URI using source_type/source_id from URI
-        let oracle_states = Self::get_oracle_source_states().await;
-        let oracle_state = Self::find_oracle_state_for_uri(uri, &oracle_states);
+        let oracle_states = Self::get_oracle_source_states().await?;
+        let oracle_state = Self::require_oracle_state_for_uri(uri, &oracle_states)?;
 
-        // Extract nonce and block_number for reconciliation
-        let (onchain_nonce, onchain_block_number) = if let Some(state) = oracle_state {
-            let nonce = Some(state.latest_nonce);
-            let block = state.latest_record.as_ref().map(|r| r.block_number);
-            (nonce, block)
-        } else {
-            (None, None)
-        };
+        // Extract fixed-size progress from an authoritative OracleState snapshot.
+        let onchain_nonce = oracle_state.latest_nonce;
+        let onchain_position = Some(oracle_state.latest_position);
 
         let state = self.tracker.get_state(uri).await;
 
         info!(
-            "get_last_state - uri: {}, onchain_nonce: {:?}, onchain_block: {:?}, fetched_nonce: {:?}, last_had_update: {}",
-            uri, onchain_nonce, onchain_block_number, state.fetched_nonce, state.last_had_update
+            "get_last_state - uri: {}, onchain_nonce: {:?}, onchain_position: {:?}, fetched_nonce: {:?}, last_had_update: {}",
+            uri, onchain_nonce, onchain_position, state.fetched_nonce, state.last_had_update
         );
 
         if Self::should_block_poll(&state, onchain_nonce) {
@@ -336,11 +329,11 @@ impl Relayer for RelayerWrapper {
         }
 
         let result =
-            self.poll_and_update_state(uri, onchain_nonce, onchain_block_number, &state).await?;
+            self.poll_and_update_state(uri, Some(onchain_nonce), onchain_position, &state).await?;
 
-        // Subtask 2: never surface an observation whose nonce is already committed on-chain — it
+        // Never surface an observation whose nonce is already committed on-chain; it
         // would inject a guaranteed-revert oracle `recordBatch`. See `guard_already_committed`.
-        Ok(Self::guard_already_committed(uri, result, onchain_nonce))
+        Ok(Self::guard_already_committed(uri, result, Some(onchain_nonce)))
     }
 }
 
@@ -369,6 +362,69 @@ mod tests {
     }
 
     #[test]
+    fn oracle_state_decoder_distinguishes_empty_from_invalid() {
+        let authoritative_empty = bcs::to_bytes(&Vec::<OracleSourceState>::new()).unwrap();
+        assert!(RelayerWrapper::decode_oracle_source_states(&authoritative_empty)
+            .unwrap()
+            .is_empty());
+
+        assert!(RelayerWrapper::decode_oracle_source_states(&[0xff]).is_err());
+    }
+
+    #[test]
+    fn oracle_state_decoder_preserves_fixed_size_progress() {
+        let encoded = bcs::to_bytes(&vec![OracleSourceState {
+            source_type: 7,
+            source_id: 1001,
+            latest_nonce: 7,
+            latest_position: 1_710_000_419_999,
+        }])
+        .unwrap();
+
+        let decoded = RelayerWrapper::decode_oracle_source_states(&encoded).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].latest_nonce, 7);
+        assert_eq!(decoded[0].latest_position, 1_710_000_419_999);
+    }
+
+    #[test]
+    fn missing_source_in_authoritative_snapshot_is_an_error() {
+        let error =
+            RelayerWrapper::require_oracle_state_for_uri("gravity://7/1001/custom_task", &[])
+                .unwrap_err();
+
+        assert!(
+            matches!(error, ExecError::Other(message) if message.contains("Oracle state not found"))
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_snapshot_decode_does_not_mutate_pending_tracker() {
+        let tracker = ProviderProgressTracker::new();
+        let uri = "gravity://8/42/custom_task";
+        tracker.update_state(uri, &poll_result(8, true)).await;
+
+        assert!(RelayerWrapper::decode_oracle_source_states(&[0xff]).is_err());
+
+        let pending = tracker.get_state(uri).await;
+        assert_eq!(pending.fetched_nonce, Some(8));
+        assert!(pending.last_had_update);
+        assert_eq!(pending.last_result.unwrap().nonce, Some(8));
+    }
+
+    #[test]
+    fn pending_result_blocks_poll_until_authoritative_nonce_catches_up() {
+        let state = ProviderState {
+            fetched_nonce: Some(8),
+            last_had_update: true,
+            last_result: Some(poll_result(8, true)),
+        };
+
+        assert!(RelayerWrapper::should_block_poll(&state, 7));
+        assert!(!RelayerWrapper::should_block_poll(&state, 8));
+    }
+
+    #[test]
     fn guard_suppresses_an_already_committed_duplicate() {
         // Artificial duplicate: an observation whose nonce (7) is already committed on-chain (7).
         // Re-submitting it would revert NonceNotSequential — the guard must drop it.
@@ -394,5 +450,37 @@ mod tests {
             Some(7),
         );
         assert!(fresh.updated, "a genuinely-new observation (8 > 7) must NOT be suppressed");
+    }
+
+    #[test]
+    fn test_parse_custom_source_uri() {
+        let uri = "gravity://7/1001/custom_task?provider=example";
+        assert_eq!(RelayerWrapper::parse_source_from_uri(uri), Some((7, 1001)));
+    }
+
+    #[test]
+    fn test_parse_blockchain_source_uri() {
+        let uri = "gravity://0/31337/events?contract=0x0000000000000000000000000000000000000001";
+        assert_eq!(RelayerWrapper::parse_source_from_uri(uri), Some((0, 31337)));
+    }
+
+    #[test]
+    fn test_parse_source_accepts_identity_only_uri() {
+        assert_eq!(RelayerWrapper::parse_source_from_uri("gravity://7/1001"), Some((7, 1001)));
+    }
+
+    #[test]
+    fn test_parse_source_rejects_unroutable_uri() {
+        assert_eq!(RelayerWrapper::parse_source_from_uri("gravity://price/1001"), None);
+        assert_eq!(RelayerWrapper::parse_source_from_uri("https://oracle.example/3/1001"), None);
+    }
+
+    #[test]
+    fn test_sanitize_url_removes_credentials_and_path() {
+        let sanitized = sanitize_url("https://user:secret@rpc.example:8443/v1/key?token=abc");
+        assert_eq!(sanitized, "https://rpc.example:8443 /***");
+        assert!(!sanitized.contains("user"));
+        assert!(!sanitized.contains("secret"));
+        assert!(!sanitized.contains("token"));
     }
 }

--- a/bin/gravity_node/src/reth_cli.rs
+++ b/bin/gravity_node/src/reth_cli.rs
@@ -69,17 +69,10 @@ static GCEI_COINBASE_FALLBACK_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
 pub(crate) type RethBlockChainProvider =
     BlockchainProvider<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>;
 
-pub(crate) type RethTransactionPool = greth::reth_transaction_pool::Pool<
-    greth::reth_transaction_pool::TransactionValidationTaskExecutor<
-        greth::reth_transaction_pool::EthTransactionValidator<
-            RethBlockChainProvider,
-            greth::reth_transaction_pool::EthPooledTransaction,
-        >,
-    >,
-    greth::reth_transaction_pool::CoinbaseTipOrdering<
-        greth::reth_transaction_pool::EthPooledTransaction,
-    >,
+pub(crate) type RethTransactionPool = greth::reth_transaction_pool::EthTransactionPool<
+    RethBlockChainProvider,
     greth::reth_transaction_pool::blobstore::DiskFileBlobStore,
+    greth::reth_node_ethereum::EthEvmConfig,
 >;
 
 pub(crate) trait RethEthCall:


### PR DESCRIPTION
## Summary

- wire `gravity_node` to the merged generic Reth Oracle relayer API
- decode the fixed-size `OracleState` snapshot from the latest committed Gravity block
- reconcile providers by the shared `(source_type, source_id)` URI identity
- retain and re-emit a pending observation until the authoritative on-chain nonce catches up
- suppress stale or already-committed observations before they become guaranteed-revert system transactions
- keep provider endpoints validator-local and redact credentials, paths, and query strings from logs

## Runtime behavior

`add_uri` now requires an authoritative on-chain source state before warming the Reth provider with its `latest_nonce` and `latest_position`. `get_last_state` follows the same snapshot and fails closed when `OracleState` is unavailable, malformed, or missing the requested source.

After a provider returns an update, the wrapper caches that exact `PollResult`. While its nonce is ahead of the committed state, later observations return the cached payload instead of polling again. Once execution catches up, polling resumes. A provider result with `observed_nonce <= onchain_nonce` is marked unchanged so it cannot inject a `recordBatch` that must revert with `NonceNotSequential`.

The state-read error path does not mutate the pending tracker, so a transient committed-state failure cannot erase an observation waiting for execution.

## Dependency alignment

- pin Gravity Aptos to the merged Oracle state API revision from Galxe/gravity-aptos#79
- pin Gravity Reth to the merged generic relayer core plus dependency correction from Galxe/gravity-reth#416 and Galxe/gravity-reth#417
- align the node CLI and transaction-pool type aliases with Reth 2.3
- keep Alloy and Reth helper crates on versions compatible with the SDK Rust 1.93 toolchain

The lockfile is necessarily large because the existing SDK branch moves from its older Reth/Aptos dependency graphs to those merged revisions.

## Non-goals

- no Binance source implementation
- no Polygon or Polymarket source implementation
- no external-network E2E or frontend demo

Those remain isolated provider and E2E slices in the split plan.

## Validation

- `RUSTFLAGS='--cfg tokio_unstable' cargo +1.93.0 check -p gravity_node --tests --locked`
- `RUSTFLAGS='--cfg tokio_unstable' cargo +1.93.0 test -p gravity_node relayer::tests --locked` (12 passed)
- `cargo +nightly fmt --all -- --check`
- `cargo +1.93.0 metadata --locked --no-deps --format-version 1`

## Tracking

- Galxe/gravity-audit#1038
- Addresses Galxe/gravity-audit#908
