### PR TITLE
chore(deps): [v1.9] integrate greth v2.3.0 (pin bc817c64)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -62,7 +62,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -151,15 +151,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "3b5cc30538e90795a57647bef8d8864aad6e8d86190617009b4ef8d8b647b49a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "num_enum",
+ "phf 0.14.0",
  "serde",
- "strum 0.27.2",
 ]
 
 [[package]]
@@ -168,13 +168,40 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59094911f05dbff1cf5b29046a00ef26452eccc8d47136d50a47c0cf22f00c85"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.0.37",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
  "alloy-trie",
- "alloy-tx-macros",
+ "alloy-tx-macros 1.0.37",
  "auto_impl",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
+dependencies = [
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "alloy-trie",
+ "alloy-tx-macros 2.1.1",
+ "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
@@ -194,11 +221,25 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903cb8f728107ca27c816546f15be38c688df3c381d7bd1a4a9f215effc1ddb4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.0.37",
+ "alloy-eips 1.0.37",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -208,16 +249,16 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03df5cb3b428ac96b386ad64c11d5c6e87a5505682cf1fbd6f8f773e9eda04f6"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.0.37",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-network 1.0.37",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
+ "alloy-provider 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.0.41",
  "futures",
  "futures-util",
  "serde_json",
@@ -226,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -238,7 +279,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -256,26 +297,56 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "k256",
  "serde",
  "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
  "thiserror 2.0.18",
 ]
 
@@ -290,8 +361,32 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
  "auto_impl",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928 0.3.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
+ "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
@@ -300,50 +395,48 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.21.3"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1bfade4de9f464719b5aca30cf5bb02b9fda7036f0cf43addc3a0e66a0340c"
+checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.1.1",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1421f6c9d15e5b86afbfe5865ca84dea3b9f77173a0963c1a2ee4e626320ada9"
+checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "alloy-trie",
+ "borsh",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.3.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889eb3949b58368a09d4f16931c660275ef5fb08e5fbd4a96573b19c7085c41f"
+checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -355,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -381,21 +474,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f59a869fa4b4c3a7f08b1c8cb79aec61c29febe6e24a24fe0fcfded8a9b5703"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.37",
+ "alloy-consensus-any 1.0.37",
+ "alloy-eips 1.0.37",
+ "alloy-json-rpc 1.0.41",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
+ "alloy-rpc-types-any 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-serde 1.0.37",
+ "alloy-signer 1.0.41",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-consensus-any 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types-any 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "alloy-signer 2.0.5",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -412,27 +546,41 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e9374c667c95c41177602ebe6f6a2edd455193844f011d973d374b65501b38"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.0.37",
+ "alloy-eips 1.0.37",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 1.0.37",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9485c56de23438127a731a6b4c87803d49faf1a7068dcd1d8768aca3a9edb9"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more 2.1.1",
- "foldhash 0.1.5",
- "getrandom 0.3.4",
- "hashbrown 0.15.5",
+ "fixed-cache",
+ "foldhash 0.2.0",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "itoa",
  "k256",
@@ -440,11 +588,12 @@ dependencies = [
  "paste",
  "proptest",
  "rand 0.9.2",
+ "rapidhash",
  "ruint",
  "rustc-hash 2.1.1",
+ "secp256k1 0.31.1",
  "serde",
- "sha3 0.10.8",
- "tiny-keccak",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -454,25 +603,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77818b7348bd5486491a5297579dbfe5f706a81f8e1f5976393025f1e22a7c7d"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.37",
+ "alloy-eips 1.0.37",
+ "alloy-json-rpc 1.0.41",
+ "alloy-network 1.0.37",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
- "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-client 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-signer 1.0.41",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
+ "alloy-transport 1.0.41",
+ "alloy-transport-http 1.0.37",
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -490,14 +636,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-pubsub"
-version = "1.0.41"
+name = "alloy-provider"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e45a68423e732900a0c824b8e22237db461b79d2e472dd68b7547c16104427"
+checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-chains",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-network-primitives 2.0.5",
  "alloy-primitives",
- "alloy-transport",
+ "alloy-pubsub",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types-debug",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-rpc-types-trace",
+ "alloy-signer 2.0.5",
+ "alloy-sol-types",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.5",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap 6.2.1",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.4",
+ "parking_lot 0.12.5",
+ "pin-project",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd85cfea1fa8ebd20d3475e961fe3a3624c0eb4659ea137715c0c83c8aeaff0"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
+ "alloy-primitives",
+ "alloy-transport 2.0.5",
  "auto_impl",
  "bimap",
  "futures",
@@ -513,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec 0.7.6",
@@ -524,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -539,16 +729,39 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2430d5623e428dd012c6c2156ae40b7fe638d6fca255e3244e0fba51fa698e93"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.0.41",
+ "alloy-primitives",
+ "alloy-transport 1.0.41",
+ "alloy-transport-http 1.0.37",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 2.0.5",
+ "alloy-transport-http 2.0.5",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
@@ -566,17 +779,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e131624d08a25cfc40557041e7dc42e1182fa1153e7592d120f769a1edce56"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-serde 1.0.37",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052c031d1f7c5611997056bbcb8814e5cbf20f7efeee8c3de690555172038cf2"
+dependencies = [
+ "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59407723b1850ebaa49e46d10c2ba9c10c10b3aedf2f7e97015ee23c3f4e639"
+checksum = "ef669b370940e7945a3a384cc4024038cd69ee658b71270d59c20b78dd8d20d4"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -586,13 +811,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65e3266095e6d8e8028aab5f439c6b8736c5147314f7e606c61597e014cb8a0"
+checksum = "2ff111a54268dc0bbd3b17f98571a7e27cc661dc081ad2999d91888647eb2e11"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -602,20 +827,36 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07429a1099cd17227abcddb91b5e38c960aaeb02a6967467f5bb561fbe716ac6"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-consensus-any 1.0.37",
+ "alloy-rpc-types-eth 1.0.37",
+ "alloy-serde 1.0.37",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
+dependencies = [
+ "alloy-consensus-any 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e0e876b20eb9debf316d3e875536f389070635250f22b5a678cf4632a3e0cf"
+checksum = "9a62f6ce2d95f59ed310bd90d5fd1566a29d1ec45cc219abbc5dcc807d31f136"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
@@ -628,11 +869,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.41"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388cf910e66bd4f309a81ef746dcf8f9bca2226e3577890a8d56c5839225cf46"
+checksum = "48b9ad6eee93dd35a9ec0a6c1c6b180892a900ee17a6ed6500921552dd71e846"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more 2.1.1",
  "serde",
  "serde_with",
@@ -640,19 +882,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ecadcea6aac65e75e32b6735635ee98517aa63b111849ee01ae988a71d685"
+checksum = "7eba59e1c069f168a01982f42a57797736923b76aa854194df4930be17867e1c"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken 10.4.0",
  "rand 0.8.5",
  "serde",
  "strum 0.27.2",
@@ -664,13 +906,34 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db46b0901ee16bbb68d986003c66dcb74a12f9d9b3c44f8e85d51974f2458f0f"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 1.0.37",
+ "alloy-consensus-any 1.0.37",
+ "alloy-eips 1.0.37",
+ "alloy-network-primitives 1.0.37",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.0.37",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-consensus-any 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-network-primitives 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -681,28 +944,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a60d4baadd3f278faa4e2305cca095dfd4ab286e071b768ff09181d8ae215"
+checksum = "ed1004c1d68bfaee001712f83356f88031ab74a727b8560fb7fc738d1281ebe5"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f10620724bd45f80c79668a8cdbacb6974f860686998abce28f6196ae79444"
+checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -710,13 +973,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.37"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864f41befa90102d4e02327679699a7e9510930e2924c529e31476086609fa89"
+checksum = "76e34a42ebb4a71ab0bfdebc6d2f3c7bf809f01edf154d08fed159d10d1ef1d4"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "serde",
 ]
 
@@ -725,6 +988,17 @@ name = "alloy-serde"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5413814be7a22fbc81e0f04a2401fcc3eb25e56fd53b04683e8acecc6e1fe01b"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -747,15 +1021,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alloy-signer-local"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6006c4cbfa5d08cadec1fcabea6cb56dc585a30a9fce40bcf81e307d6a71c8e"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.0.37",
+ "alloy-network 1.0.37",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 1.0.41",
  "async-trait",
  "k256",
  "rand 0.8.5",
@@ -763,10 +1052,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-macro"
-version = "1.5.4"
+name = "alloy-signer-local"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
+checksum = "e48366d2c42b8d95ef951101bafa28486590f21b7a1e68b6b2d069746557bbe3"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-primitives",
+ "alloy-signer 2.0.5",
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -778,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -789,16 +1097,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3 0.10.8",
+ "sha3 0.11.0",
  "syn 2.0.114",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -812,19 +1120,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b91b13181d3bcd23680fd29d7bc861d1f33fbe90fdd0af67162434aeba902d"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -838,8 +1146,31 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "025a940182bddaeb594c26fe3728525ae262d0806fe6a4befdf5d7bc13d54bce"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.0.41",
  "alloy-primitives",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more 2.1.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "auto_impl",
  "base64 0.22.1",
  "derive_more 2.1.1",
@@ -862,8 +1193,8 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f8a6338d594f6c6481292215ee8f2fd7b986c80aba23f3f44e761a8658de78"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 1.0.41",
+ "alloy-transport 1.0.41",
  "reqwest 0.12.28",
  "serde_json",
  "tower 0.5.3",
@@ -872,14 +1203,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ipc"
-version = "1.0.41"
+name = "alloy-transport-http"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47962f3f1d9276646485458dc842b4e35675f42111c9d814ae4711c664c8300"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 2.0.5",
+ "alloy-transport 2.0.5",
+ "itertools 0.14.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "reqwest 0.13.1",
+ "serde_json",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-opentelemetry",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb89df168b24773ef603af14f2449c05a7d3f27d05d3eceaea6bf96cccae168"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "bytes",
  "futures",
  "interprocess",
@@ -893,31 +1243,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.41"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9476a36a34e2fb51b6746d009c53d309a186a825aa95435407f0e07149f4ad2d"
+checksum = "33e32e0b47d3b3bf5770b7c132090c614b008d307c5e1544f1925f5b7e9e9af6"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "futures",
  "http 1.4.0",
  "rustls 0.23.36",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec 0.7.6",
  "derive_more 2.1.1",
  "nybbles",
  "serde",
@@ -933,6 +1283,18 @@ source = "git+https://github.com/alloy-rs/alloy?tag=v1.0.37#8f6c1489f89e90649dac
 dependencies = [
  "alloy-primitives",
  "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+dependencies = [
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1091,6 +1453,15 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tokio",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2242,7 +2613,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tonic-reflection",
 ]
 
@@ -2300,7 +2671,7 @@ dependencies = [
  "lz4",
  "once_cell",
  "prometheus",
- "prost",
+ "prost 0.13.5",
  "redis",
  "redis-test",
  "ripemd",
@@ -2308,7 +2679,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
  "url",
  "warp",
@@ -2903,9 +3274,9 @@ version = "1.3.1"
 source = "git+https://github.com/Galxe/gravity-aptos.git?rev=b1f68dc85781ef0d28a568d9d64604b153be9d9e#b1f68dc85781ef0d28a568d9d64604b153be9d9e"
 dependencies = [
  "pbjson",
- "prost",
+ "prost 0.13.5",
  "serde",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -3144,7 +3515,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "tonic-reflection",
 ]
 
@@ -3421,7 +3792,7 @@ dependencies = [
  "derive_builder",
  "memchr",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3714,6 +4085,12 @@ checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
@@ -4181,9 +4558,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "asn1_der"
@@ -4248,15 +4622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4302,24 +4667,26 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4516,6 +4883,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bellpepper"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4605,7 +4978,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -4613,7 +4986,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.1",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.114",
 ]
 
@@ -4656,9 +5029,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -4671,6 +5044,12 @@ checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -4739,6 +5118,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.6",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,6 +5148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4826,11 +5228,11 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -4841,84 +5243,92 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
 dependencies = [
+ "aligned-vec",
  "arrayvec 0.7.6",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "boa_ast",
  "boa_gc",
  "boa_interner",
  "boa_macros",
  "boa_parser",
- "boa_profiler",
  "boa_string",
  "bytemuck",
  "cfg-if",
- "dashmap 6.1.0",
+ "cow-utils",
+ "dashmap 6.2.1",
+ "dynify",
  "fast-float2",
- "hashbrown 0.15.5",
- "icu_normalizer 1.5.0",
+ "float16",
+ "futures-channel",
+ "futures-concurrency",
+ "futures-lite",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
  "indexmap 2.13.0",
  "intrusive-collections",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "num_enum",
- "once_cell",
- "pollster",
+ "paste",
  "portable-atomic",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regress",
  "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
- "sptr",
+ "small_btree",
  "static_assertions",
+ "tag_ptr",
  "tap",
  "thin-vec",
  "thiserror 2.0.18",
  "time",
+ "xsum",
 ]
 
 [[package]]
 name = "boa_gc"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
 dependencies = [
  "boa_macros",
- "boa_profiler",
  "boa_string",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "once_cell",
- "phf 0.11.3",
+ "phf 0.13.1",
  "rustc-hash 2.1.1",
  "static_assertions",
 ]
 
 [[package]]
 name = "boa_macros"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
 dependencies = [
+ "cfg-if",
+ "cow-utils",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -4927,17 +5337,16 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
- "boa_profiler",
  "fast-float2",
- "icu_properties 1.5.1",
+ "icu_properties",
  "num-bigint 0.4.6",
  "num-traits",
  "regress",
@@ -4945,22 +5354,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "boa_profiler"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
-
-[[package]]
 name = "boa_string"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
 dependencies = [
  "fast-float2",
+ "itoa",
  "paste",
  "rustc-hash 2.1.1",
- "sptr",
+ "ryu-js",
  "static_assertions",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4999,6 +5427,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -5051,6 +5480,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-slice-cast"
@@ -5117,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "blst",
  "cc",
@@ -5214,14 +5649,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -5250,6 +5685,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -5336,7 +5782,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -5499,6 +5945,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "coins-bip32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2073678591747aed4000dd468b97b14d7007f7936851d3f2f01846899f5ebf08"
+dependencies = [
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "hmac 0.12.1",
+ "k256",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
+dependencies = [
+ "bitvec 1.0.1",
+ "coins-bip32",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2 0.12.2",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b962ad8545e43a28e14e87377812ba9ae748dd4fd963f4c10e9fcc6d13475b"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bs58",
+ "const-hex",
+ "digest 0.10.7",
+ "generic-array",
+ "ripemd",
+ "serde",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5541,9 +6038,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -5610,7 +6107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -5670,15 +6167,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "convert_case"
@@ -5774,6 +6262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5787,6 +6281,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -5947,31 +6450,19 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "mio 1.1.1",
- "parking_lot 0.12.5",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
+ "derive_more 2.1.1",
  "document-features",
+ "mio 1.2.1",
  "parking_lot 0.12.5",
  "rustix 1.1.3",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi 0.3.9",
 ]
 
@@ -6021,6 +6512,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -6104,7 +6604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -6204,6 +6704,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim 0.11.1",
  "syn 2.0.114",
 ]
@@ -6255,9 +6756,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -6528,8 +7029,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -6576,9 +7087,8 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b4e7798d2ff74e29cee344dc490af947ae657d6ab5273dde35d58ce06a4d71"
+version = "0.10.4"
+source = "git+https://github.com/sigp/discv5?rev=7663c00#7663c00ee0837ea98547caaedede95d9d6736f4d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -6594,13 +7104,12 @@ dependencies = [
  "hkdf 0.12.4",
  "lazy_static",
  "libp2p-identity",
- "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot 0.12.5",
  "rand 0.8.5",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -6613,7 +7122,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -6674,6 +7183,26 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dynify"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
+dependencies = [
+ "dynify-macros",
+]
+
+[[package]]
+name = "dynify-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "ecdsa"
@@ -6766,9 +7295,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -6827,18 +7356,6 @@ dependencies = [
  "serde",
  "sha3 0.10.8",
  "zeroize",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -6961,11 +7478,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_hashing"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
+checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring 0.17.14",
  "sha2 0.10.9",
 ]
@@ -6985,13 +7502,13 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.9.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+checksum = "e462875ad8693755ea8913d6e905715c76ea4836e2254e18c9cf0f7a8f8c2a13"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "smallvec",
@@ -7000,11 +7517,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.9.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+checksum = "daf022360bdbe9456eda5f35718a50476d5b2a0d51a97ed4eae27420737a6fba"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -7015,6 +7532,17 @@ name = "ethnum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+
+[[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
 
 [[package]]
 name = "eyre"
@@ -7042,6 +7570,12 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -7157,6 +7691,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+ "typeid",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7181,6 +7726,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-map"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed19add84e8cb9e8cc5f7074de0324247149ffef0b851e215fb0edc50c229b"
+dependencies = [
+ "fixed-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "fixed-map-derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7191,6 +7757,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -7242,6 +7814,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "float16"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
+dependencies = [
+ "cfg-if",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -7361,6 +7943,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7382,6 +7977,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -7548,12 +8156,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "serde",
  "typenum",
  "version_check",
  "zeroize",
@@ -7616,9 +8238,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7643,7 +8277,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -7675,7 +8309,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "ignore",
  "walkdir",
 ]
@@ -7724,16 +8358,6 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7804,7 +8428,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-retry2",
- "tonic",
+ "tonic 0.12.3",
  "tower 0.4.13",
  "tracing",
 ]
@@ -7815,9 +8439,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886aa8ec755382a1fdf4651f6e6ec01f2f3bf49f2cb0f068b9a74cafd574a715"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "prost-types",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -7900,8 +8524,8 @@ dependencies = [
 
 [[package]]
 name = "gravity-precompiles"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -7912,8 +8536,8 @@ dependencies = [
 
 [[package]]
 name = "gravity-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 
 [[package]]
 name = "gravity-sdk"
@@ -7926,8 +8550,8 @@ dependencies = [
 
 [[package]]
 name = "gravity-storage"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7953,17 +8577,17 @@ dependencies = [
 name = "gravity_cli"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.0.37",
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.0.37",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-provider 1.0.37",
+ "alloy-rpc-types 1.0.37",
+ "alloy-signer 1.0.41",
+ "alloy-signer-local 1.0.37",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport-http",
+ "alloy-transport-http 1.0.37",
  "anyhow",
  "aptos-consensus 0.1.0",
  "async-trait",
@@ -7998,13 +8622,13 @@ dependencies = [
 name = "gravity_node"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-transport-http",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
+ "alloy-transport-http 2.0.5",
  "anyhow",
  "api",
  "async-trait",
@@ -8048,13 +8672,13 @@ dependencies = [
 
 [[package]]
 name = "greth"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "async-trait",
  "gravity-primitives",
  "gravity-storage",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -8090,13 +8714,12 @@ dependencies = [
 [[package]]
 name = "grevm"
 version = "2.2.2"
-source = "git+https://github.com/Galxe/grevm?rev=2a42859a56f03197fce5be4ceb475d9f1a7d7c3d#2a42859a56f03197fce5be4ceb475d9f1a7d7c3d"
+source = "git+https://github.com/Galxe/grevm?rev=dcd1460b20d9f3d793c8309c28b0b7401be91523#dcd1460b20d9f3d793c8309c28b0b7401be91523"
 dependencies = [
  "ahash 0.8.12",
  "alloy-evm",
- "atomic",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures",
  "lazy_static",
  "metrics",
@@ -8196,6 +8819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8232,7 +8861,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -8247,12 +8875,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.9.1"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "hashbrown 0.14.5",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -8378,24 +9019,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna 1.1.0",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring 0.17.14",
- "serde",
+ "jni 0.22.4",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -8404,22 +9043,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna 1.1.0",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring 0.17.14",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.2",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8621,6 +9286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8761,7 +9435,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -8781,7 +9455,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -8795,27 +9469,15 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke 0.7.5",
- "zerofrom",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -8825,146 +9487,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
- "litemap 0.8.1",
- "tinystr 0.8.2",
- "writeable 0.6.2",
- "zerovec 0.11.5",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
 ]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap 0.7.5",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
  "displaydoc",
- "icu_collections 1.5.0",
- "icu_normalizer_data 1.5.1",
- "icu_properties 1.5.1",
- "icu_provider 1.5.0",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
  "smallvec",
  "utf16_iter",
- "utf8_iter",
  "write16",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections 2.1.1",
- "icu_normalizer_data 2.1.1",
- "icu_properties 2.1.2",
- "icu_provider 2.1.1",
- "smallvec",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
  "displaydoc",
- "icu_collections 1.5.0",
- "icu_locid_transform",
- "icu_properties_data 1.5.1",
- "icu_provider 1.5.0",
- "tinystr 0.7.6",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections 2.1.1",
+ "icu_collections",
  "icu_locale_core",
- "icu_properties_data 2.1.2",
- "icu_provider 2.1.1",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
  "zerotrie",
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr 0.7.6",
- "writeable 0.5.5",
- "yoke 0.7.5",
- "zerofrom",
- "zerovec 0.10.4",
-]
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -8974,22 +9547,13 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "writeable 0.6.2",
- "yoke 0.8.1",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
  "zerofrom",
  "zerotrie",
- "zerovec 0.11.5",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "zerovec",
 ]
 
 [[package]]
@@ -9025,15 +9589,15 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
- "icu_normalizer 2.1.1",
- "icu_properties 2.1.2",
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -9061,12 +9625,37 @@ version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
- "bitmaps",
+ "bitmaps 2.1.0",
  "rand_core 0.6.4",
  "rand_xoshiro 0.6.0",
  "sized-chunks",
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "imbl"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps 3.2.1",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.7.0",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps 3.2.1",
 ]
 
 [[package]]
@@ -9204,7 +9793,7 @@ dependencies = [
  "clap 4.5.57",
  "crossbeam-channel",
  "crossbeam-utils",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "env_logger 0.11.8",
  "indexmap 2.13.0",
  "is-terminal",
@@ -9234,7 +9823,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -9298,9 +9887,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -9308,7 +9897,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring 1.2.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9348,6 +9937,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -9433,7 +10025,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -9441,10 +10033,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "jobserver"
@@ -9505,7 +10146,7 @@ dependencies = [
  "pin-project",
  "rustls 0.23.36",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 2.0.18",
  "tokio",
@@ -9557,7 +10198,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustls 0.23.36",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -9688,6 +10329,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem 3.0.6",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "simple_asn1 0.6.3",
+ "zeroize",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9703,12 +10362,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -9788,10 +10468,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "left-right"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -9857,7 +10548,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -9938,6 +10629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "linemux"
 version = "0.3.0"
 source = "git+https://github.com/Galxe/linemux.git?rev=0194e0222134c587dcd50039a1ff9c8a14fae550#0194e0222134c587dcd50039a1ff9c8a14fae550"
@@ -9972,21 +10672,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
-name = "litemap"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litemap"
@@ -10020,6 +10708,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "lru"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10030,20 +10731,29 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -10073,9 +10783,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 
 [[package]]
 name = "mach"
@@ -10088,15 +10798,24 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10171,19 +10890,19 @@ version = "3.0.0"
 source = "git+https://github.com/aptos-labs/merlin#3454ccc85e37355c729ba40e6dac6e867ddf59f5"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.5",
  "rand_core 0.6.4",
  "zeroize",
 ]
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash 0.8.12",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -10199,16 +10918,17 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
+ "evmap",
  "indexmap 2.13.0",
  "metrics",
  "metrics-util",
  "quanta 0.12.6",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10219,27 +10939,28 @@ checksum = "4268d87f64a752f5a651314fc683f04da10be65701ea3e721ba4d74f79163cac"
 dependencies = [
  "libc",
  "libproc",
- "mach2",
+ "mach2 0.6.0",
  "metrics",
  "once_cell",
  "procfs 0.18.0",
  "rlimit 0.11.0",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta 0.12.6",
  "rand 0.9.2",
  "rand_xoshiro 0.7.0",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -10304,9 +11025,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -10349,9 +11070,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+checksum = "2956e537fc68236d2aa048f55704f231cc93f1c4de42fe1ecb5bd7938061fc4a"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -10359,13 +11080,13 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11200,6 +11921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "neptune"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11235,7 +11962,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -11261,6 +11988,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -11292,13 +12028,13 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify 0.11.1",
  "kqueue",
  "libc",
  "log",
- "mio 1.1.1",
+ "mio 1.2.1",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -11310,7 +12046,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -11581,10 +12317,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -11597,9 +12352,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -11618,53 +12373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a501241474c3118833d6195312ae7eb7cc90bbb0d5f524cbb0b06619e49ff67"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e50c94013a1d036a529df259151991dbbd6cf8dc215e3b68b784f95eec60e6"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "derive_more 2.1.1",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "op-alloy-consensus",
- "snap",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "10.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826f43a5b1613c224f561847c152bfbaefcb593a9ae2c612ff4dc4661c6e625f"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
-]
-
-[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11676,7 +12384,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -11731,6 +12439,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11781,12 +12569,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -11843,6 +12665,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -11907,7 +12735,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "499cff8432e71c5f8784d9645aac0f9fca604d67f59b68a606170b5e229c6538"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "ciborium",
  "coset",
  "data-encoding",
@@ -11960,6 +12788,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
  "crypto-mac 0.8.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -12095,9 +12933,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
  "phf_shared 0.11.3",
- "serde",
 ]
 
 [[package]]
@@ -12110,12 +12946,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -12130,13 +12986,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_macros"
-version = "0.11.3"
+name = "phf_generator"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_generator",
- "phf_shared 0.11.3",
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12161,19 +13027,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.10"
+name = "phf_shared"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12369,19 +13253,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -12428,7 +13306,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "zerovec 0.11.5",
+ "zerovec",
 ]
 
 [[package]]
@@ -12498,6 +13376,17 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -12655,38 +13544,15 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
-dependencies = [
- "bitflags 2.10.0",
- "chrono",
- "flate2",
- "hex",
- "procfs-core 0.17.0",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.10.0",
- "procfs-core 0.18.0",
- "rustix 1.1.3",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "chrono",
- "hex",
+ "flate2",
+ "procfs-core",
+ "rustix 1.1.3",
 ]
 
 [[package]]
@@ -12695,7 +13561,8 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
+ "chrono",
  "hex",
 ]
 
@@ -12729,7 +13596,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -12758,7 +13625,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -12775,12 +13652,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -12830,7 +13720,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -12934,7 +13824,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12947,6 +13837,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -12971,7 +13862,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -12990,6 +13881,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -13038,6 +13935,17 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -13099,6 +14007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13153,23 +14067,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rapidhash"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
- "bitflags 2.10.0",
- "cassowary",
- "compact_str",
- "crossterm 0.28.1",
- "indoc 2.0.7",
+ "getrandom 0.3.4",
+ "rustversion",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
  "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.18.1",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc 2.0.7",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -13188,7 +14157,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -13276,7 +14245,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -13285,7 +14254,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -13444,6 +14413,47 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -13502,10 +14512,11 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-rpc-types",
+ "alloy-primitives",
+ "alloy-rpc-types 2.0.5",
  "aquamarine",
  "clap 4.5.57",
  "eyre",
@@ -13528,7 +14539,7 @@ dependencies = [
  "reth-node-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-primitives",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-ress-protocol",
  "reth-ress-provider",
@@ -13548,16 +14559,17 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "futures-core",
  "futures-util",
  "metrics",
  "reth-chain-state",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -13566,17 +14578,19 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
+ "reth-trie-parallel",
+ "serde",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-chain-state"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "derive_more 2.1.1",
  "metrics",
@@ -13601,12 +14615,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -13621,8 +14635,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -13630,23 +14644,23 @@ dependencies = [
  "reth-cli-runner",
  "reth-db",
  "serde_json",
- "shellexpand",
 ]
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
+ "blake3",
  "clap 4.5.57",
  "comfy-table",
- "crossterm 0.28.1",
+ "crossterm 0.29.0",
  "eyre",
  "fdlimit",
  "futures",
@@ -13656,7 +14670,8 @@ dependencies = [
  "itertools 0.14.0",
  "lz4",
  "ratatui",
- "reqwest 0.12.28",
+ "rayon",
+ "reqwest 0.13.1",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -13692,10 +14707,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
+ "reth-prune-types",
  "reth-revm",
  "reth-stages",
+ "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
+ "reth-storage-api",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
@@ -13705,15 +14724,16 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-stream",
- "toml 0.8.23",
+ "toml 0.9.11+spec-1.1.0",
  "tracing",
+ "url",
  "zstd",
 ]
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -13722,10 +14742,10 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -13735,22 +14755,24 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
+ "tikv-jemalloc-sys",
  "tikv-jemallocator",
 ]
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98afe24504bdbdf20f746794e1708886c21cb4a59826652c9047cba7dfc716d4"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "parity-scale-codec 3.7.5",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -13758,10 +14780,10 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb02fa6170f3d13e621f1c05d0c6baa867e0b8ba9f841455114443bd2411a4e"
 dependencies = [
- "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13769,25 +14791,27 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "eyre",
  "humantime-serde",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
+ "reth-static-file-types",
  "serde",
- "toml 0.8.23",
+ "toml 0.9.11+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
+ "alloy-eip7928 0.4.5",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
@@ -13797,11 +14821,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -13809,23 +14834,22 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-json-rpc 2.0.5",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 2.0.5",
  "alloy-rpc-types-engine",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "auto_impl",
  "derive_more 2.1.1",
  "eyre",
  "futures",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth-node-api",
- "reth-primitives-traits",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -13835,31 +14859,34 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
  "eyre",
+ "libc",
  "metrics",
+ "page_size",
  "parking_lot 0.12.5",
  "reth-db-api",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-nippy-jar",
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
  "rocksdb",
- "sysinfo 0.33.1",
+ "sysinfo 0.38.4",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-db-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "bytes",
@@ -13877,14 +14904,15 @@ dependencies = [
  "reth-trie-common",
  "roaring",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-db-common"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "boyer-moore-magiclen",
@@ -13912,10 +14940,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
@@ -13926,14 +14954,13 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "discv5",
  "enr",
- "generic-array",
  "itertools 0.14.0",
  "parking_lot 0.12.5",
  "rand 0.8.5",
@@ -13952,8 +14979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -13976,15 +15003,15 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
+ "dashmap 6.2.1",
  "data-encoding",
  "enr",
  "hickory-resolver",
  "linked_hash_set",
- "parking_lot 0.12.5",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-tokio-util",
@@ -14000,13 +15027,14 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
+ "async-compression",
  "futures",
  "futures-util",
  "itertools 0.14.0",
@@ -14030,8 +15058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -14043,28 +15071,25 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "generic-array",
  "hmac 0.12.1",
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
- "sha3 0.10.8",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
- "typenum",
 ]
 
 [[package]]
 name = "reth-engine-local"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
@@ -14074,7 +15099,8 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-payload-builder",
  "reth-payload-primitives",
- "reth-provider",
+ "reth-primitives-traits",
+ "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -14083,11 +15109,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -14107,44 +15133,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-engine-service"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
-dependencies = [
- "futures",
- "pin-project",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-engine-tree",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-network-p2p",
- "reth-node-types",
- "reth-payload-builder",
- "reth-provider",
- "reth-prune",
- "reth-stages-api",
- "reth-tasks",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "reth-engine-tree"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
+ "crossbeam-channel",
  "derive_more 2.1.1",
  "futures",
  "gravity-primitives",
+ "indexmap 2.13.0",
  "metrics",
  "mini-moka",
+ "moka",
  "parking_lot 0.12.5",
  "rayon",
  "reth-chain-state",
@@ -14183,10 +15189,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -14211,30 +15219,31 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "reth-ethereum-primitives",
+ "sha2 0.10.9",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
+ "reth-era",
  "reth-fs-util",
  "sha2 0.10.9",
  "tokio",
@@ -14242,10 +15251,10 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures-util",
@@ -14264,8 +15273,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -14275,8 +15284,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -14303,12 +15312,13 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eip7928 0.4.5",
+ "alloy-eips 2.0.5",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -14324,8 +15334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -14340,17 +15350,18 @@ dependencies = [
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-rpc-server-types",
+ "reth-tasks",
  "reth-tracing",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -14362,26 +15373,24 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
  "reth-ethereum-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -14393,11 +15402,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -14408,6 +15417,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-execution-cache",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -14422,27 +15432,22 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "modular-bitfield",
+ "alloy-rpc-types-eth 2.0.5",
  "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
- "serde_with",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -14451,17 +15456,19 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eip7928 0.4.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more 2.1.1",
  "futures-util",
  "metrics",
+ "rayon",
  "reth-execution-errors",
  "reth-execution-types",
  "reth-metrics",
@@ -14474,14 +15481,16 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-sol-types",
+ "derive_more 2.1.1",
  "gravity-primitives",
  "grevm",
  "reth-chainspec",
@@ -14492,12 +15501,31 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-errors",
  "revm",
+ "tracing",
+]
+
+[[package]]
+name = "reth-execution-cache"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
+dependencies = [
+ "alloy-primitives",
+ "fixed-cache",
+ "metrics",
+ "parking_lot 0.12.5",
+ "reth-errors",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "reth-trie",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14509,13 +15537,14 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more 2.1.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -14527,11 +15556,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -14565,10 +15594,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -14579,8 +15608,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "serde",
  "serde_json",
@@ -14589,10 +15618,10 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -14608,6 +15637,7 @@ dependencies = [
  "reth-rpc-api",
  "reth-tracing",
  "reth-trie",
+ "revm",
  "revm-bytecode",
  "revm-database",
  "serde",
@@ -14616,8 +15646,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "bytes",
  "futures",
@@ -14635,33 +15665,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-libmdbx"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "crossbeam-queue",
+ "dashmap 6.2.1",
+ "derive_more 2.1.1",
+ "parking_lot 0.12.5",
+ "reth-mdbx-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "reth-mdbx-sys"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
 name = "reth-metrics"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
+ "reth-primitives-traits",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
+ "ipnet",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -14670,11 +15728,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -14689,6 +15747,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "rand 0.9.2",
+ "rayon",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -14716,6 +15775,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -14725,13 +15785,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-admin",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "auto_impl",
  "derive_more 2.1.1",
  "enr",
@@ -14750,11 +15810,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "auto_impl",
  "derive_more 2.1.1",
@@ -14772,8 +15832,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14787,8 +15847,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -14801,8 +15861,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -14818,8 +15878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -14842,14 +15902,14 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types 2.0.5",
  "alloy-rpc-types-engine",
  "aquamarine",
  "eyre",
@@ -14857,11 +15917,11 @@ dependencies = [
  "futures",
  "gravity-primitives",
  "jsonrpsee 0.26.0",
+ "parking_lot 0.12.5",
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
- "reth-cli-util",
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
@@ -14871,7 +15931,6 @@ dependencies = [
  "reth-downloaders",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
  "reth-evm",
@@ -14902,6 +15961,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -14911,11 +15971,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap 4.5.57",
@@ -14925,6 +15985,7 @@ dependencies = [
  "futures",
  "gravity-primitives",
  "humantime",
+ "ipnet",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
@@ -14936,6 +15997,7 @@ dependencies = [
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
+ "reth-net-banlist",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
@@ -14948,14 +16010,15 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-tracing",
+ "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "shellexpand",
  "strum 0.27.2",
  "thiserror 2.0.18",
- "toml 0.8.23",
+ "toml 0.9.11+spec-1.1.0",
  "tracing",
  "url",
  "vergen",
@@ -14964,14 +16027,19 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
- "alloy-network",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
+ "alloy-network 2.0.5",
+ "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
+ "ethereum_ssz",
  "eyre",
+ "http-body-util",
+ "jsonrpsee 0.26.0",
  "reth-chainspec",
  "reth-engine-local",
  "reth-engine-primitives",
@@ -14984,6 +16052,7 @@ dependencies = [
  "reth-network",
  "reth-node-api",
  "reth-node-builder",
+ "reth-node-core",
  "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-provider",
@@ -14997,15 +16066,18 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "revm",
+ "serde",
+ "serde_json",
  "tokio",
+ "tower 0.5.3",
 ]
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "chrono",
  "futures-util",
@@ -15019,18 +16091,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more 2.1.1",
@@ -15050,17 +16122,20 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
+ "bytes",
  "eyre",
  "http 1.4.0",
+ "http-body-util",
  "jsonrpsee-server",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "procfs 0.17.0",
+ "procfs 0.18.0",
+ "reqwest 0.13.1",
  "reth-metrics",
  "reth-tasks",
  "tikv-jemalloc-ctl",
@@ -15071,8 +16146,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -15083,20 +16158,23 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 2.0.5",
+ "derive_more 2.1.1",
  "futures-util",
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-trie-parallel",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -15104,8 +16182,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -15116,38 +16194,41 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
  "either",
- "op-alloy-rpc-types-engine",
- "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
+ "reth-execution-types",
  "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -15159,13 +16240,13 @@ dependencies = [
 
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-sol-macro",
  "alloy-sol-types",
  "api-types",
@@ -15206,21 +16287,21 @@ dependencies = [
 
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-network",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
+ "alloy-provider 2.0.5",
+ "alloy-rpc-types 2.0.5",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "anyhow",
  "api-types",
  "async-trait",
  "chrono",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "serde",
  "serde_json",
  "tokio",
@@ -15230,10 +16311,10 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "once_cell",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -15243,23 +16324,23 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.1"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-trie",
- "auto_impl",
  "byteorder",
  "bytes",
+ "dashmap 6.2.1",
  "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
+ "quanta 0.12.6",
  "rayon",
  "reth-codecs",
  "revm-bytecode",
@@ -15273,14 +16354,14 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "eyre",
  "gravity-primitives",
  "itertools 0.14.0",
@@ -15316,11 +16397,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -15344,23 +16425,25 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
  "modular-bitfield",
  "reth-codecs",
  "serde",
+ "strum 0.27.2",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "futures",
@@ -15376,10 +16459,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -15403,10 +16486,12 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -15416,42 +16501,38 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-evm",
  "alloy-genesis",
- "alloy-network",
+ "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types 2.0.5",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-serde 2.0.5",
+ "alloy-signer 2.0.5",
+ "alloy-signer-local 2.0.5",
  "async-trait",
  "derive_more 2.1.1",
  "dyn-clone",
  "futures",
  "gravity-precompiles",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
  "itertools 0.14.0",
  "jsonrpsee 0.26.0",
  "jsonrpsee-types",
- "jsonwebtoken 9.3.1",
  "parking_lot 0.12.5",
  "pin-project",
  "reth-chain-state",
@@ -15460,6 +16541,8 @@ dependencies = [
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -15489,46 +16572,47 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
  "tracing",
  "tracing-futures",
 ]
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-genesis",
- "alloy-json-rpc",
+ "alloy-json-rpc 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 2.0.5",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "jsonrpsee 0.26.0",
  "reth-chain-state",
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-network",
- "alloy-provider",
+ "alloy-network 2.0.5",
+ "alloy-provider 2.0.5",
  "dyn-clone",
  "http 1.4.0",
  "jsonrpsee 0.26.0",
@@ -15537,20 +16621,24 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
  "reth-metrics",
  "reth-network-api",
  "reth-node-core",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
+ "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
+ "reth-tokio-util",
  "reth-transaction-pool",
  "serde",
  "thiserror 2.0.18",
@@ -15563,41 +16651,42 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-consensus 2.0.5",
+ "alloy-evm",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-types-eth 2.0.5",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
- "revm-context",
+ "reth-rpc-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "parking_lot 0.12.5",
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-metrics",
+ "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -15614,20 +16703,21 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eip7928 0.4.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-json-rpc 2.0.5",
+ "alloy-network 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 2.0.5",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -15642,6 +16732,7 @@ dependencies = [
  "reth-network-api",
  "reth-node-api",
  "reth-primitives-traits",
+ "reth-prune-types",
  "reth-revm",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -15658,18 +16749,20 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-chains",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-evm",
- "alloy-network",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
+ "alloy-rpc-client 2.0.5",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 2.0.5",
  "derive_more 2.1.1",
  "futures",
  "itertools 0.14.0",
@@ -15677,7 +16770,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -15701,12 +16794,13 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -15719,10 +16813,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -15734,20 +16828,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-stages"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+name = "reth-rpc-traits"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947a4e5cec5166505ea078c9164f06bf691fd83d3850e72851b58a9f1900cb6d"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-network 2.0.5",
  "alloy-primitives",
- "bincode",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-signer 2.0.5",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-stages"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-primitives",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest 0.13.1",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -15770,6 +16878,7 @@ dependencies = [
  "reth-stages-api",
  "reth-static-file-types",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-parallel",
  "thiserror 2.0.18",
@@ -15779,15 +16888,16 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
  "futures-util",
  "metrics",
+ "reth-codecs",
  "reth-consensus",
  "reth-errors",
  "reth-metrics",
@@ -15806,8 +16916,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15819,8 +16929,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -15839,27 +16949,29 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
  "derive_more 2.1.1",
+ "fixed-map",
  "serde",
  "strum 0.27.2",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "gravity-primitives",
  "metrics",
  "metrics-derive",
@@ -15881,33 +16993,38 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 2.1.1",
+ "reth-codecs",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
+ "revm-state",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "auto_impl",
- "dyn-clone",
+ "crossbeam-utils",
+ "dashmap 6.2.1",
  "futures-util",
+ "libc",
  "metrics",
+ "parking_lot 0.12.5",
  "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",
+ "thread-priority",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -15915,8 +17032,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -15925,33 +17042,55 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "clap 4.5.57",
  "eyre",
+ "reth-tracing-otlp",
  "rolling-file",
  "tracing",
  "tracing-appender",
+ "tracing-chrome",
  "tracing-journald",
  "tracing-logfmt",
+ "tracing-samply",
  "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
-name = "reth-transaction-pool"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+name = "reth-tracing-otlp"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "base64 0.22.1",
+ "clap 4.5.57",
+ "eyre",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.22",
+ "url",
+]
+
+[[package]]
+name = "reth-transaction-pool"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
+dependencies = [
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "futures-util",
  "gravity-primitives",
+ "imbl",
  "metrics",
  "parking_lot 0.12.5",
  "pin-project",
@@ -15960,6 +17099,8 @@ dependencies = [
  "reth-chainspec",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
@@ -15967,6 +17108,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
+ "revm",
  "revm-interpreter",
  "revm-primitives",
  "rustc-hash 2.1.1",
@@ -15982,17 +17124,18 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.0.5",
+ "alloy-eips 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
+ "parking_lot 0.12.5",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -16006,14 +17149,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.0.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.0.5",
+ "alloy-serde 2.0.5",
  "alloy-trie",
  "bytes",
  "derive_more 2.1.1",
@@ -16033,8 +17176,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16052,11 +17195,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
+ "alloy-eip7928 0.4.5",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
+ "crossbeam-channel",
  "derive_more 2.1.1",
  "itertools 0.14.0",
  "metrics",
@@ -16070,6 +17216,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "reth-trie-sparse",
+ "revm-state",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -16077,8 +17224,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16090,14 +17237,16 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
+ "serde",
+ "serde_json",
  "smallvec",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "2.3.0"
+source = "git+https://github.com/Galxe/gravity-reth?rev=bc817c642c9c3816cc4e22754e13e3c9633419dd#bc817c642c9c3816cc4e22754e13e3c9633419dd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16114,8 +17263,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/Galxe/gravity-reth?rev=b49b4864aeaa3c35c6871a77d7133bb9486edbf1#b49b4864aeaa3c35c6871a77d7133bb9486edbf1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395b92a7cf863f70bd109e35f70a2fe36033187de06f6840e0ccf61c8008375d"
 dependencies = [
  "zstd",
 ]
@@ -16133,9 +17283,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "29.0.1"
+version = "40.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718d90dce5f07e115d0e66450b1b8aa29694c1cf3f89ebddaddccc2ccbd2f13e"
+checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -16152,21 +17302,21 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.2.2"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
 dependencies = [
  "bitvec 1.0.1",
- "phf 0.11.3",
+ "phf 0.13.1",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "9.1.0"
+version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a20c98e7008591a6f012550c2a00aa36cba8c14cc88eb88dec32eb9102554b4"
+checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
 dependencies = [
  "bitvec 1.0.1",
  "cfg-if",
@@ -16181,9 +17331,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "10.2.0"
+version = "19.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d241ed1ce647b94caf174fcd0239b7651318b2c4c06b825b59b973dfb8495"
+checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -16197,11 +17347,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.5"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.5",
+ "derive_more 2.1.1",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -16211,22 +17362,23 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.5"
+version = "12.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
  "revm-state",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "10.0.1"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550331ea85c1d257686e672081576172fe3d5a10526248b663bbf54f1bef226a"
+checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -16243,9 +17395,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "10.0.1"
+version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0a6e9ccc2ae006f5bed8bd80cd6f8d3832cd55c5e861b9402fdd556098512f"
+checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
@@ -16261,12 +17413,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.30.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de23199c4b6181a6539e4131cf7e31cde4df05e1192bcdce491c34a511241588"
+checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 2.0.5",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -16281,21 +17433,22 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "25.0.3"
+version = "37.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575dc51b1d8f5091daa12a435733a90b4a132dca7ccee0666c7db3851bc30c"
+checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "27.0.0"
+version = "36.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b57d4bd9e6b5fe469da5452a8a137bc2d030a3cd47c46908efc615bbc699da"
+checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-bn254 0.5.0",
@@ -16304,38 +17457,39 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
- "libsecp256k1",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
- "rug",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "20.2.1"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
 dependencies = [
  "alloy-primitives",
- "num_enum",
  "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "7.0.5"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
 dependencies = [
- "bitflags 2.10.0",
+ "alloy-eip7928 0.4.5",
+ "bitflags 2.13.0",
+ "nonmax",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -16400,9 +17554,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
 
 [[package]]
 name = "ripemd"
@@ -16462,9 +17616,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -16546,18 +17700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rug"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
-]
-
-[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16620,6 +17762,15 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -16652,24 +17803,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -16778,7 +17916,7 @@ checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.36",
@@ -16789,6 +17927,27 @@ dependencies = [
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.6",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16859,6 +18018,15 @@ name = "ryu-js"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -17003,7 +18171,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -17016,7 +18184,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -17035,11 +18203,20 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
@@ -17051,6 +18228,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -17078,11 +18261,11 @@ name = "sentinel"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
+ "alloy-provider 1.0.37",
+ "alloy-rpc-types 1.0.37",
  "alloy-sol-macro",
  "alloy-sol-types",
- "alloy-transport-http",
+ "alloy-transport-http 1.0.37",
  "anyhow",
  "chrono",
  "csv",
@@ -17243,6 +18426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17327,7 +18519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -17345,7 +18537,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -17357,7 +18549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -17369,7 +18561,7 @@ checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
- "keccak",
+ "keccak 0.1.5",
  "opaque-debug",
 ]
 
@@ -17380,7 +18572,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.5",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -17418,19 +18620,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -17450,7 +18649,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.1.1",
+ "mio 1.2.1",
  "signal-hook",
 ]
 
@@ -17485,6 +18684,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -17558,7 +18773,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
- "bitmaps",
+ "bitmaps 2.1.0",
  "typenum",
 ]
 
@@ -17597,6 +18812,15 @@ checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
 dependencies = [
  "deunicode",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "small_btree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+dependencies = [
+ "arrayvec 0.7.6",
 ]
 
 [[package]]
@@ -17672,12 +18896,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17736,12 +18960,6 @@ dependencies = [
  "base64ct",
  "der 0.7.10",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -17824,20 +19042,20 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -17868,22 +19086,21 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -17927,6 +19144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17950,9 +19173,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -18003,15 +19226,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -18031,7 +19255,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -18057,6 +19281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tag_ptr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18070,9 +19300,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -18225,6 +19455,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2e834949be5111506bb252643498af1514f600d9e1dceedaa42afae155b67f"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18281,7 +19525,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -18316,7 +19559,7 @@ dependencies = [
  "anyhow",
  "hmac 0.8.1",
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash 1.1.0",
  "sha2 0.9.9",
@@ -18337,22 +19580,13 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec 0.10.4",
-]
-
-[[package]]
-name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
- "zerovec 0.11.5",
+ "serde_core",
+ "zerovec",
 ]
 
 [[package]]
@@ -18382,26 +19616,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "backtrace",
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio 1.2.1",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18507,9 +19742,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -18518,7 +19753,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite 0.26.2",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -18544,7 +19779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.19.15",
 ]
@@ -18556,9 +19791,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -18587,7 +19837,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -18600,7 +19850,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.14",
@@ -18634,6 +19884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18654,7 +19910,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rustls-native-certs 0.8.3",
  "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
@@ -18670,16 +19926,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
 name = "tonic-reflection"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -18736,7 +20029,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -18785,11 +20078,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.22",
@@ -18804,6 +20098,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -18867,6 +20172,38 @@ checksum = "a250055a3518b5efba928a18ffac8d32d42ea607a9affff4532144cd5b2e378e"
 dependencies = [
  "time",
  "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.22",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-samply"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c175f7ecc002b6ef04776a39f440503e4e788790ddbdbfac8259b7a069526334"
+dependencies = [
+ "cfg-if",
+ "itoa",
+ "libc",
+ "mach2 0.5.0",
+ "memmap2",
+ "smallvec",
  "tracing-core",
  "tracing-subscriber 0.3.22",
 ]
@@ -18941,9 +20278,9 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
@@ -18954,11 +20291,11 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -19034,9 +20371,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -19065,6 +20402,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -19206,13 +20549,13 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -19239,7 +20582,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -19682,6 +21025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19738,22 +21091,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -19764,19 +21107,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -19785,10 +21116,10 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
 ]
 
@@ -19798,20 +21129,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -19819,17 +21139,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -19859,7 +21168,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -19870,17 +21179,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -20226,6 +21526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20246,12 +21555,6 @@ name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "writeable"
@@ -20316,6 +21619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xsum"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20341,37 +21650,13 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive 0.7.5",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
- "yoke-derive 0.8.1",
+ "yoke-derive",
  "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "synstructure",
 ]
 
 [[package]]
@@ -20492,19 +21777,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
- "yoke 0.8.1",
+ "yoke",
  "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke 0.7.5",
- "zerofrom",
- "zerovec-derive 0.10.3",
 ]
 
 [[package]]
@@ -20513,20 +21787,10 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
- "yoke 0.8.1",
+ "serde",
+ "yoke",
  "zerofrom",
- "zerovec-derive 0.11.2",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "zerovec-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -508,3 +508,10 @@ alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy", tag = "v1.0.37" }
 # 100% CPU spin). Upstream issue: https://github.com/jmagnuson/linemux/issues/57
 linemux = { git = "https://github.com/Galxe/linemux.git", rev = "0194e0222134c587dcd50039a1ff9c8a14fae550" }
 
+# greth's own `[patch.crates-io]` is IGNORED once greth is consumed as a git
+# dependency (only the top-level workspace's patches apply), so replicate its
+# single active redirect here: collapse the transitive crates.io
+# `reth-primitives-traits` onto greth's in-tree crate so the whole graph
+# unifies on one `reth-primitives-traits`.
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "bc817c642c9c3816cc4e22754e13e3c9633419dd" }
+

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -20,7 +20,12 @@ futures-util = "0.3.30"
 clap = { version = "4.5.17", features = ["derive", "env"] }
 futures = "0.3.30"
 dirs = "5.0.1"
-tokio = "1.40.0"
+# `taskdump` is required because the SDK builds with `--cfg tokio_unstable`
+# (needed by aptos-runtimes), which activates greth's
+# `#[cfg(tokio_unstable)] handle_tokio_dump` in reth-node-metrics; that calls
+# `Handle::dump()`, gated on `tokio_unstable + feature="taskdump"`. greth never
+# enables it (it never sets tokio_unstable standalone), so we enable it here.
+tokio = { version = "1.40.0", features = ["taskdump"] }
 tokio-stream = "0.1.16"
 eyre = "0.6.12"
 tracing = "0.1.40"
@@ -33,15 +38,19 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "b49b4864aeaa3c35c6871a77d7133bb9486edbf1" }
+# greth main @ PR #414 (block-gas last gate at Beta; includes #413/#412/#410)
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "bc817c642c9c3816cc4e22754e13e3c9633419dd" }
 reqwest = "0.12.9"
-alloy-primitives = { version = "=1.3.1", default-features = false, features = ["map-foldhash"] }
-alloy-eips = { version = "^1.0.37", default-features = false }
-alloy-consensus = { version = "=1.0.37" }
-alloy-genesis = { version = "=1.0.37", default-features = false }
-alloy-serde = { version = "=1.0.37" }
-alloy-transport-http = "=1.0.37"
-alloy-rpc-types-eth = "=1.0.37"
+# Aligned with gravity-reth v2.3.0 (alloy-primitives 1.6.0, alloy-* 2.0.5) so
+# gravity_node's own alloy types unify with the ones re-exported through greth.
+# Kept as caret (not `=`) to share a single resolved version with greth.
+alloy-primitives = { version = "1.6.0", default-features = false, features = ["map-foldhash"] }
+alloy-eips = { version = "2.0.5", default-features = false }
+alloy-consensus = { version = "2.0.5" }
+alloy-genesis = { version = "2.0.5", default-features = false }
+alloy-serde = { version = "2.0.5" }
+alloy-transport-http = "2.0.5"
+alloy-rpc-types-eth = "2.0.5"
 async-trait.workspace = true
 api.workspace = true
 gaptos = { workspace = true, features = ["gcp-secret-manager"] }

--- a/bin/gravity_node/src/cli.rs
+++ b/bin/gravity_node/src/cli.rs
@@ -12,7 +12,7 @@ use greth::{
     reth_node_builder::{NodeBuilder, WithLaunchContext},
     reth_node_core::args::LogArgs,
     reth_node_ethereum::{consensus::EthBeaconConsensus, EthEvmConfig, EthereumNode},
-    reth_tracing::FileWorkerGuard,
+    reth_tracing::TracingGuards,
 };
 use std::{
     collections::BTreeMap,
@@ -155,10 +155,20 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
         self.logs.log_file_directory =
             self.logs.log_file_directory.join(self.chain.chain.to_string());
 
+        // greth keeps the node-subcommand default (5 files) outside LogArgs, so `--log.file.*`
+        // are otherwise accepted while the file layer is never installed (see its app.rs).
+        if matches!(self.command, Commands::Node(_)) {
+            self.logs.apply_node_defaults();
+        }
+
         let _guard = self.init_tracing()?;
         debug!(target: "reth::cli", "Initialized tracing, log directory: {}, log level {:?}", self.logs.log_file_directory, self.logs.verbosity);
 
         let runner = CliRunner::try_default_runtime()?;
+        // reth v2.3.0: init/init-state execute() now take a Runtime; db/prune
+        // execute() take a CliContext supplied via the *_command_until_exit runner
+        // methods (see gravity-reth crates/ethereum/cli/src/app.rs).
+        let rt = runner.runtime();
         let components = |spec: Arc<C::ChainSpec>| {
             (EthEvmConfig::ethereum(spec.clone()), Arc::new(EthBeaconConsensus::new(spec)))
         };
@@ -171,18 +181,20 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
             }
             Commands::Init(command) => {
                 println!("Running init command");
-                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
+                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>(rt))
             }
             Commands::InitState(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
+                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>(rt))
             }
             Commands::DumpGenesis(command) => runner.run_blocking_until_ctrl_c(command.execute()),
             Commands::Db(command) => {
-                runner.run_blocking_until_ctrl_c(command.execute::<EthereumNode>())
+                runner.run_blocking_command_until_exit(|ctx| command.execute::<EthereumNode>(ctx))
             }
             Commands::P2P(command) => runner.run_until_ctrl_c(command.execute::<EthereumNode>()),
             Commands::Config(command) => runner.run_until_ctrl_c(command.execute()),
-            Commands::Prune(command) => runner.run_until_ctrl_c(command.execute::<EthereumNode>()),
+            Commands::Prune(command) => {
+                runner.run_command_until_exit(|ctx| command.execute::<EthereumNode>(ctx))
+            }
             Commands::Stage(command) => {
                 println!("Running stage command");
                 runner.run_command_until_exit(|ctx| {
@@ -197,7 +209,7 @@ impl<C: ChainSpecParser<ChainSpec = ChainSpec>, Ext: clap::Args + fmt::Debug> Cl
     ///
     /// If file logging is enabled, this function returns a guard that must be kept alive to ensure
     /// that all logs are flushed to disk.
-    pub fn init_tracing(&self) -> eyre::Result<Option<FileWorkerGuard>> {
+    pub fn init_tracing(&self) -> eyre::Result<TracingGuards> {
         let guard = self.logs.init_tracing()?;
         Ok(guard)
     }

--- a/bin/gravity_node/src/reth_cli.rs
+++ b/bin/gravity_node/src/reth_cli.rs
@@ -74,6 +74,7 @@ pub(crate) type RethTransactionPool = greth::reth_transaction_pool::Pool<
         greth::reth_transaction_pool::EthTransactionValidator<
             RethBlockChainProvider,
             greth::reth_transaction_pool::EthPooledTransaction,
+            greth::reth_node_ethereum::EthEvmConfig,
         >,
     >,
     greth::reth_transaction_pool::CoinbaseTipOrdering<

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -449,14 +449,44 @@ START_SCRIPT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE="$SCRIPT_DIR/.."
 
+# Wait until the kernel has reaped the process. greth v2.3+ can keep the
+# RocksDB LOCK held for several seconds after SIGTERM while flushing; if we
+# delete the pid file and return early, e2e restart races the lock and dies
+# with "Resource temporarily unavailable".
+wait_pid_gone() {
+    local pid="$1"
+    local max_iters="$2"
+    local i
+    for i in $(seq 1 "$max_iters"); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    return 1
+}
+
 if [ -e "${WORKSPACE}/script/node.pid" ]; then
     pid=$(cat "${WORKSPACE}/script/node.pid")
     if kill -0 "$pid" 2>/dev/null; then
-        kill "$pid"
-        echo "Stopped node (PID: $pid)"
+        kill "$pid" 2>/dev/null || true
+        # ~30s graceful (SIGTERM)
+        if wait_pid_gone "$pid" 60; then
+            echo "Stopped node (PID: $pid)"
+        else
+            echo "Node (PID: $pid) still alive after SIGTERM; sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+            # ~20s after SIGKILL for process to disappear
+            if wait_pid_gone "$pid" 40; then
+                echo "Stopped node (PID: $pid, forced)"
+            else
+                echo "ERROR: node PID $pid still alive after SIGKILL" >&2
+            fi
+        fi
     else
         echo "Node not running (stale PID file)"
     fi
+    # Only drop the pid file after the process is gone (or we gave up).
     rm -f "${WORKSPACE}/script/node.pid"
 else
     echo "No PID file found"
@@ -573,14 +603,44 @@ START_SCRIPT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE="$SCRIPT_DIR/.."
 
+# Wait until the kernel has reaped the process. greth v2.3+ can keep the
+# RocksDB LOCK held for several seconds after SIGTERM while flushing; if we
+# delete the pid file and return early, e2e restart races the lock and dies
+# with "Resource temporarily unavailable".
+wait_pid_gone() {
+    local pid="$1"
+    local max_iters="$2"
+    local i
+    for i in $(seq 1 "$max_iters"); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    return 1
+}
+
 if [ -e "${WORKSPACE}/script/node.pid" ]; then
     pid=$(cat "${WORKSPACE}/script/node.pid")
     if kill -0 "$pid" 2>/dev/null; then
-        kill "$pid"
-        echo "Stopped node (PID: $pid)"
+        kill "$pid" 2>/dev/null || true
+        # ~30s graceful (SIGTERM)
+        if wait_pid_gone "$pid" 60; then
+            echo "Stopped node (PID: $pid)"
+        else
+            echo "Node (PID: $pid) still alive after SIGTERM; sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+            # ~20s after SIGKILL for process to disappear
+            if wait_pid_gone "$pid" 40; then
+                echo "Stopped node (PID: $pid, forced)"
+            else
+                echo "ERROR: node PID $pid still alive after SIGKILL" >&2
+            fi
+        fi
     else
         echo "Node not running (stale PID file)"
     fi
+    # Only drop the pid file after the process is gone (or we gave up).
     rm -f "${WORKSPACE}/script/node.pid"
 else
     echo "No PID file found"
@@ -706,14 +766,44 @@ START_SCRIPT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE="$SCRIPT_DIR/.."
 
+# Wait until the kernel has reaped the process. greth v2.3+ can keep the
+# RocksDB LOCK held for several seconds after SIGTERM while flushing; if we
+# delete the pid file and return early, e2e restart races the lock and dies
+# with "Resource temporarily unavailable".
+wait_pid_gone() {
+    local pid="$1"
+    local max_iters="$2"
+    local i
+    for i in $(seq 1 "$max_iters"); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    return 1
+}
+
 if [ -e "${WORKSPACE}/script/node.pid" ]; then
     pid=$(cat "${WORKSPACE}/script/node.pid")
     if kill -0 "$pid" 2>/dev/null; then
-        kill "$pid"
-        echo "Stopped node (PID: $pid)"
+        kill "$pid" 2>/dev/null || true
+        # ~30s graceful (SIGTERM)
+        if wait_pid_gone "$pid" 60; then
+            echo "Stopped node (PID: $pid)"
+        else
+            echo "Node (PID: $pid) still alive after SIGTERM; sending SIGKILL"
+            kill -9 "$pid" 2>/dev/null || true
+            # ~20s after SIGKILL for process to disappear
+            if wait_pid_gone "$pid" 40; then
+                echo "Stopped node (PID: $pid, forced)"
+            else
+                echo "ERROR: node PID $pid still alive after SIGKILL" >&2
+            fi
+        fi
     else
         echo "Node not running (stale PID file)"
     fi
+    # Only drop the pid file after the process is gone (or we gave up).
     rm -f "${WORKSPACE}/script/node.pid"
 else
     echo "No PID file found"

--- a/cluster/stop.sh
+++ b/cluster/stop.sh
@@ -113,9 +113,13 @@ stop_node() {
     
     log_info "Stopping $node_id (PID: $pid)..."
     kill "$pid" 2>/dev/null || true
-    
-    # Wait for graceful shutdown
-    for i in {1..10}; do
+
+    # Wait until the process is really gone before dropping the pid file.
+    # greth v2.3+ can hold the RocksDB LOCK for several seconds after SIGTERM
+    # while flushing; returning early races the next start
+    # ("Resource temporarily unavailable" on .../db/state/LOCK).
+    # ~30s graceful
+    for i in {1..60}; do
         if ! kill -0 "$pid" 2>/dev/null; then
             rm -f "$pid_file"
             log_info "$node_id stopped"
@@ -123,12 +127,22 @@ stop_node() {
         fi
         sleep 0.5
     done
-    
-    # Force kill if still running
+
+    # Force kill if still running, then wait again for the kernel to reap it.
     log_warn "$node_id: Force killing..."
     kill -9 "$pid" 2>/dev/null || true
+    for i in {1..40}; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            rm -f "$pid_file"
+            log_info "$node_id stopped (forced)"
+            return 0
+        fi
+        sleep 0.5
+    done
+
+    # Last resort: drop pid bookkeeping so callers are not stuck, but warn.
     rm -f "$pid_file"
-    log_info "$node_id stopped (forced)"
+    log_error "$node_id: PID $pid still alive after SIGKILL"
 }
 
 # Main

--- a/gravity_e2e/cluster_test_cases/prague/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/prague/genesis.toml
@@ -3,6 +3,11 @@
 # !! pragueTime must be > genesis_timestamp_secs so the EIP-2935 deployment
 #    hook (pipe-exec eip_2935.rs gate parent_ts < pragueTime <= current_ts)
 #    fires on block 1. Change one, change the other.
+#
+# !! betaTime (gravity-reth #412): until Beta, filter_invalid_txs wholesale-rejects
+#    type-4 and from/to-delegated traffic (EIP-7702 emergency lockdown). Missing
+#    betaTime → lockdown forever (fail-closed). This suite exercises Prague 7702
+#    behaviour, so release lockdown at the same timestamp as pragueTime.
 
 [dependencies.genesis_contracts]
 repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
@@ -29,6 +34,8 @@ initial_locked_until_micros = 1798848000000000
 
 [genesis.hardforks]
 pragueTime = 1775664001
+# Same wall-clock as pragueTime: Prague protocol + Beta lockdown release together.
+betaTime = 1775664001
 
 [genesis.faucet]
 address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"

--- a/gravity_e2e/gravity_e2e/cluster/node.py
+++ b/gravity_e2e/gravity_e2e/cluster/node.py
@@ -274,6 +274,13 @@ class Node:
         """
         Stop this individual node.
         Returns True if node is now STOPPED.
+
+        Important: ``NodeState.STOPPED`` from get_state() only means the PID
+        file is gone or the process is not reachable via that file. The
+        generated stop.sh used to delete the pid file right after SIGTERM
+        while gravity_node was still flushing RocksDB. We capture the PID
+        *before* stop.sh runs and wait until the OS reports it gone so the
+        next start does not race the RocksDB LOCK.
         """
         if not self.stop_script.exists():
             LOG.warning(
@@ -287,6 +294,14 @@ class Node:
         if current_state == NodeState.STOPPED:
             LOG.info(f"Node {self.id} is already stopped.")
             return True
+
+        # Capture PID before stop.sh deletes the pid file.
+        pid: Optional[int] = None
+        if self.pid_file.exists():
+            try:
+                pid = int(self.pid_file.read_text().strip())
+            except ValueError:
+                pid = None
 
         LOG.info(f"Stopping node {self.id}...")
 
@@ -304,9 +319,16 @@ class Node:
                 LOG.error(f"Node {self.id} stop script failed: {stderr.decode()}")
                 return False
 
-            # Verify stopped
-            await asyncio.sleep(1)
-            # Re-check live state
+            # Belt-and-suspenders: wait for the real process to exit even if
+            # stop.sh returned early (older generated scripts, or race).
+            if pid is not None:
+                if not await self._wait_for_pid_exit(pid, timeout=50.0):
+                    LOG.error(
+                        f"Node {self.id}: PID {pid} still alive after stop script; "
+                        f"restart would race RocksDB LOCK"
+                    )
+                    return False
+
             final_state, _ = await self.get_state()
 
             if final_state == NodeState.STOPPED:
@@ -322,11 +344,29 @@ class Node:
             LOG.error(f"Exception stopping node {self.id}: {e}")
             return False
 
+    async def _wait_for_pid_exit(self, pid: int, timeout: float = 50.0) -> bool:
+        """Wait until ``pid`` is no longer alive (ProcessLookupError on kill 0)."""
+        import os
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return True
+            except PermissionError:
+                # Process exists but not owned by us — treat as still alive.
+                pass
+            await asyncio.sleep(0.25)
+        return False
+
     async def restart(self) -> bool:
         """Bounce the node."""
         if not await self.stop():
             return False
-        await asyncio.sleep(2)  # Grace period
+        # stop() already waits for process exit / RocksDB unlock; short settle only.
+        await asyncio.sleep(0.5)
         return await self.start()
 
     def is_running(self) -> bool:


### PR DESCRIPTION
## Summary

Port of [#802](https://github.com/Galxe/gravity-sdk/pull/802) onto **`branch-v1.9`**.

- **Base:** `branch-v1.9` (not `main`)
- **Explicitly excludes [#803](https://github.com/Galxe/gravity-sdk/pull/803)** (`feat(oracle): wire generic relayer runtime`), which was merged to `main` but must not land on v1.9. That PR rewires the oracle relayer + pins different greth/gaptos revs (`53a9df97` / `a64f8adc`).
- Cherry-picked the three #802 commits cleanly onto `upstream/branch-v1.9` @ `6c233dfc` (same merge-base as the original #802 head).

### Greth pin

- `greth` / workspace `reth-primitives-traits` patch → [`bc817c642c9c3816cc4e22754e13e3c9633419dd`](https://github.com/Galxe/gravity-reth/commit/bc817c642c9c3816cc4e22754e13e3c9633419dd) (Galxe/gravity-reth#414 — block-gas last gate at Beta; includes #413/#412/#410)
- `gaptos` remains the v1.9 pin (`b1f68dc…`), **not** the #803 Aptos rev

### Key changes (same as #802)

1. **Deps:** greth v2.3.0 pin + lockfile; alloy pins aligned (`alloy-primitives` 1.6.0, `alloy-*` 2.0.5); tokio `taskdump` enabled for `gravity_node`
2. **CLI:** `cli.rs` / `reth_cli.rs` adapted to reth v2.3.0 command signatures (`Runtime` / `CliContext`) and greth node log defaults / `TracingGuards`
3. **Prague e2e:** set `betaTime` with `pragueTime` so greth #412 EIP-7702 lockdown is released for SetCode txs
4. **Stop LOCK race:** wait for real process exit in `cluster/stop.sh`, `cluster/deploy.sh` stop templates, and `node.py` so greth v2.3+ RocksDB LOCK flush after SIGTERM does not race e2e restart

### Out of scope (same as #802)

- No `gravity_e2e` storage_v2 baseline/upgrade/fresh_sync work
- No #803 oracle relayer rewrite

## Test plan

- [ ] File set matches #802: `Cargo.toml`, `Cargo.lock`, `bin/gravity_node/Cargo.toml`, `cli.rs`, `reth_cli.rs`, `cluster/deploy.sh`, `cluster/stop.sh`, prague `genesis.toml`, `node.py`
- [ ] Greth rev is `bc817c64…`; no `53a9df97` / `a64f8adc` (#803) pins; `relayer.rs` unchanged vs `branch-v1.9`
- [ ] `RUSTFLAGS="--cfg tokio_unstable" cargo check -p gravity_node`
- [ ] Smoke: node starts and writes log files with default node log settings
- [ ] Local e2e batch stop / restart no longer hits RocksDB LOCK `Resource temporarily unavailable`
- [ ] CI e2e (incl. prague suite with `betaTime`)