### PR TITLE
test(oracle): add deterministic Polymarket quorum E2E

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 
 [[package]]
 name = "gravity-sdk"
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -14538,7 +14538,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 2.0.5",
@@ -14585,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14612,7 +14612,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14641,7 +14641,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14661,7 +14661,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -14674,7 +14674,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14758,7 +14758,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -14768,7 +14768,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14817,7 +14817,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -14833,7 +14833,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -14847,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14860,7 +14860,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14885,7 +14885,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -14909,7 +14909,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14935,7 +14935,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14966,7 +14966,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14980,7 +14980,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15005,7 +15005,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15029,7 +15029,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -15053,7 +15053,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15084,7 +15084,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -15112,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15135,7 +15135,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15160,7 +15160,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15215,7 +15215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15245,7 +15245,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15261,7 +15261,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15277,7 +15277,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15299,7 +15299,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -15310,7 +15310,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -15338,7 +15338,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -15360,7 +15360,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15383,7 +15383,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15399,7 +15399,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15415,7 +15415,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -15428,7 +15428,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15458,7 +15458,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15472,7 +15472,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -15482,7 +15482,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -15507,7 +15507,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15532,7 +15532,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -15550,7 +15550,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -15563,7 +15563,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15582,7 +15582,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15620,7 +15620,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15634,7 +15634,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "serde",
  "serde_json",
@@ -15644,7 +15644,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15672,7 +15672,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "bytes",
  "futures",
@@ -15692,7 +15692,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -15709,7 +15709,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "bindgen",
  "cc",
@@ -15718,7 +15718,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "futures",
  "metrics",
@@ -15731,7 +15731,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -15740,7 +15740,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -15754,7 +15754,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15811,7 +15811,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15836,7 +15836,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15858,7 +15858,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15873,7 +15873,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -15887,7 +15887,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "anyhow",
  "bincode",
@@ -15904,7 +15904,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -15928,7 +15928,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15997,7 +15997,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16053,7 +16053,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16100,7 +16100,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16124,7 +16124,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16148,7 +16148,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "bytes",
  "eyre",
@@ -16172,7 +16172,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -16184,7 +16184,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16208,7 +16208,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -16220,7 +16220,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16243,7 +16243,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
@@ -16253,7 +16253,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -16266,7 +16266,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16313,7 +16313,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -16337,7 +16337,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "once_cell",
@@ -16350,7 +16350,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.4.1"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16380,7 +16380,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16423,7 +16423,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16451,7 +16451,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16466,7 +16466,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16485,7 +16485,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16512,7 +16512,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16527,7 +16527,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16604,7 +16604,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -16634,7 +16634,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-provider 2.0.5",
@@ -16677,7 +16677,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -16698,7 +16698,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16729,7 +16729,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16775,7 +16775,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -16825,7 +16825,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -16839,7 +16839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16870,7 +16870,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16914,7 +16914,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16942,7 +16942,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16955,7 +16955,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -16975,7 +16975,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -16989,7 +16989,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17019,7 +17019,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -17037,7 +17037,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -17058,7 +17058,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -17068,7 +17068,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -17086,7 +17086,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "base64 0.22.1",
  "clap 4.5.57",
@@ -17104,7 +17104,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17150,7 +17150,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17175,7 +17175,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -17202,7 +17202,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17221,7 +17221,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-eip7928 0.4.5",
  "alloy-evm",
@@ -17250,7 +17250,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17271,7 +17271,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4ee9f656d5eb36f86934ffd712c476b57145d328#4ee9f656d5eb36f86934ffd712c476b57145d328"
+source = "git+https://github.com/Galxe/gravity-reth?rev=0c038e180cc26ae400f3fb2e6199e6f079f68fbc#0c038e180cc26ae400f3fb2e6199e6f079f68fbc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "4ee9f656d5eb36f86934ffd712c476b57145d328" }
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "0c038e180cc26ae400f3fb2e6199e6f079f68fbc" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -33,7 +33,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "4ee9f656d5eb36f86934ffd712c476b57145d328" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "0c038e180cc26ae400f3fb2e6199e6f079f68fbc" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.6.0", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "=2.0.5", default-features = false }

--- a/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/README.md
+++ b/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/README.md
@@ -1,0 +1,36 @@
+# Deterministic Polymarket Settlement Multi-Validator E2E
+
+This merge-gating suite proves the complete `sourceType=6` transport path
+without calling a public Polygon RPC at runtime:
+
+1. A four-validator Gravity cluster starts with equal voting power.
+2. Governance deploys the resolver binding and dynamically registers one
+   Polygon CTF settlement task.
+3. Every validator discovers the new task and independently scans a localhost
+   Polygon JSON-RPC fixture.
+4. The fixture exposes the settlement at `latest` while keeping the finalized
+   watermark one block behind. The test first verifies an empty scan cursor and
+   no on-chain settlement.
+5. Advancing the finalized watermark releases byte-identical CTF observations.
+   At least three validators certify them and form a JWK voting-power quorum.
+6. The execution layer records terminal nonce `1` in `NativeOracle`, invokes
+   `PolymarketSettlementResolver`, and stores the expected winner and Polygon
+   provenance.
+7. The test verifies relayer checkpoints and identical contract state through
+   all four Gravity RPC endpoints at one block.
+
+Run from the SDK repository root after building `gravity_node` and
+`gravity_cli`:
+
+```bash
+PATH="$HOME/.foundry/bin:$PWD/target/quick-release:$PATH" \
+  ./gravity_e2e/run_test.sh \
+    polymarket_settlement_multivalidator \
+    --force-init \
+    --log-cli-level=INFO
+```
+
+The oracle data-source fixture binds and calls localhost only. Initial builds may
+still download repository dependencies. The suite contains no Polygon
+credentials and does not cover prediction-market betting, live Polygon, or
+product settlement.

--- a/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/cluster.toml
@@ -1,0 +1,73 @@
+[cluster]
+name = "gravity-devnet-polymarket-settlement-multivalidator"
+base_dir = "/tmp/gravity-cluster-polymarket-settlement-multivalidator"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[relayer]
+relayer_rpc_url = "http://127.0.0.1:18548"
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26280
+vfn_port = 26290
+rpc_port = 26300
+api_port = 26310
+metrics_port = 26320
+inspection_port = 26330
+https_port = 26340
+authrpc_port = 26350
+reth_p2p_port = 26360
+
+[[nodes]]
+id = "node2"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26281
+vfn_port = 26291
+rpc_port = 26301
+api_port = 26311
+metrics_port = 26321
+inspection_port = 26331
+https_port = 26341
+authrpc_port = 26351
+reth_p2p_port = 26361
+
+[[nodes]]
+id = "node3"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26282
+vfn_port = 26292
+rpc_port = 26302
+api_port = 26312
+metrics_port = 26322
+inspection_port = 26332
+https_port = 26342
+authrpc_port = 26352
+reth_p2p_port = 26362
+
+[[nodes]]
+id = "node4"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 26283
+vfn_port = 26293
+rpc_port = 26303
+api_port = 26313
+metrics_port = 26323
+inspection_port = 26333
+https_port = 26343
+authrpc_port = 26353
+reth_p2p_port = 26363
+
+[faucet_init]
+num_accounts = 0

--- a/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/genesis.toml
@@ -1,0 +1,101 @@
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "f447687bf6f6f9efabd92626b588aeda94148f88"
+
+# node1 is the faucet so the test can execute the governance setup with one
+# development key. All four validators retain equal JWK voting power.
+[[genesis_validators]]
+id = "node1"
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+host = "127.0.0.1"
+validator_port = 26280
+vfn_port = 26290
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node2"
+address = "0x7b254Bd44F6CE45e00a912b2460D47F3Be56fAD7"
+host = "127.0.0.1"
+validator_port = 26281
+vfn_port = 26291
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node3"
+address = "0x9B2C25E77a97d3e84DC0Cb7F83fb676ddC4F24b9"
+host = "127.0.0.1"
+validator_port = 26282
+vfn_port = 26292
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node4"
+address = "0x18c23753385ce7A60B15d171302E48b6AFf0BDC5"
+host = "127.0.0.1"
+validator_port = 26283
+vfn_port = 26293
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 30000000
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+initial_locked_until_micros = 1798848000000000
+governance_owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "1000000000000000000"
+voting_duration_micros = 5000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1, 6]
+callbacks = [
+  "0x00000000000000000000000000000001625F4001",
+  "0x0000000000000000000000000000000000000000",
+]
+
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/relayer_config.json
+++ b/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/relayer_config.json
@@ -1,0 +1,5 @@
+{
+  "uri_mappings": {
+    "gravity://6/9001/polymarket_settlement?ctf=0x4D97DCd97eC945f40cF65F87097ACe5EA0476045&condition=0xd874d3b83fa09e192fdda031b6a3b3ec78be60cb82678aa67b23f8fd027c86ae&fromBlock=49999998&chainId=137&maxBlocksPerPoll=20": "http://127.0.0.1:18548"
+  }
+}

--- a/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/test_polymarket_settlement_multivalidator.py
+++ b/gravity_e2e/cluster_test_cases/polymarket_settlement_multivalidator/test_polymarket_settlement_multivalidator.py
@@ -1,0 +1,353 @@
+"""Four-validator finalized Polymarket CTF settlement oracle E2E."""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+import time
+
+import pytest
+from web3 import Web3
+
+from gravity_e2e.cluster.manager import Cluster
+from gravity_e2e.utils import oracle_test_support as support
+from gravity_e2e.utils.mock_polymarket_polygon import (
+    CONDITION_ID,
+    CTF_ADDRESS,
+    LOG_INDEX,
+    MIRROR_ID,
+    MOCK_POLYGON_PORT,
+    ORACLE_ADDRESS,
+    OUTCOME_SLOT_COUNT,
+    QUESTION_ID,
+    SOURCE_BLOCK,
+    TX_HASH,
+    mock_polymarket_polygon_server,
+)
+
+LOG = logging.getLogger(__name__)
+SUITE_DIR = Path(__file__).resolve().parent
+SOURCE_TYPE_POLYMARKET_SETTLEMENT = 6
+TASK_POLYMARKET_SETTLEMENT = Web3.keccak(text="polymarket_settlement")
+POLYGON_CHAIN_ID = 137
+TARGET_NONCE = 1
+WINNING_SLOT = 1
+SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION = 1
+QUORUM_VALIDATORS = 3
+
+
+def _settlement_uri() -> str:
+    return (
+        f"gravity://6/{MIRROR_ID}/polymarket_settlement?"
+        f"ctf={CTF_ADDRESS}&condition={CONDITION_ID}&fromBlock={SOURCE_BLOCK - 2}&"
+        "chainId=137&maxBlocksPerPoll=20"
+    )
+
+
+def _consensus_log(cluster: Cluster, node_id: str) -> Path:
+    return cluster.base_dir / node_id / "consensus_log" / "validator.log"
+
+
+def _relayer_state(cluster: Cluster, node_id: str) -> Path:
+    return cluster.base_dir / node_id / "data" / "reth" / "relayer_state.json"
+
+
+def _line_matches(content: str, marker: str, issuer: str) -> bool:
+    return any(marker in line and issuer in line for line in content.splitlines())
+
+
+def _read_source_state(cluster: Cluster, node_id: str, uri: str) -> dict | None:
+    state_path = _relayer_state(cluster, node_id)
+    if not state_path.exists():
+        return None
+    return json.loads(state_path.read_text())["sources"].get(uri)
+
+
+async def _wait_for_empty_scan_watermarks(
+    cluster: Cluster,
+    uri: str,
+    *,
+    timeout: int = 240,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        states = {
+            node_id: _read_source_state(cluster, node_id, uri)
+            for node_id in cluster.nodes
+        }
+        if all(
+            state is not None
+            and int(state["last_nonce"]) == 0
+            and int(state["last_nonce_block"]) == 0
+            and int(state["cursor_block"]) >= SOURCE_BLOCK - 1
+            for state in states.values()
+        ):
+            return
+        await asyncio.sleep(2)
+    raise AssertionError(f"validators did not persist empty finalized scans: {states}")
+
+
+async def _wait_for_terminal_relayer_state(
+    cluster: Cluster,
+    uri: str,
+    *,
+    timeout: int = 180,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        states = {
+            node_id: _read_source_state(cluster, node_id, uri)
+            for node_id in cluster.nodes
+        }
+        if all(
+            state is not None
+            and int(state["last_nonce"]) == TARGET_NONCE
+            and int(state["last_nonce_block"]) == SOURCE_BLOCK
+            and int(state["cursor_block"]) >= SOURCE_BLOCK
+            for state in states.values()
+        ):
+            return
+        await asyncio.sleep(2)
+    raise AssertionError(f"validators did not persist terminal settlement: {states}")
+
+
+async def _wait_for_consensus_evidence(
+    cluster: Cluster,
+    *,
+    timeout: int = 180,
+) -> None:
+    issuer = f"gravity://6/{MIRROR_ID}"
+    missing_observers = set(cluster.nodes)
+    certifiers = set()
+    quorum_seen = False
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        logs = {}
+        for node_id in cluster.nodes:
+            path = _consensus_log(cluster, node_id)
+            logs[node_id] = path.read_text(errors="replace") if path.exists() else ""
+
+        for node_id in list(missing_observers):
+            if _line_matches(logs[node_id], "JWKObserver spawned.", issuer):
+                missing_observers.remove(node_id)
+        for node_id, content in logs.items():
+            if _line_matches(content, "Start certifying update.", issuer):
+                certifiers.add(node_id)
+        quorum_seen = quorum_seen or any(
+            any(
+                "Peer vote aggregated." in line
+                and issuer in line
+                and (
+                    "threshold_exceeded=true" in line
+                    or '"threshold_exceeded":true' in line
+                )
+                for line in content.splitlines()
+            )
+            for content in logs.values()
+        )
+
+        if not missing_observers and len(certifiers) >= QUORUM_VALIDATORS and quorum_seen:
+            return
+        await asyncio.sleep(2)
+
+    raise AssertionError(
+        "missing validator oracle evidence: "
+        f"observers={sorted(missing_observers)}, "
+        f"certifiers={sorted(certifiers)}, quorum_seen={quorum_seen}"
+    )
+
+
+async def _wait_for_settlement(native_oracle, resolver, *, timeout: int = 300):
+    condition = bytes.fromhex(CONDITION_ID.removeprefix("0x"))
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        progress = tuple(
+            native_oracle.functions.getSourceProgress(
+                SOURCE_TYPE_POLYMARKET_SETTLEMENT,
+                MIRROR_ID,
+            ).call()
+        )
+        settlement = tuple(resolver.functions.getSettlement(MIRROR_ID, condition).call())
+        if progress == (TARGET_NONCE, SOURCE_BLOCK) and settlement[0]:
+            return progress, settlement
+        await asyncio.sleep(2)
+    raise TimeoutError("Polymarket settlement did not reach NativeOracle and resolver")
+
+
+async def _wait_for_block(w3, block_number: int, timeout: int = 60) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if w3.eth.block_number >= block_number:
+            return
+        await asyncio.sleep(1)
+    raise TimeoutError(f"RPC did not reach Gravity block {block_number}")
+
+
+def _assert_settlement(settlement: tuple) -> None:
+    assert settlement[0] is True
+    assert settlement[1] == TARGET_NONCE
+    assert settlement[2] == POLYGON_CHAIN_ID
+    assert Web3.to_checksum_address(settlement[3]) == Web3.to_checksum_address(CTF_ADDRESS)
+    assert Web3.to_checksum_address(settlement[4]) == Web3.to_checksum_address(ORACLE_ADDRESS)
+    assert bytes(settlement[5]) == bytes.fromhex(QUESTION_ID.removeprefix("0x"))
+    assert settlement[6] == OUTCOME_SLOT_COUNT
+    assert bytes(settlement[7]) == bytes.fromhex(TX_HASH.removeprefix("0x"))
+    assert settlement[8] == LOG_INDEX
+    assert settlement[9] == SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION
+
+
+@pytest.mark.asyncio
+async def test_four_validators_finalize_polymarket_settlement(cluster: Cluster):
+    assert len(cluster.nodes) == 4
+    assert await cluster.set_full_live(timeout=180)
+    assert await cluster.check_block_increasing(timeout=60)
+    validator_set = await cluster.validator_list()
+    assert {validator.id for validator in validator_set.active} == set(cluster.nodes)
+
+    node1 = cluster.get_node("node1")
+    assert node1 is not None and node1.w3.is_connected()
+    w3 = node1.w3
+
+    required = [
+        ("PolymarketSettlementResolver.sol", "PolymarketSettlementResolver"),
+        ("NativeOracle.sol", "NativeOracle"),
+        ("OracleTaskConfig.sol", "OracleTaskConfig"),
+    ]
+    contracts_out = support.ensure_contract_artifacts(SUITE_DIR, required)
+    resolver_artifact = support.load_artifact(
+        contracts_out,
+        "PolymarketSettlementResolver.sol",
+        "PolymarketSettlementResolver",
+    )
+    native_artifact = support.load_artifact(
+        contracts_out,
+        "NativeOracle.sol",
+        "NativeOracle",
+    )
+    task_artifact = support.load_artifact(
+        contracts_out,
+        "OracleTaskConfig.sol",
+        "OracleTaskConfig",
+    )
+
+    resolver = support.deploy_contract(w3, resolver_artifact)
+    native_oracle = w3.eth.contract(
+        address=support.NATIVE_ORACLE_ADDRESS,
+        abi=native_artifact["abi"],
+    )
+    task_config = w3.eth.contract(
+        address=support.ORACLE_TASK_CONFIG_ADDRESS,
+        abi=task_artifact["abi"],
+    )
+    uri = _settlement_uri()
+    relayer_config = json.loads((SUITE_DIR / "relayer_config.json").read_text())
+
+    with mock_polymarket_polygon_server(MOCK_POLYGON_PORT) as mock:
+        assert relayer_config["uri_mappings"] == {uri: mock.rpc_url}
+        await support.execute_governance_proposal(
+            w3,
+            support.faucet_voting_pool(w3),
+            [
+                support.NATIVE_ORACLE_ADDRESS,
+                resolver.address,
+                support.ORACLE_TASK_CONFIG_ADDRESS,
+            ],
+            [
+                support.function_calldata(
+                    native_oracle.functions.setDefaultCallback(
+                        SOURCE_TYPE_POLYMARKET_SETTLEMENT,
+                        resolver.address,
+                    )
+                ),
+                support.function_calldata(
+                    resolver.functions.registerMirror(
+                        MIRROR_ID,
+                        POLYGON_CHAIN_ID,
+                        Web3.to_checksum_address(CTF_ADDRESS),
+                        bytes.fromhex(CONDITION_ID.removeprefix("0x")),
+                        OUTCOME_SLOT_COUNT,
+                    )
+                ),
+                support.function_calldata(
+                    task_config.functions.setTask(
+                        SOURCE_TYPE_POLYMARKET_SETTLEMENT,
+                        MIRROR_ID,
+                        TASK_POLYMARKET_SETTLEMENT,
+                        uri.encode(),
+                    )
+                ),
+            ],
+            "deterministic-polymarket-settlement-multivalidator-e2e",
+        )
+
+        await _wait_for_empty_scan_watermarks(cluster, uri)
+        assert tuple(
+            native_oracle.functions.getSourceProgress(
+                SOURCE_TYPE_POLYMARKET_SETTLEMENT,
+                MIRROR_ID,
+            ).call()
+        ) == (0, 0)
+        assert resolver.functions.isSettlementObserved(
+            MIRROR_ID,
+            bytes.fromhex(CONDITION_ID.removeprefix("0x")),
+        ).call() is False
+        assert (SOURCE_BLOCK - 1, SOURCE_BLOCK - 1) in mock.scan_ranges()
+        assert mock.request_count("eth_getLogs") >= len(cluster.nodes)
+
+        mock.set_finalized_block(SOURCE_BLOCK)
+        progress, settlement = await _wait_for_settlement(native_oracle, resolver)
+        await _wait_for_consensus_evidence(cluster)
+        await _wait_for_terminal_relayer_state(cluster, uri)
+
+        assert progress == (TARGET_NONCE, SOURCE_BLOCK)
+        _assert_settlement(settlement)
+        observation = tuple(
+            resolver.functions.getSettlementObservation(
+                MIRROR_ID,
+                bytes.fromhex(CONDITION_ID.removeprefix("0x")),
+            ).call()
+        )
+        assert observation[0] == 1
+        assert observation[1] == WINNING_SLOT
+        assert observation[2] == TARGET_NONCE
+        assert observation[3] > 0
+        assert bytes(observation[4]) == bytes.fromhex(TX_HASH.removeprefix("0x"))
+        assert observation[5] == LOG_INDEX
+
+        assert (SOURCE_BLOCK, SOURCE_BLOCK) in mock.scan_ranges()
+        assert mock.request_count("eth_chainId") >= len(cluster.nodes)
+        assert mock.request_count("eth_getLogs") >= 2 * len(cluster.nodes)
+
+        snapshot_block = w3.eth.block_number
+        for node_id, node in cluster.nodes.items():
+            await _wait_for_block(node.w3, snapshot_block)
+            replica_native = node.w3.eth.contract(
+                address=support.NATIVE_ORACLE_ADDRESS,
+                abi=native_artifact["abi"],
+            )
+            replica_resolver = node.w3.eth.contract(
+                address=resolver.address,
+                abi=resolver_artifact["abi"],
+            )
+            replica_progress = tuple(
+                replica_native.functions.getSourceProgress(
+                    SOURCE_TYPE_POLYMARKET_SETTLEMENT,
+                    MIRROR_ID,
+                ).call(block_identifier=snapshot_block)
+            )
+            replica_settlement = tuple(
+                replica_resolver.functions.getSettlement(
+                    MIRROR_ID,
+                    bytes.fromhex(CONDITION_ID.removeprefix("0x")),
+                ).call(block_identifier=snapshot_block)
+            )
+            assert replica_progress == progress, node_id
+            assert replica_settlement == settlement, node_id
+
+        LOG.info(
+            "Four-validator Polymarket QC stored mirror=%s block=%s winningSlot=%s",
+            MIRROR_ID,
+            SOURCE_BLOCK,
+            WINNING_SLOT,
+        )

--- a/gravity_e2e/gravity_e2e/utils/mock_polymarket_polygon.py
+++ b/gravity_e2e/gravity_e2e/utils/mock_polymarket_polygon.py
@@ -1,0 +1,245 @@
+"""Deterministic localhost Polygon JSON-RPC fixture for oracle tests."""
+
+from collections import Counter
+from contextlib import contextmanager
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from eth_abi.packed import encode_packed
+from eth_utils import keccak
+
+LOG = logging.getLogger(__name__)
+
+POLYGON_CHAIN_ID = 137
+MOCK_POLYGON_PORT = 18_548
+CTF_ADDRESS = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+ORACLE_ADDRESS = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296"
+MIRROR_ID = 9_001
+QUESTION_ID = "0x" + "22" * 32
+OUTCOME_SLOT_COUNT = 2
+PAYOUT_NUMERATORS = [0, 1]
+SOURCE_BLOCK = 50_000_000
+LOG_INDEX = 17
+TX_HASH = "0x" + "aa" * 32
+
+CONDITION_RESOLUTION_TOPIC = "0x" + keccak(
+    text="ConditionResolution(bytes32,address,bytes32,uint256,uint256[])"
+).hex()
+
+
+def derive_condition_id(
+    oracle: str = ORACLE_ADDRESS,
+    question_id: str = QUESTION_ID,
+    outcome_slot_count: int = OUTCOME_SLOT_COUNT,
+) -> str:
+    packed = encode_packed(
+        ["address", "bytes32", "uint256"],
+        [oracle, bytes.fromhex(question_id.removeprefix("0x")), outcome_slot_count],
+    )
+    return "0x" + keccak(packed).hex()
+
+
+CONDITION_ID = derive_condition_id()
+
+
+def _quantity(value: int) -> str:
+    return hex(value)
+
+
+def _hash(seed: int) -> str:
+    return "0x" + seed.to_bytes(32, "big").hex()
+
+
+def _word(value: int) -> bytes:
+    return value.to_bytes(32, "big")
+
+
+def _address_topic(address: str) -> str:
+    return "0x" + bytes.fromhex(address.removeprefix("0x")).rjust(32, b"\x00").hex()
+
+
+def condition_resolution_log() -> dict:
+    data = _word(OUTCOME_SLOT_COUNT) + _word(64) + _word(len(PAYOUT_NUMERATORS))
+    data += b"".join(_word(value) for value in PAYOUT_NUMERATORS)
+    return {
+        "address": CTF_ADDRESS.lower(),
+        "topics": [
+            CONDITION_RESOLUTION_TOPIC,
+            CONDITION_ID,
+            _address_topic(ORACLE_ADDRESS),
+            QUESTION_ID,
+        ],
+        "data": "0x" + data.hex(),
+        "blockNumber": _quantity(SOURCE_BLOCK),
+        "blockHash": _hash(SOURCE_BLOCK + 0x100),
+        "transactionHash": TX_HASH,
+        "transactionIndex": "0x0",
+        "logIndex": _quantity(LOG_INDEX),
+        "removed": False,
+    }
+
+
+class MockPolymarketPolygon(ThreadingHTTPServer):
+    """Thread-safe JSON-RPC server with one CTF log and a controlled finalized head."""
+
+    allow_reuse_address = True
+
+    def __init__(self, address):
+        super().__init__(address, _MockPolygonHandler)
+        self.latest_block = SOURCE_BLOCK
+        self.finalized_block = SOURCE_BLOCK - 1
+        self._log = condition_resolution_log()
+        self._request_counts = Counter()
+        self._scan_ranges = []
+        self._lock = threading.Lock()
+
+    @property
+    def rpc_url(self) -> str:
+        host, port = self.server_address
+        return f"http://{host}:{port}"
+
+    def set_finalized_block(self, block_number: int) -> None:
+        if block_number > self.latest_block:
+            raise ValueError("finalized block cannot exceed latest block")
+        with self._lock:
+            self.finalized_block = block_number
+
+    def request_count(self, method: str) -> int:
+        with self._lock:
+            return self._request_counts[method]
+
+    def scan_ranges(self) -> list[tuple[int, int]]:
+        with self._lock:
+            return list(self._scan_ranges)
+
+    def handle_rpc(self, request: dict) -> dict:
+        method = request.get("method")
+        params = request.get("params", [])
+        request_id = request.get("id")
+        with self._lock:
+            self._request_counts[method] += 1
+
+        try:
+            if method == "eth_chainId":
+                result = _quantity(POLYGON_CHAIN_ID)
+            elif method == "net_version":
+                result = str(POLYGON_CHAIN_ID)
+            elif method == "eth_blockNumber":
+                result = _quantity(self.latest_block)
+            elif method == "eth_getBlockByNumber":
+                result = self._block_by_number(params)
+            elif method == "eth_getLogs":
+                result = self._logs(params)
+            else:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {"code": -32601, "message": f"unsupported method: {method}"},
+                }
+            return {"jsonrpc": "2.0", "id": request_id, "result": result}
+        except (IndexError, KeyError, TypeError, ValueError) as error:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32602, "message": str(error)},
+            }
+
+    def _parse_block(self, value) -> int:
+        if value == "finalized":
+            return self.finalized_block
+        if value in ("latest", "safe", "pending"):
+            return self.latest_block
+        if value == "earliest":
+            return 0
+        return int(value, 16) if isinstance(value, str) and value.startswith("0x") else int(value)
+
+    def _block_by_number(self, params: list) -> dict | None:
+        block_number = self._parse_block(params[0])
+        if block_number > self.latest_block:
+            return None
+        return {
+            "number": _quantity(block_number),
+            "hash": _hash(block_number + 0x100),
+            "parentHash": _hash(block_number + 0xFF),
+            "timestamp": _quantity(1_700_000_000 + block_number),
+            "gasLimit": _quantity(30_000_000),
+            "gasUsed": "0x0",
+            "miner": "0x" + "00" * 20,
+            "difficulty": "0x0",
+            "totalDifficulty": "0x0",
+            "size": "0x100",
+            "nonce": "0x0000000000000000",
+            "extraData": "0x",
+            "logsBloom": "0x" + "00" * 256,
+            "transactionsRoot": "0x" + "00" * 32,
+            "stateRoot": "0x" + "00" * 32,
+            "receiptsRoot": "0x" + "00" * 32,
+            "sha3Uncles": "0x" + "00" * 32,
+            "uncles": [],
+            "transactions": [],
+            "baseFeePerGas": "0x0",
+            "mixHash": "0x" + "00" * 32,
+        }
+
+    def _logs(self, params: list) -> list[dict]:
+        query = params[0]
+        from_block = self._parse_block(query.get("fromBlock", "earliest"))
+        to_block = self._parse_block(query.get("toBlock", "latest"))
+        with self._lock:
+            self._scan_ranges.append((from_block, to_block))
+
+        if not (from_block <= SOURCE_BLOCK <= to_block):
+            return []
+        if query.get("address", "").lower() not in ("", CTF_ADDRESS.lower()):
+            return []
+
+        filters = query.get("topics", [])
+        topics = self._log["topics"]
+        for index, expected in enumerate(filters):
+            if expected is None:
+                continue
+            if index >= len(topics):
+                return []
+            allowed = expected if isinstance(expected, list) else [expected]
+            if topics[index].lower() not in {value.lower() for value in allowed}:
+                return []
+        return [self._log]
+
+
+class _MockPolygonHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self):
+        try:
+            content_length = int(self.headers.get("content-length", "0"))
+            request = json.loads(self.rfile.read(content_length))
+            if isinstance(request, list):
+                response = [self.server.handle_rpc(item) for item in request]
+            else:
+                response = self.server.handle_rpc(request)
+            payload = json.dumps(response).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except (json.JSONDecodeError, ValueError) as error:
+            self.send_error(400, str(error))
+
+    def log_message(self, fmt: str, *args):
+        LOG.debug("mock Polygon: " + fmt, *args)
+
+
+@contextmanager
+def mock_polymarket_polygon_server(port: int = MOCK_POLYGON_PORT):
+    server = MockPolymarketPolygon(("127.0.0.1", port))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/gravity_e2e/gravity_e2e/utils/test_mock_polymarket_polygon.py
+++ b/gravity_e2e/gravity_e2e/utils/test_mock_polymarket_polygon.py
@@ -1,0 +1,104 @@
+"""Unit coverage for the deterministic Polygon settlement fixture."""
+
+import json
+from urllib.request import ProxyHandler, Request, build_opener
+
+from eth_abi import decode
+
+from gravity_e2e.utils.mock_polymarket_polygon import (
+    CONDITION_ID,
+    CONDITION_RESOLUTION_TOPIC,
+    CTF_ADDRESS,
+    LOG_INDEX,
+    ORACLE_ADDRESS,
+    OUTCOME_SLOT_COUNT,
+    PAYOUT_NUMERATORS,
+    QUESTION_ID,
+    SOURCE_BLOCK,
+    derive_condition_id,
+    mock_polymarket_polygon_server,
+)
+
+
+def _rpc(url: str, method: str, params: list):
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+    ).encode()
+    request = Request(url, data=payload, headers={"content-type": "application/json"})
+    with build_opener(ProxyHandler({})).open(request, timeout=2) as response:
+        body = json.loads(response.read())
+    assert "error" not in body, body
+    return body["result"]
+
+
+def test_condition_identity_and_event_encoding_are_canonical():
+    assert CONDITION_ID == derive_condition_id()
+    assert CONDITION_ID == (
+        "0xd874d3b83fa09e192fdda031b6a3b3ec78be60cb82678aa67b23f8fd027c86ae"
+    )
+
+    with mock_polymarket_polygon_server(port=0) as server:
+        logs = _rpc(
+            server.rpc_url,
+            "eth_getLogs",
+            [
+                {
+                    "fromBlock": hex(SOURCE_BLOCK),
+                    "toBlock": hex(SOURCE_BLOCK),
+                    "address": CTF_ADDRESS,
+                    "topics": [CONDITION_RESOLUTION_TOPIC, CONDITION_ID],
+                }
+            ],
+        )
+
+    assert len(logs) == 1
+    log = logs[0]
+    assert log["topics"][1] == CONDITION_ID
+    assert log["topics"][2].endswith(ORACLE_ADDRESS.removeprefix("0x").lower())
+    assert log["topics"][3] == QUESTION_ID
+    assert int(log["logIndex"], 16) == LOG_INDEX
+    assert decode(["uint256", "uint256[]"], bytes.fromhex(log["data"][2:])) == (
+        OUTCOME_SLOT_COUNT,
+        tuple(PAYOUT_NUMERATORS),
+    )
+
+
+def test_finalized_head_is_independent_and_requests_are_recorded():
+    with mock_polymarket_polygon_server(port=0) as server:
+        finalized = _rpc(
+            server.rpc_url,
+            "eth_getBlockByNumber",
+            ["finalized", False],
+        )
+        latest = _rpc(server.rpc_url, "eth_getBlockByNumber", ["latest", False])
+        assert int(finalized["number"], 16) == SOURCE_BLOCK - 1
+        assert int(latest["number"], 16) == SOURCE_BLOCK
+
+        server.set_finalized_block(SOURCE_BLOCK)
+        finalized = _rpc(
+            server.rpc_url,
+            "eth_getBlockByNumber",
+            ["finalized", False],
+        )
+        assert int(finalized["number"], 16) == SOURCE_BLOCK
+        assert server.request_count("eth_getBlockByNumber") == 3
+
+
+def test_log_filter_rejects_wrong_condition_and_tracks_ranges():
+    with mock_polymarket_polygon_server(port=0) as server:
+        wrong = "0x" + "ff" * 32
+        logs = _rpc(
+            server.rpc_url,
+            "eth_getLogs",
+            [
+                {
+                    "fromBlock": hex(SOURCE_BLOCK - 1),
+                    "toBlock": hex(SOURCE_BLOCK),
+                    "address": CTF_ADDRESS,
+                    "topics": [CONDITION_RESOLUTION_TOPIC, wrong],
+                }
+            ],
+        )
+
+        assert logs == []
+        assert server.scan_ranges() == [(SOURCE_BLOCK - 1, SOURCE_BLOCK)]


### PR DESCRIPTION
## Summary

- pin the SDK runtime to merged gravity-reth #420
- add a deterministic localhost Polygon JSON-RPC fixture with a separately controlled finalized head
- add one four-validator merge-gating E2E for the complete Polymarket settlement transport path
- document the exact local run command and scope boundaries

Tracks Galxe/gravity-audit#1038 and preserves the split requested by Galxe/gravity-audit#1033.

## Dependency baseline

- gravity-aptos #79: `a64f8adc274bf2681df796766ef9a5b195fee44b`
- gravity_chain_core_contracts #115: `f447687bf6f6f9efabd92626b588aeda94148f88`
- gravity-reth #420: `0c038e180cc26ae400f3fb2e6199e6f079f68fbc`
- gravity-sdk main / #805: `fc7cb8f4b665e524e132f0921d5b99dc7cde6929`

Both the direct `greth` dependency and the `reth-primitives-traits` patch point at the same merged reth revision. The lockfile changes are limited to replacing the previous gravity-reth source revision.

## Workflow covered

1. Start four validators with equal voting power.
2. Governance deploys `PolymarketSettlementResolver`, binds source type 6, registers one CTF mirror, and activates the task.
3. Every validator independently polls the same localhost Polygon fixture.
4. The CTF event exists at `latest`, while `finalized` remains one block behind.
5. All validators persist an empty-scan cursor and no settlement reaches `NativeOracle`.
6. The fixture advances `finalized`; validators derive byte-identical observations.
7. At least three validators certify, JWK consensus reaches a voting-power quorum, and execution records nonce `1`.
8. The resolver stores winner slot `1` and canonical Polygon provenance.
9. All four relayer checkpoints become terminal and all four Gravity RPCs return identical contract state at the same block.

The fixture uses the canonical Polygon CTF `ConditionResolution` ABI and validates the derived condition ID, topic layout, dynamic payout encoding, filter behavior, and finalized/latest separation.

## Deliberate exclusions

- no prediction-market betting/product contract
- no live Polygon RPC or credentials
- no frontend/demo/soak test
- no new Aptos or reth runtime behavior

The oracle data-source runtime path is localhost-only. A fresh build may still download repository dependencies.

## Validation

- `make MODE=quick-release gravity_node gravity_cli`
- fixture unit tests: `3 passed`
- four-validator Polymarket E2E: `1 passed` in `46.57s`
- TOML/JSON parsing, Python bytecode compilation, `git diff --check`, and credential/user-path scans passed
- no Rust source files changed

## Run

```bash
make MODE=quick-release gravity_node gravity_cli

PATH="$HOME/.foundry/bin:$PWD/target/quick-release:$PATH" \
  ./gravity_e2e/run_test.sh \
    polymarket_settlement_multivalidator \
    --force-init \
    --log-cli-level=INFO
```
