### PR TITLE
test(oracle): add deterministic Binance quorum E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4981,7 +4981,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -6008,7 +6008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7464,7 +7464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 
 [[package]]
 name = "gravity-sdk"
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -9429,7 +9429,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -9954,7 +9954,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12068,7 +12068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12273,7 +12273,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13670,7 +13670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13683,7 +13683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13849,7 +13849,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -13887,9 +13887,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -14538,7 +14538,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 2.0.5",
@@ -14585,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14612,7 +14612,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14641,7 +14641,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14661,7 +14661,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -14674,7 +14674,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14758,7 +14758,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -14768,7 +14768,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14817,7 +14817,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -14833,7 +14833,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -14847,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14860,7 +14860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14885,7 +14885,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -14909,7 +14909,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14935,7 +14935,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14966,7 +14966,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14980,7 +14980,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15005,7 +15005,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15029,7 +15029,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -15053,7 +15053,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15084,7 +15084,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -15112,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15135,7 +15135,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15160,7 +15160,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15215,7 +15215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15245,7 +15245,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15261,7 +15261,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15277,7 +15277,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15299,7 +15299,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -15310,7 +15310,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -15338,7 +15338,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -15360,7 +15360,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15383,7 +15383,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15399,7 +15399,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15415,7 +15415,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -15428,7 +15428,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15458,7 +15458,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15472,7 +15472,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -15482,7 +15482,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -15507,7 +15507,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15532,7 +15532,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -15550,7 +15550,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -15563,7 +15563,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15582,7 +15582,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15620,7 +15620,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15634,7 +15634,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "serde",
  "serde_json",
@@ -15644,7 +15644,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15672,7 +15672,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "bytes",
  "futures",
@@ -15692,7 +15692,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -15709,7 +15709,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "bindgen",
  "cc",
@@ -15718,7 +15718,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "futures",
  "metrics",
@@ -15731,7 +15731,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -15740,7 +15740,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -15754,7 +15754,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15811,7 +15811,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15836,7 +15836,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15858,7 +15858,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15873,7 +15873,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -15887,7 +15887,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "anyhow",
  "bincode",
@@ -15904,7 +15904,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -15928,7 +15928,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15997,7 +15997,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16053,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16100,7 +16100,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16124,7 +16124,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16148,7 +16148,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "bytes",
  "eyre",
@@ -16172,7 +16172,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -16184,7 +16184,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16208,7 +16208,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -16220,7 +16220,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16243,7 +16243,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
@@ -16253,7 +16253,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -16266,7 +16266,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16313,7 +16313,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -16337,7 +16337,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "once_cell",
@@ -16350,7 +16350,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.4.1"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16380,7 +16380,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16423,7 +16423,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16451,7 +16451,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16466,7 +16466,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16485,7 +16485,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16512,7 +16512,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16527,7 +16527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16604,7 +16604,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -16634,7 +16634,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-provider 2.0.5",
@@ -16677,7 +16677,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -16698,7 +16698,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16729,7 +16729,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16775,7 +16775,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -16825,7 +16825,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -16839,7 +16839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16870,7 +16870,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16914,7 +16914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16942,7 +16942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16955,7 +16955,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -16975,7 +16975,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -16989,7 +16989,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17019,7 +17019,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -17037,7 +17037,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -17058,7 +17058,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -17068,7 +17068,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -17086,7 +17086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "base64 0.22.1",
  "clap 4.5.57",
@@ -17104,7 +17104,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17150,7 +17150,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17175,7 +17175,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -17202,7 +17202,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17221,7 +17221,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-eip7928 0.4.5",
  "alloy-evm",
@@ -17250,7 +17250,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17271,7 +17271,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=53a9df97145c24f81f3281e5eac78593c93545cf#53a9df97145c24f81f3281e5eac78593c93545cf"
+source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17836,7 +17836,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17972,7 +17972,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19364,7 +19364,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21116,7 +21116,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "53a9df97145c24f81f3281e5eac78593c93545cf" }
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "4ee9f656d5eb36f86934ffd712c476b57145d328" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "53a9df97145c24f81f3281e5eac78593c93545cf" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "4ee9f656d5eb36f86934ffd712c476b57145d328" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.6.0", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "=2.0.5", default-features = false }

--- a/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/README.md
+++ b/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/README.md
@@ -1,0 +1,31 @@
+# Deterministic Binance Multi-Validator E2E
+
+This merge-gating suite proves the complete price-feed path without public
+network access:
+
+1. A four-validator Gravity cluster starts with equal voting power.
+2. The test deploys `PriceFeedResolver` and uses governance to register two
+   `sourceType=3` tasks plus the resolver callback.
+3. Every validator observes the tasks after the next epoch and independently
+   fetches exact closed 1-minute index-price buckets from a local Binance
+   `indexPriceKlines` fixture.
+4. At least three validators certify byte-identical payloads and form a JWK
+   voting-power quorum.
+5. The execution layer records source progress in `NativeOracle` and invokes
+   `PriceFeedResolver`.
+6. The test checks each validator's relayer state, quorum evidence, resolver
+   values, and identical state from all four RPC endpoints at one block.
+
+Run from the SDK repository root after building `gravity_node` and
+`gravity_cli`:
+
+```bash
+PATH="$HOME/.foundry/bin:$PWD/target/quick-release:$PATH" \
+  ./gravity_e2e/run_test.sh \
+    binance_price_feed_multivalidator \
+    --force-init \
+    --log-cli-level=INFO
+```
+
+No Binance credentials are used. The test only binds and calls localhost. Live
+Binance coverage belongs in a separate manual, non-gating suite.

--- a/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/cluster.toml
@@ -1,0 +1,70 @@
+[cluster]
+name = "gravity-devnet-binance-price-feed-multivalidator"
+base_dir = "/tmp/gravity-cluster-binance-price-feed-multivalidator"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26080
+vfn_port = 26090
+rpc_port = 26100
+api_port = 26110
+metrics_port = 26120
+inspection_port = 26130
+https_port = 26140
+authrpc_port = 26150
+reth_p2p_port = 26160
+
+[[nodes]]
+id = "node2"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26081
+vfn_port = 26091
+rpc_port = 26101
+api_port = 26111
+metrics_port = 26121
+inspection_port = 26131
+https_port = 26141
+authrpc_port = 26151
+reth_p2p_port = 26161
+
+[[nodes]]
+id = "node3"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26082
+vfn_port = 26092
+rpc_port = 26102
+api_port = 26112
+metrics_port = 26122
+inspection_port = 26132
+https_port = 26142
+authrpc_port = 26152
+reth_p2p_port = 26162
+
+[[nodes]]
+id = "node4"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26083
+vfn_port = 26093
+rpc_port = 26103
+api_port = 26113
+metrics_port = 26123
+inspection_port = 26133
+https_port = 26143
+authrpc_port = 26153
+reth_p2p_port = 26163
+
+[faucet_init]
+num_accounts = 0

--- a/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/genesis.toml
@@ -1,0 +1,101 @@
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "ccd88ee62d90d38f824def26b32063fd094807c7"
+
+# node1 is the faucet so the test can execute the governance setup with one
+# development key. All four validators retain equal JWK voting power.
+[[genesis_validators]]
+id = "node1"
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+host = "127.0.0.1"
+validator_port = 26080
+vfn_port = 26090
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node2"
+address = "0x7b254Bd44F6CE45e00a912b2460D47F3Be56fAD7"
+host = "127.0.0.1"
+validator_port = 26081
+vfn_port = 26091
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node3"
+address = "0x9B2C25E77a97d3e84DC0Cb7F83fb676ddC4F24b9"
+host = "127.0.0.1"
+validator_port = 26082
+vfn_port = 26092
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node4"
+address = "0x18c23753385ce7A60B15d171302E48b6AFf0BDC5"
+host = "127.0.0.1"
+validator_port = 26083
+vfn_port = 26093
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 30000000
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+initial_locked_until_micros = 1798848000000000
+governance_owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "1000000000000000000"
+voting_duration_micros = 5000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1, 3]
+callbacks = [
+  "0x00000000000000000000000000000001625F4001",
+  "0x0000000000000000000000000000000000000000",
+]
+
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/relayer_config.json
+++ b/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/relayer_config.json
@@ -1,0 +1,6 @@
+{
+  "uri_mappings": {
+    "gravity://3/1001/price_feed?provider=binance_index_kline_v1&pair=NVDAUSDT&interval=1m&bucketStartMs=1783252500000&decimals=8&graceMs=0": "http://127.0.0.1:18547",
+    "gravity://3/1002/price_feed?provider=binance_index_kline_v1&pair=TSLAUSDT&interval=1m&bucketStartMs=1783252500000&decimals=8&graceMs=0": "http://127.0.0.1:18547"
+  }
+}

--- a/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/test_binance_price_feed_multivalidator.py
+++ b/gravity_e2e/cluster_test_cases/binance_price_feed_multivalidator/test_binance_price_feed_multivalidator.py
@@ -1,0 +1,276 @@
+"""Four-validator Binance closed index-kline oracle E2E."""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+import time
+
+import pytest
+
+from gravity_e2e.cluster.manager import Cluster
+from gravity_e2e.utils import oracle_test_support as support
+from gravity_e2e.utils.mock_binance_index import (
+    BUCKET_START_MS,
+    DECIMALS,
+    INTERVAL_MS,
+    MOCK_BINANCE_PORT,
+    mock_binance_index_kline_server,
+    mock_scaled_price,
+)
+
+LOG = logging.getLogger(__name__)
+SUITE_DIR = Path(__file__).resolve().parent
+FEEDS = {1001: "NVDAUSDT", 1002: "TSLAUSDT"}
+TARGET_NONCE = 1
+QUORUM_VALIDATORS = 3
+
+
+def _price_feed_uri(feed_id: int, pair: str) -> str:
+    return (
+        f"gravity://3/{feed_id}/price_feed?"
+        f"provider=binance_index_kline_v1&pair={pair}&interval=1m&"
+        f"bucketStartMs={BUCKET_START_MS}&decimals={DECIMALS}&graceMs=0"
+    )
+
+
+def _consensus_log(cluster: Cluster, node_id: str) -> Path:
+    return cluster.base_dir / node_id / "consensus_log" / "validator.log"
+
+
+def _relayer_state(cluster: Cluster, node_id: str) -> Path:
+    return cluster.base_dir / node_id / "data" / "reth" / "relayer_state.json"
+
+
+def _line_matches(content: str, marker: str, issuer: str) -> bool:
+    return any(marker in line and issuer in line for line in content.splitlines())
+
+
+async def _wait_for_consensus_evidence(
+    cluster: Cluster,
+    feed_ids: list[int],
+    *,
+    timeout: int = 180,
+) -> None:
+    missing_observers = {
+        (node_id, feed_id)
+        for node_id in cluster.nodes
+        for feed_id in feed_ids
+    }
+    certifiers = {feed_id: set() for feed_id in feed_ids}
+    missing_quorums = set(feed_ids)
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        logs = {}
+        for node_id in cluster.nodes:
+            path = _consensus_log(cluster, node_id)
+            logs[node_id] = path.read_text(errors="replace") if path.exists() else ""
+
+        for node_id, feed_id in list(missing_observers):
+            issuer = f"gravity://3/{feed_id}"
+            if _line_matches(logs[node_id], "JWKObserver spawned.", issuer):
+                missing_observers.remove((node_id, feed_id))
+
+        for feed_id in feed_ids:
+            issuer = f"gravity://3/{feed_id}"
+            for node_id, content in logs.items():
+                if _line_matches(content, "Start certifying update.", issuer):
+                    certifiers[feed_id].add(node_id)
+
+        for feed_id in list(missing_quorums):
+            issuer = f"gravity://3/{feed_id}"
+            if any(
+                any(
+                    "Peer vote aggregated." in line
+                    and issuer in line
+                    and (
+                        "threshold_exceeded=true" in line
+                        or '"threshold_exceeded":true' in line
+                    )
+                    for line in content.splitlines()
+                )
+                for content in logs.values()
+            ):
+                missing_quorums.remove(feed_id)
+
+        if (
+            not missing_observers
+            and all(len(certifiers[feed_id]) >= QUORUM_VALIDATORS for feed_id in feed_ids)
+            and not missing_quorums
+        ):
+            return
+        await asyncio.sleep(2)
+
+    raise AssertionError(
+        "missing validator oracle evidence: "
+        f"observers={sorted(missing_observers)}, "
+        f"certifiers={ {feed: sorted(nodes) for feed, nodes in certifiers.items()} }, "
+        f"quorums={sorted(missing_quorums)}"
+    )
+
+
+def _assert_relayer_state(cluster: Cluster, uris: dict[int, str]) -> None:
+    for node_id in cluster.nodes:
+        state_path = _relayer_state(cluster, node_id)
+        assert state_path.exists(), f"{node_id} has no relayer state"
+        state = json.loads(state_path.read_text())
+        for feed_id, uri in uris.items():
+            source = state["sources"].get(uri)
+            assert source is not None, f"{node_id} has no state for feedId={feed_id}"
+            assert source["source_type"] == support.SOURCE_TYPE_PRICE_FEED
+            assert source["source_id"] == feed_id
+            assert int(source["last_nonce"]) >= TARGET_NONCE
+
+
+async def _wait_for_block(w3, block_number: int, timeout: int = 60) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if w3.eth.block_number >= block_number:
+            return
+        await asyncio.sleep(1)
+    raise TimeoutError(f"RPC did not reach Gravity block {block_number}")
+
+
+@pytest.mark.asyncio
+async def test_four_validators_resolve_deterministic_binance_prices(cluster: Cluster):
+    assert len(cluster.nodes) == 4
+    assert await cluster.set_full_live(timeout=180)
+    assert await cluster.check_block_increasing(timeout=60)
+
+    validator_set = await cluster.validator_list()
+    assert {validator.id for validator in validator_set.active} == set(cluster.nodes)
+
+    node1 = cluster.get_node("node1")
+    assert node1 is not None and node1.w3.is_connected()
+    w3 = node1.w3
+
+    required = [
+        ("PriceFeedResolver.sol", "PriceFeedResolver"),
+        ("NativeOracle.sol", "NativeOracle"),
+        ("OracleTaskConfig.sol", "OracleTaskConfig"),
+    ]
+    contracts_out = support.ensure_contract_artifacts(SUITE_DIR, required)
+    resolver_artifact = support.load_artifact(
+        contracts_out, "PriceFeedResolver.sol", "PriceFeedResolver"
+    )
+    native_artifact = support.load_artifact(
+        contracts_out, "NativeOracle.sol", "NativeOracle"
+    )
+    task_artifact = support.load_artifact(
+        contracts_out, "OracleTaskConfig.sol", "OracleTaskConfig"
+    )
+
+    resolver = support.deploy_contract(w3, resolver_artifact)
+    native_oracle = w3.eth.contract(
+        address=support.NATIVE_ORACLE_ADDRESS,
+        abi=native_artifact["abi"],
+    )
+    task_config = w3.eth.contract(
+        address=support.ORACLE_TASK_CONFIG_ADDRESS,
+        abi=task_artifact["abi"],
+    )
+    uris = {feed_id: _price_feed_uri(feed_id, pair) for feed_id, pair in FEEDS.items()}
+
+    with mock_binance_index_kline_server(MOCK_BINANCE_PORT) as mock:
+        assert mock.base_url == f"http://127.0.0.1:{MOCK_BINANCE_PORT}"
+        targets = [support.NATIVE_ORACLE_ADDRESS]
+        calls = [
+            support.function_calldata(
+                native_oracle.functions.setDefaultCallback(
+                    support.SOURCE_TYPE_PRICE_FEED,
+                    resolver.address,
+                )
+            )
+        ]
+        for feed_id, uri in uris.items():
+            targets.append(support.ORACLE_TASK_CONFIG_ADDRESS)
+            calls.append(
+                support.function_calldata(
+                    task_config.functions.setTask(
+                        support.SOURCE_TYPE_PRICE_FEED,
+                        feed_id,
+                        support.TASK_PRICE_FEED,
+                        uri.encode(),
+                    )
+                )
+            )
+
+        await support.execute_governance_proposal(
+            w3,
+            support.faucet_voting_pool(w3),
+            targets,
+            calls,
+            "deterministic-binance-multivalidator-e2e",
+        )
+
+        for feed_id in FEEDS:
+            await support.wait_for_latest_price(
+                native_oracle,
+                resolver,
+                feed_id,
+                TARGET_NONCE,
+            )
+
+        await _wait_for_consensus_evidence(cluster, list(FEEDS))
+        _assert_relayer_state(cluster, uris)
+        for pair in FEEDS.values():
+            assert mock.request_count(pair) >= QUORUM_VALIDATORS
+
+        snapshot_block = w3.eth.block_number
+        expected_progress = {}
+        expected_rounds = {}
+        for feed_id, pair in FEEDS.items():
+            progress = tuple(
+                native_oracle.functions.getSourceProgress(
+                    support.SOURCE_TYPE_PRICE_FEED,
+                    feed_id,
+                ).call(block_identifier=snapshot_block)
+            )
+            latest = tuple(
+                resolver.functions.latestPrice(feed_id).call(
+                    block_identifier=snapshot_block
+                )
+            )
+            delivery_nonce = int(progress[0])
+            bucket_start = BUCKET_START_MS + (delivery_nonce - 1) * INTERVAL_MS
+            assert latest == (
+                True,
+                bucket_start // INTERVAL_MS,
+                bucket_start + INTERVAL_MS - 1,
+                DECIMALS,
+                mock_scaled_price(pair, delivery_nonce - 1),
+            )
+            assert progress[1] == latest[2]
+            expected_progress[feed_id] = progress
+            expected_rounds[feed_id] = latest
+
+        for node_id, node in cluster.nodes.items():
+            await _wait_for_block(node.w3, snapshot_block)
+            replica_native = node.w3.eth.contract(
+                address=support.NATIVE_ORACLE_ADDRESS,
+                abi=native_artifact["abi"],
+            )
+            replica_resolver = node.w3.eth.contract(
+                address=resolver.address,
+                abi=resolver_artifact["abi"],
+            )
+            for feed_id in FEEDS:
+                progress = tuple(
+                    replica_native.functions.getSourceProgress(
+                        support.SOURCE_TYPE_PRICE_FEED,
+                        feed_id,
+                    ).call(block_identifier=snapshot_block)
+                )
+                latest = tuple(
+                    replica_resolver.functions.latestPrice(feed_id).call(
+                        block_identifier=snapshot_block
+                    )
+                )
+                assert progress == expected_progress[feed_id], node_id
+                assert latest == expected_rounds[feed_id], node_id
+
+        LOG.info(
+            "Four-validator Binance QC stored rounds: %s",
+            {feed_id: round_data[1] for feed_id, round_data in expected_rounds.items()},
+        )

--- a/gravity_e2e/gravity_e2e/utils/mock_binance_index.py
+++ b/gravity_e2e/gravity_e2e/utils/mock_binance_index.py
@@ -1,0 +1,123 @@
+"""Deterministic local Binance index-kline server for oracle tests."""
+
+from contextlib import contextmanager
+import json
+import logging
+import threading
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+LOG = logging.getLogger(__name__)
+
+BUCKET_START_MS = 1_783_252_500_000
+INTERVAL_MS = 60_000
+DECIMALS = 8
+MOCK_BINANCE_PORT = 18_547
+SUPPORTED_PAIRS = {"NVDAUSDT", "TSLAUSDT"}
+
+_BASE_PRICES = {"NVDAUSDT": 19_592_645_000, "TSLAUSDT": 40_067_545_000}
+_INCREMENTS = {"NVDAUSDT": 10_000_000, "TSLAUSDT": 25_000_000}
+
+
+def format_price(scaled_price: int) -> str:
+    whole = scaled_price // 10**DECIMALS
+    fraction = scaled_price % 10**DECIMALS
+    return f"{whole}.{fraction:0{DECIMALS}d}"
+
+
+def mock_scaled_price(pair: str, bucket_index: int) -> int:
+    return _BASE_PRICES[pair] + bucket_index * _INCREMENTS[pair]
+
+
+class _MockBinanceServer(ThreadingHTTPServer):
+    allow_reuse_address = True
+
+    def __init__(self, address):
+        super().__init__(address, _MockBinanceHandler)
+        self._request_counts = Counter()
+        self._request_lock = threading.Lock()
+
+    @property
+    def base_url(self) -> str:
+        host, port = self.server_address
+        return f"http://{host}:{port}"
+
+    def record_request(self, pair: str) -> None:
+        with self._request_lock:
+            self._request_counts[pair] += 1
+
+    def request_count(self, pair: str) -> int:
+        with self._request_lock:
+            return self._request_counts[pair]
+
+
+class _MockBinanceHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path != "/fapi/v1/indexPriceKlines":
+            self.send_error(404)
+            return
+
+        params = parse_qs(parsed.query)
+        pair = params.get("pair", [""])[0]
+        try:
+            start_time = int(params.get("startTime", ["-1"])[0])
+            end_time = int(params.get("endTime", ["-1"])[0])
+        except ValueError:
+            self.send_error(400)
+            return
+
+        valid = (
+            params.get("interval", [""])[0] == "1m"
+            and params.get("limit", [""])[0] == "1"
+            and start_time >= BUCKET_START_MS
+            and (start_time - BUCKET_START_MS) % INTERVAL_MS == 0
+            and end_time == start_time + INTERVAL_MS - 1
+            and pair in SUPPORTED_PAIRS
+        )
+        if not valid:
+            self.send_error(400)
+            return
+
+        bucket_index = (start_time - BUCKET_START_MS) // INTERVAL_MS
+        close_price = format_price(mock_scaled_price(pair, bucket_index))
+        response = [[
+            start_time,
+            close_price,
+            close_price,
+            close_price,
+            close_price,
+            "0",
+            end_time,
+            "0",
+            60,
+            "0",
+            "0",
+            "0",
+        ]]
+        payload = json.dumps(response).encode()
+        self.server.record_request(pair)
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, fmt: str, *args):
+        LOG.debug("mock Binance index kline: " + fmt, *args)
+
+
+@contextmanager
+def mock_binance_index_kline_server(port: int = MOCK_BINANCE_PORT):
+    server = _MockBinanceServer(("127.0.0.1", port))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/gravity_e2e/gravity_e2e/utils/oracle_test_support.py
+++ b/gravity_e2e/gravity_e2e/utils/oracle_test_support.py
@@ -1,0 +1,299 @@
+"""Contract and governance helpers shared by oracle E2E suites."""
+
+import asyncio
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from eth_abi import encode
+from eth_account import Account
+from web3 import Web3
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+
+NATIVE_ORACLE_ADDRESS = Web3.to_checksum_address(
+    "0x00000000000000000000000000000001625F4000"
+)
+ORACLE_TASK_CONFIG_ADDRESS = Web3.to_checksum_address(
+    "0x00000000000000000000000000000001625F1009"
+)
+GOVERNANCE_ADDRESS = Web3.to_checksum_address(
+    "0x00000000000000000000000000000001625F3000"
+)
+STAKING_ADDRESS = Web3.to_checksum_address(
+    "0x00000000000000000000000000000001625F2000"
+)
+
+FAUCET_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+FAUCET_ADDRESS = Web3.to_checksum_address(
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+)
+
+SOURCE_TYPE_PRICE_FEED = 3
+TASK_PRICE_FEED = Web3.keccak(text="price_feed")
+
+_PROPOSAL_CREATED_TOPIC = Web3.keccak(
+    text="ProposalCreated(uint64,address,address,bytes32,string)"
+)
+_SEL_OWNER = Web3.keccak(text="owner()")[:4]
+_SEL_ADD_EXECUTOR = Web3.keccak(text="addExecutor(address)")[:4]
+_SEL_IS_EXECUTOR = Web3.keccak(text="isExecutor(address)")[:4]
+_SEL_GET_POOL = Web3.keccak(text="getPool(uint256)")[:4]
+_SEL_GET_POOL_VOTER = Web3.keccak(text="getPoolVoter(address)")[:4]
+_SEL_GET_POOL_VOTING_POWER = Web3.keccak(text="getPoolVotingPowerNow(address)")[:4]
+_SEL_CREATE_PROPOSAL = Web3.keccak(
+    text="createProposal(address,address[],bytes[],string)"
+)[:4]
+_SEL_VOTE = Web3.keccak(text="vote(address,uint64,uint128,bool)")[:4]
+_SEL_RESOLVE = Web3.keccak(text="resolve(uint64)")[:4]
+_SEL_EXECUTE = Web3.keccak(text="execute(uint64,address[],bytes[])")[:4]
+_SEL_GET_PROPOSAL_STATE = Web3.keccak(text="getProposalState(uint64)")[:4]
+
+_MAX_UINT128 = (1 << 128) - 1
+_PROPOSAL_STATE_SUCCEEDED = 1
+_VOTING_DURATION_SECS = 5
+
+
+def function_calldata(fn) -> bytes:
+    encoded = fn._encode_transaction_data()
+    return bytes.fromhex(encoded[2:]) if isinstance(encoded, str) else bytes(encoded)
+
+
+def _send_tx(
+    w3: Web3,
+    to: Optional[str],
+    data,
+    *,
+    gas: int = 1_000_000,
+) -> dict:
+    sender = Account.from_key(FAUCET_KEY)
+    tx = {
+        "data": data,
+        "gas": gas,
+        "gasPrice": w3.eth.gas_price,
+        "nonce": w3.eth.get_transaction_count(sender.address),
+        "chainId": w3.eth.chain_id,
+    }
+    if to is not None:
+        tx["to"] = to
+    signed = sender.sign_transaction(tx)
+    tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+    assert receipt["status"] == 1, f"transaction failed: {receipt}"
+    return receipt
+
+
+def _artifact_file(out_dir: Path, source_name: str, contract_name: str) -> Path:
+    path = out_dir / source_name / f"{contract_name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"missing {source_name}/{contract_name}.json under {out_dir}")
+    return path
+
+
+def _contracts_repo(suite_dir: Path) -> Path:
+    config = tomllib.loads((suite_dir / "genesis.toml").read_text())
+    dependency = config.get("dependencies", {}).get("genesis_contracts", {})
+    sdk_root = suite_dir.parents[2]
+    if dependency.get("path"):
+        generated = sdk_root / "external" / "gravity_chain_core_contracts_local"
+        return generated if generated.is_dir() else (suite_dir / dependency["path"]).resolve()
+    return sdk_root / "external" / "gravity_chain_core_contracts"
+
+
+def ensure_contract_artifacts(
+    suite_dir: Path,
+    required: list[tuple[str, str]],
+) -> Path:
+    contracts_repo = _contracts_repo(suite_dir)
+    if not contracts_repo.is_dir():
+        raise FileNotFoundError(f"contracts checkout not found under SDK external dependencies")
+    if not shutil.which("forge"):
+        raise FileNotFoundError("forge is required to build oracle contract artifacts")
+
+    sources = []
+    for source_name, _ in required:
+        matches = [
+            path
+            for root_name in ("src", "test", "script")
+            for path in (contracts_repo / root_name).rglob(source_name)
+            if (contracts_repo / root_name).is_dir()
+        ]
+        assert len(matches) == 1, f"expected one {source_name}, found {matches}"
+        sources.append(str(matches[0].relative_to(contracts_repo)))
+
+    subprocess.run(["forge", "build", *dict.fromkeys(sources)], cwd=contracts_repo, check=True)
+    out_dir = contracts_repo / "out"
+    for source_name, contract_name in required:
+        _artifact_file(out_dir, source_name, contract_name)
+    return out_dir
+
+
+def load_artifact(out_dir: Path, source_name: str, contract_name: str) -> dict:
+    return json.loads(_artifact_file(out_dir, source_name, contract_name).read_text())
+
+
+def deploy_contract(w3: Web3, artifact: dict):
+    bytecode = artifact["bytecode"]
+    if isinstance(bytecode, dict):
+        bytecode = bytecode["object"]
+    if not bytecode.startswith("0x"):
+        bytecode = f"0x{bytecode}"
+
+    sender = Account.from_key(FAUCET_KEY)
+    factory = w3.eth.contract(abi=artifact["abi"], bytecode=bytecode)
+    tx = factory.constructor().build_transaction({
+        "from": sender.address,
+        "gas": 8_000_000,
+        "gasPrice": w3.eth.gas_price,
+        "nonce": w3.eth.get_transaction_count(sender.address),
+        "chainId": w3.eth.chain_id,
+    })
+    signed = sender.sign_transaction(tx)
+    tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=120)
+    assert receipt["status"] == 1, f"contract deployment failed: {receipt}"
+    return w3.eth.contract(address=receipt["contractAddress"], abi=artifact["abi"])
+
+
+def _call(w3: Web3, to: str, data: bytes) -> bytes:
+    return w3.eth.call({"to": to, "data": data})
+
+
+def _decode_address(raw: bytes) -> str:
+    return Web3.to_checksum_address("0x" + raw[-20:].hex())
+
+
+def _ensure_faucet_executor(w3: Web3) -> None:
+    owner = _decode_address(_call(w3, GOVERNANCE_ADDRESS, _SEL_OWNER))
+    assert owner == FAUCET_ADDRESS, f"Governance.owner expected faucet, got {owner}"
+    is_executor = bool(int.from_bytes(
+        _call(
+            w3,
+            GOVERNANCE_ADDRESS,
+            _SEL_IS_EXECUTOR + encode(["address"], [FAUCET_ADDRESS]),
+        ),
+        "big",
+    ))
+    if not is_executor:
+        _send_tx(
+            w3,
+            GOVERNANCE_ADDRESS,
+            _SEL_ADD_EXECUTOR + encode(["address"], [FAUCET_ADDRESS]),
+        )
+
+
+def faucet_voting_pool(w3: Web3) -> str:
+    pool = _decode_address(
+        _call(w3, STAKING_ADDRESS, _SEL_GET_POOL + encode(["uint256"], [0]))
+    )
+    voter = _decode_address(
+        _call(
+            w3,
+            STAKING_ADDRESS,
+            _SEL_GET_POOL_VOTER + encode(["address"], [pool]),
+        )
+    )
+    assert voter == FAUCET_ADDRESS, f"pool[0].voter expected faucet, got {voter}"
+    voting_power = int.from_bytes(
+        _call(
+            w3,
+            STAKING_ADDRESS,
+            _SEL_GET_POOL_VOTING_POWER + encode(["address"], [pool]),
+        ),
+        "big",
+    )
+    assert voting_power >= 10**18, f"pool[0] voting power too low: {voting_power}"
+    return pool
+
+
+async def execute_governance_proposal(
+    w3: Web3,
+    pool: str,
+    targets: list[str],
+    datas: list[bytes],
+    description: str,
+) -> dict:
+    assert len(targets) == len(datas) and targets
+    _ensure_faucet_executor(w3)
+    create_data = _SEL_CREATE_PROPOSAL + encode(
+        ["address", "address[]", "bytes[]", "string"],
+        [pool, targets, datas, description],
+    )
+    w3.eth.call({
+        "from": FAUCET_ADDRESS,
+        "to": GOVERNANCE_ADDRESS,
+        "data": create_data,
+        "gas": 5_000_000,
+    })
+    receipt = _send_tx(w3, GOVERNANCE_ADDRESS, create_data, gas=5_000_000)
+    proposal_id = next(
+        (
+            int.from_bytes(log["topics"][1], "big")
+            for log in receipt["logs"]
+            if log["topics"] and bytes(log["topics"][0]) == bytes(_PROPOSAL_CREATED_TOPIC)
+        ),
+        None,
+    )
+    assert proposal_id is not None, "ProposalCreated event not found"
+
+    vote_data = _SEL_VOTE + encode(
+        ["address", "uint64", "uint128", "bool"],
+        [pool, proposal_id, _MAX_UINT128, True],
+    )
+    _send_tx(w3, GOVERNANCE_ADDRESS, vote_data)
+    vote_block = w3.eth.block_number
+    await asyncio.sleep(_VOTING_DURATION_SECS + 2)
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline and w3.eth.block_number < vote_block + 3:
+        await asyncio.sleep(1)
+    assert w3.eth.block_number >= vote_block + 3, "chain did not advance past vote block"
+
+    _send_tx(
+        w3,
+        GOVERNANCE_ADDRESS,
+        _SEL_RESOLVE + encode(["uint64"], [proposal_id]),
+    )
+    state = int.from_bytes(
+        _call(
+            w3,
+            GOVERNANCE_ADDRESS,
+            _SEL_GET_PROPOSAL_STATE + encode(["uint64"], [proposal_id]),
+        ),
+        "big",
+    )
+    assert state == _PROPOSAL_STATE_SUCCEEDED, f"proposal state is {state}"
+
+    execute_data = _SEL_EXECUTE + encode(
+        ["uint64", "address[]", "bytes[]"],
+        [proposal_id, targets, datas],
+    )
+    return _send_tx(w3, GOVERNANCE_ADDRESS, execute_data, gas=5_000_000)
+
+
+async def wait_for_latest_price(
+    native_oracle,
+    resolver,
+    feed_id: int,
+    target_nonce: int,
+    *,
+    timeout: int = 300,
+):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        progress = tuple(
+            native_oracle.functions.getSourceProgress(
+                SOURCE_TYPE_PRICE_FEED, feed_id
+            ).call()
+        )
+        latest = tuple(resolver.functions.latestPrice(feed_id).call())
+        if progress[0] >= target_nonce and latest[0] and latest[2] == progress[1]:
+            return progress, latest
+        await asyncio.sleep(2)
+    raise TimeoutError(f"latestPrice({feed_id}) did not reach delivery nonce {target_nonce}")

--- a/gravity_e2e/gravity_e2e/utils/test_mock_binance_index.py
+++ b/gravity_e2e/gravity_e2e/utils/test_mock_binance_index.py
@@ -1,0 +1,48 @@
+import json
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+import pytest
+
+from gravity_e2e.utils.mock_binance_index import (
+    BUCKET_START_MS,
+    INTERVAL_MS,
+    format_price,
+    mock_binance_index_kline_server,
+    mock_scaled_price,
+)
+
+
+def _url(base_url: str, pair: str, start_time: int) -> str:
+    return (
+        f"{base_url}/fapi/v1/indexPriceKlines?pair={pair}&interval=1m&"
+        f"startTime={start_time}&endTime={start_time + INTERVAL_MS - 1}&limit=1"
+    )
+
+
+def test_returns_exact_closed_bucket_and_tracks_requests():
+    with mock_binance_index_kline_server(port=0) as server:
+        with urlopen(_url(server.base_url, "TSLAUSDT", BUCKET_START_MS), timeout=2) as response:
+            rows = json.loads(response.read())
+
+        assert len(rows) == 1
+        assert rows[0][0] == BUCKET_START_MS
+        assert rows[0][4] == format_price(mock_scaled_price("TSLAUSDT", 0))
+        assert rows[0][6] == BUCKET_START_MS + INTERVAL_MS - 1
+        assert server.request_count("TSLAUSDT") == 1
+
+
+def test_price_is_deterministic_per_pair_and_bucket():
+    with mock_binance_index_kline_server(port=0) as server:
+        start_time = BUCKET_START_MS + 2 * INTERVAL_MS
+        with urlopen(_url(server.base_url, "NVDAUSDT", start_time), timeout=2) as response:
+            rows = json.loads(response.read())
+
+        assert rows[0][4] == format_price(mock_scaled_price("NVDAUSDT", 2))
+
+
+def test_rejects_unaligned_bucket():
+    with mock_binance_index_kline_server(port=0) as server:
+        with pytest.raises(HTTPError) as error:
+            urlopen(_url(server.base_url, "TSLAUSDT", BUCKET_START_MS + 1), timeout=2)
+        assert error.value.code == 400


### PR DESCRIPTION
## Summary

Add one deterministic, merge-gating E2E suite for the complete multi-validator Binance price-feed path. This PR intentionally keeps the localhost provider fixture, reusable oracle helpers, cluster definition, and E2E assertions together so the workflow can be reviewed and run as one unit.

The suite also pins `gravity-reth` to the merged generic relayer runtime through Galxe/gravity-reth#419.

## Workflow under test

1. Start four equal-voting-power Gravity validators.
2. Deploy `PriceFeedResolver` and register two `sourceType=3` tasks through the on-chain governance lifecycle.
3. Have every validator discover the tasks and fetch the same explicit, closed one-minute `indexPriceKlines` buckets for `NVDAUSDT` and `TSLAUSDT`.
4. Form JWK consensus from at least three certifying validators.
5. Execute the agreed bytes through `NativeOracle` and its resolver callback.
6. Verify observer startup, quorum evidence, per-validator relayer progress, resolver values, and identical contract state through all four RPC endpoints at one block.

## Determinism and network boundary

- The Binance-compatible endpoint binds to `127.0.0.1` only.
- Requests must include the exact pair, interval, `startTime`, `endTime`, and `limit=1` closed-bucket coordinates.
- Prices are deterministic fixed-point values keyed by pair and bucket.
- The test uses no Binance API key, secret, or public Binance endpoint.
- The mock request counters prove that multiple validators independently fetched each feed.

## Cross-repository revisions

- `gravity-aptos`: `a64f8adc274bf2681df796766ef9a5b195fee44b` (Galxe/gravity-aptos#79)
- `gravity_chain_core_contracts`: `ccd88ee62d90d38f824def26b32063fd094807c7` (Galxe/gravity_chain_core_contracts#114)
- `gravity-reth`: `4ee9f656d5eb36f86934ffd712c476b57145d328` (Galxe/gravity-reth#419)

## Run

From the SDK repository root, after building `gravity_node` and `gravity_cli`:

```bash
PATH="$HOME/.foundry/bin:$PWD/target/quick-release:$PATH" \
  ./gravity_e2e/run_test.sh \
    binance_price_feed_multivalidator \
    --force-init \
    --log-cli-level=INFO
```

Expected terminal evidence includes all four validators active, observer/certifier/quorum assertions passing for both feeds, stored round `29720875` for the fixed fixture bucket, and `All suites passed!` after all four nodes stop.

## Validation

- `cargo build --bin gravity_node --bin gravity_cli --profile quick-release` with the repository-required Rust flags
- `python3 -m pytest -q gravity_e2e/gravity_e2e/utils/test_mock_binance_index.py` (`3 passed`)
- `./gravity_e2e/run_test.sh binance_price_feed_multivalidator --log-cli-level=INFO` (`1 passed` in 40.65s)
- Python compile checks, TOML/JSON parse checks, and `git diff --check`

Refs Galxe/gravity-audit#1038
Refs Galxe/gravity-audit#1033
