### PR TITLE
feat(chainspec): schedule mainnet Beta and Osaka hardforks

### DIFF
--- a/bin/gravity_node/src/chainspec.rs
+++ b/bin/gravity_node/src/chainspec.rs
@@ -68,19 +68,36 @@ pub const GRAVITY_MAINNET_CHAIN_ID: u64 = 127_001;
 /// 2026-07-27 05:00:00 UTC.
 pub(crate) const GRAVITY_MAINNET_ALPHA_TIME: u64 = 1_785_128_400;
 
+/// Gravity mainnet Beta and Osaka activation timestamp in Unix seconds.
+///
+/// Both forks share this value: Beta (Gravity EIP-7702 lockdown release +
+/// block-gas last-gate) and Osaka (Ethereum hardfork) activate together.
+///
+/// 2026-08-17 13:00:00 Beijing (UTC+08:00), which is
+/// 2026-08-17 05:00:00 UTC.
+pub(crate) const GRAVITY_MAINNET_BETA_OSAKA_TIME: u64 = 1_786_942_800;
+
 /// Per-chain hardcoded override. Each field gates one fork.
 ///
 /// `alpha_time` is written into `genesis.config.extra_fields["alphaTime"]`,
 /// which is the same key the CL side reads. So a single
 /// `alpha_time: Some(ts)` entry pins **both** EL and CL Alpha to
 /// the same authoritative timestamp.
+///
+/// `beta_time` is written into `extra_fields["betaTime"]` (EL-only Gravity
+/// hardfork). `osaka_time` maps to the typed `ChainConfig.osaka_time` field.
 struct GravityForkOverrides {
     /// Maps to `genesis.config.prague_time` (typed field on `ChainConfig`).
     prague_time: Option<u64>,
+    /// Maps to `genesis.config.osaka_time` (typed field on `ChainConfig`).
+    osaka_time: Option<u64>,
     /// Maps to `genesis.config.extra_fields["alphaTime"]`. EL reads this in
     /// `From<Genesis>`; the CL side reads the same key in main.rs's
     /// `consensus_hardforks_from_genesis_extra_fields`.
     alpha_time: Option<u64>,
+    /// Maps to `genesis.config.extra_fields["betaTime"]`. EL reads this in
+    /// `From<Genesis>` for `GravityHardfork::Beta`. Fail-closed if unset.
+    beta_time: Option<u64>,
 }
 
 /// Chain ids the binary owns. Listed entries are authoritative for the
@@ -96,9 +113,14 @@ const HARDCODED: &[(u64, GravityForkOverrides)] = &[
         GravityForkOverrides {
             // Pinned to deployed mainnet genesis (config.pragueTime).
             prague_time: Some(1_782_709_200),
+            // Mainnet Osaka activation coordinated for 2026-08-17 13:00:00
+            // Beijing (UTC+08:00), equivalent to 2026-08-17 05:00:00 UTC.
+            osaka_time: Some(GRAVITY_MAINNET_BETA_OSAKA_TIME),
             // Mainnet Alpha activation coordinated for 2026-07-27 13:00:00
             // Beijing (UTC+08:00), equivalent to 2026-07-27 05:00:00 UTC.
             alpha_time: Some(GRAVITY_MAINNET_ALPHA_TIME),
+            // Mainnet Beta (same wall-clock as Osaka).
+            beta_time: Some(GRAVITY_MAINNET_BETA_OSAKA_TIME),
         },
     ),
 ];
@@ -183,7 +205,7 @@ fn apply_overrides(g: &mut Genesis) -> Vec<OverrideEvent> {
     };
     let chain_id = g.config.chain_id;
 
-    // Prague: typed `ChainConfig` field. `Some` overwrites, `None` clears.
+    // Typed `ChainConfig` fields. `Some` overwrites, `None` clears.
     if g.config.prague_time != ov.prague_time {
         events.push(OverrideEvent {
             chain_id,
@@ -193,8 +215,17 @@ fn apply_overrides(g: &mut Genesis) -> Vec<OverrideEvent> {
         });
         g.config.prague_time = ov.prague_time;
     }
+    if g.config.osaka_time != ov.osaka_time {
+        events.push(OverrideEvent {
+            chain_id,
+            fork: "osaka_time",
+            genesis: g.config.osaka_time,
+            forced: ov.osaka_time,
+        });
+        g.config.osaka_time = ov.osaka_time;
+    }
 
-    // Alpha: `extra_fields` map. `OtherFields` derefs to
+    // Gravity hardforks live in `extra_fields`. `OtherFields` derefs to
     // `BTreeMap<String, serde_json::Value>`, so we can `insert` / `remove`
     // directly.
     let genesis_alpha = g.config.extra_fields.get("alphaTime").and_then(|v| v.as_u64());
@@ -215,6 +246,24 @@ fn apply_overrides(g: &mut Genesis) -> Vec<OverrideEvent> {
         }
     }
 
+    let genesis_beta = g.config.extra_fields.get("betaTime").and_then(|v| v.as_u64());
+    if genesis_beta != ov.beta_time {
+        events.push(OverrideEvent {
+            chain_id,
+            fork: "betaTime",
+            genesis: genesis_beta,
+            forced: ov.beta_time,
+        });
+        match ov.beta_time {
+            Some(t) => {
+                g.config.extra_fields.insert("betaTime".to_string(), serde_json::Value::from(t));
+            }
+            None => {
+                g.config.extra_fields.remove("betaTime");
+            }
+        }
+    }
+
     events
 }
 
@@ -225,43 +274,69 @@ mod tests {
         ChainSpecBuilder, EthereumHardfork, EthereumHardforks, ForkCondition, GravityHardfork,
     };
 
-    fn genesis_json(chain_id: u64, prague_time: Option<u64>, alpha_time: Option<u64>) -> String {
-        let prague = match prague_time {
-            Some(t) => format!(r#","pragueTime":{t}"#),
+    /// Optional hardfork fields for synthetic genesis JSON used by tests.
+    #[derive(Clone, Copy, Default)]
+    struct ForkInputs {
+        prague: Option<u64>,
+        osaka: Option<u64>,
+        alpha: Option<u64>,
+        beta: Option<u64>,
+    }
+
+    fn opt_field(name: &str, value: Option<u64>) -> String {
+        match value {
+            Some(t) => format!(r#","{name}":{t}"#),
             None => String::new(),
-        };
-        let alpha = match alpha_time {
-            Some(t) => format!(r#","alphaTime":{t}"#),
-            None => String::new(),
-        };
+        }
+    }
+
+    fn genesis_json(chain_id: u64, forks: ForkInputs) -> String {
+        let prague = opt_field("pragueTime", forks.prague);
+        let osaka = opt_field("osakaTime", forks.osaka);
+        let alpha = opt_field("alphaTime", forks.alpha);
+        let beta = opt_field("betaTime", forks.beta);
         format!(
-            r#"{{"config":{{"chainId":{chain_id},"homesteadBlock":0,"eip150Block":0,"eip155Block":0,"eip158Block":0,"byzantiumBlock":0,"constantinopleBlock":0,"petersburgBlock":0,"istanbulBlock":0,"berlinBlock":0,"londonBlock":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true,"shanghaiTime":0,"cancunTime":0{prague}{alpha}}},"nonce":"0x0","timestamp":"0x0","extraData":"0x","gasLimit":"0x4c4b40","difficulty":"0x0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","coinbase":"0x0000000000000000000000000000000000000000","alloc":{{}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}}"#
+            r#"{{"config":{{"chainId":{chain_id},"homesteadBlock":0,"eip150Block":0,"eip155Block":0,"eip158Block":0,"byzantiumBlock":0,"constantinopleBlock":0,"petersburgBlock":0,"istanbulBlock":0,"berlinBlock":0,"londonBlock":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true,"shanghaiTime":0,"cancunTime":0{prague}{osaka}{alpha}{beta}}},"nonce":"0x0","timestamp":"0x0","extraData":"0x","gasLimit":"0x4c4b40","difficulty":"0x0","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","coinbase":"0x0000000000000000000000000000000000000000","alloc":{{}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}}"#
         )
     }
 
-    fn build_via_parser(
-        chain_id: u64,
-        prague_time: Option<u64>,
-        alpha_time: Option<u64>,
-    ) -> Arc<ChainSpec> {
-        let s = genesis_json(chain_id, prague_time, alpha_time);
+    fn build_via_parser(chain_id: u64, forks: ForkInputs) -> Arc<ChainSpec> {
+        let s = genesis_json(chain_id, forks);
         GravityChainSpecParser::parse(&s).expect("parse should succeed")
     }
 
-    fn table_prague_timestamp() -> u64 {
+    fn mainnet_overrides() -> &'static GravityForkOverrides {
         HARDCODED
             .iter()
             .find(|(id, _)| *id == GRAVITY_MAINNET_CHAIN_ID)
-            .and_then(|(_, ov)| ov.prague_time)
-            .expect("mainnet must have a Some(ts) Prague entry")
+            .map(|(_, ov)| ov)
+            .expect("mainnet must be in HARDCODED")
+    }
+
+    fn table_prague_timestamp() -> u64 {
+        mainnet_overrides().prague_time.expect("mainnet must have a Some(ts) Prague entry")
+    }
+
+    fn table_osaka_timestamp() -> u64 {
+        mainnet_overrides().osaka_time.expect("mainnet must have a Some(ts) Osaka entry")
     }
 
     fn table_alpha_timestamp() -> u64 {
-        HARDCODED
-            .iter()
-            .find(|(id, _)| *id == GRAVITY_MAINNET_CHAIN_ID)
-            .and_then(|(_, ov)| ov.alpha_time)
-            .expect("mainnet must have a Some(ts) Alpha entry")
+        mainnet_overrides().alpha_time.expect("mainnet must have a Some(ts) Alpha entry")
+    }
+
+    fn table_beta_timestamp() -> u64 {
+        mainnet_overrides().beta_time.expect("mainnet must have a Some(ts) Beta entry")
+    }
+
+    /// Genesis that already matches every mainnet table entry — silent apply.
+    fn matching_mainnet_forks() -> ForkInputs {
+        ForkInputs {
+            prague: Some(table_prague_timestamp()),
+            osaka: Some(table_osaka_timestamp()),
+            alpha: Some(table_alpha_timestamp()),
+            beta: Some(table_beta_timestamp()),
+        }
     }
 
     // ---------- Trait wiring ----------
@@ -282,7 +357,10 @@ mod tests {
     #[test]
     fn mainnet_overrides_prague_when_genesis_supplies_a_different_value() {
         let table_ts = table_prague_timestamp();
-        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, Some(100), None);
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: Some(100), ..matching_mainnet_forks() },
+        );
         assert_eq!(
             cs.hardforks.fork(EthereumHardfork::Prague),
             ForkCondition::Timestamp(table_ts),
@@ -296,7 +374,10 @@ mod tests {
     #[test]
     fn mainnet_overrides_prague_when_genesis_omits_it() {
         let table_ts = table_prague_timestamp();
-        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, None, None);
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: None, ..matching_mainnet_forks() },
+        );
         assert_eq!(cs.hardforks.fork(EthereumHardfork::Prague), ForkCondition::Timestamp(table_ts),);
         assert!(!cs.is_prague_active_at_timestamp(table_ts - 1));
         assert!(cs.is_prague_active_at_timestamp(table_ts));
@@ -305,7 +386,8 @@ mod tests {
     #[test]
     fn non_mainnet_chain_id_passes_prague_through() {
         // Gravity testnet chain id — not in the table, so genesis wins.
-        let cs = build_via_parser(7_771_625, Some(100), None);
+        let cs =
+            build_via_parser(7_771_625, ForkInputs { prague: Some(100), ..Default::default() });
         assert_eq!(cs.hardforks.fork(EthereumHardfork::Prague), ForkCondition::Timestamp(100),);
         assert!(cs.is_prague_active_at_timestamp(100));
         assert!(!cs.is_prague_active_at_timestamp(99));
@@ -313,9 +395,48 @@ mod tests {
 
     #[test]
     fn mainnet_does_not_touch_shanghai_or_cancun() {
-        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, None, None);
+        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, ForkInputs::default());
         assert!(cs.is_shanghai_active_at_timestamp(0));
         assert!(cs.is_cancun_active_at_timestamp(0));
+    }
+
+    // ---------- Ethereum-side: Osaka override ----------
+
+    #[test]
+    fn mainnet_overrides_osaka_when_genesis_supplies_a_different_value() {
+        let table_ts = table_osaka_timestamp();
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { osaka: Some(100), ..matching_mainnet_forks() },
+        );
+        assert_eq!(
+            cs.hardforks.fork(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(table_ts),
+            "binary value must win over genesis",
+        );
+        assert!(!cs.is_osaka_active_at_timestamp(100));
+        assert!(!cs.is_osaka_active_at_timestamp(table_ts - 1));
+        assert!(cs.is_osaka_active_at_timestamp(table_ts));
+    }
+
+    #[test]
+    fn mainnet_overrides_osaka_when_genesis_omits_it() {
+        let table_ts = table_osaka_timestamp();
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { osaka: None, ..matching_mainnet_forks() },
+        );
+        assert_eq!(cs.hardforks.fork(EthereumHardfork::Osaka), ForkCondition::Timestamp(table_ts),);
+        assert!(!cs.is_osaka_active_at_timestamp(table_ts - 1));
+        assert!(cs.is_osaka_active_at_timestamp(table_ts));
+    }
+
+    #[test]
+    fn non_mainnet_chain_id_passes_osaka_through() {
+        let cs = build_via_parser(7_771_625, ForkInputs { osaka: Some(100), ..Default::default() });
+        assert_eq!(cs.hardforks.fork(EthereumHardfork::Osaka), ForkCondition::Timestamp(100),);
+        assert!(cs.is_osaka_active_at_timestamp(100));
+        assert!(!cs.is_osaka_active_at_timestamp(99));
     }
 
     // ---------- Gravity-side (extra_fields): Alpha override ----------
@@ -323,7 +444,10 @@ mod tests {
     #[test]
     fn mainnet_overrides_alpha_when_genesis_supplies_a_different_value() {
         let table_ts = table_alpha_timestamp();
-        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, None, Some(100));
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { alpha: Some(100), ..matching_mainnet_forks() },
+        );
         assert_eq!(
             cs.genesis().config.extra_fields.get("alphaTime").and_then(|v| v.as_u64()),
             Some(table_ts),
@@ -343,7 +467,10 @@ mod tests {
     #[test]
     fn mainnet_overrides_alpha_when_genesis_omits_it() {
         let table_ts = table_alpha_timestamp();
-        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, None, None);
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { alpha: None, ..matching_mainnet_forks() },
+        );
         assert_eq!(
             cs.genesis().config.extra_fields.get("alphaTime").and_then(|v| v.as_u64()),
             Some(table_ts),
@@ -358,7 +485,7 @@ mod tests {
     fn non_mainnet_chain_id_passes_alpha_through() {
         // Testnet: not in the table, so the operator's alphaTime survives
         // in extra_fields, and the CL side will pick it up at startup.
-        let cs = build_via_parser(7_771_625, None, Some(100));
+        let cs = build_via_parser(7_771_625, ForkInputs { alpha: Some(100), ..Default::default() });
         assert_eq!(
             cs.genesis().config.extra_fields.get("alphaTime").and_then(|v| v.as_u64()),
             Some(100),
@@ -369,6 +496,58 @@ mod tests {
         );
     }
 
+    // ---------- Gravity-side (extra_fields): Beta override ----------
+
+    #[test]
+    fn mainnet_overrides_beta_when_genesis_supplies_a_different_value() {
+        let table_ts = table_beta_timestamp();
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { beta: Some(100), ..matching_mainnet_forks() },
+        );
+        assert_eq!(
+            cs.genesis().config.extra_fields.get("betaTime").and_then(|v| v.as_u64()),
+            Some(table_ts),
+            "binary value must win over genesis",
+        );
+        assert_eq!(
+            cs.gravity_hardforks.fork(GravityHardfork::Beta),
+            ForkCondition::Timestamp(table_ts),
+        );
+        assert!(!cs.gravity_hardforks.is_fork_active_at_timestamp(GravityHardfork::Beta, 100));
+        assert!(!cs
+            .gravity_hardforks
+            .is_fork_active_at_timestamp(GravityHardfork::Beta, table_ts - 1));
+        assert!(cs.gravity_hardforks.is_fork_active_at_timestamp(GravityHardfork::Beta, table_ts));
+    }
+
+    #[test]
+    fn mainnet_overrides_beta_when_genesis_omits_it() {
+        let table_ts = table_beta_timestamp();
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { beta: None, ..matching_mainnet_forks() },
+        );
+        assert_eq!(
+            cs.genesis().config.extra_fields.get("betaTime").and_then(|v| v.as_u64()),
+            Some(table_ts),
+        );
+        assert_eq!(
+            cs.gravity_hardforks.fork(GravityHardfork::Beta),
+            ForkCondition::Timestamp(table_ts),
+        );
+    }
+
+    #[test]
+    fn non_mainnet_chain_id_passes_beta_through() {
+        let cs = build_via_parser(7_771_625, ForkInputs { beta: Some(100), ..Default::default() });
+        assert_eq!(
+            cs.genesis().config.extra_fields.get("betaTime").and_then(|v| v.as_u64()),
+            Some(100),
+        );
+        assert_eq!(cs.gravity_hardforks.fork(GravityHardfork::Beta), ForkCondition::Timestamp(100),);
+    }
+
     // ---------- Unified-view invariant ----------
 
     /// D-1 explicitly DOES mutate `chain_spec.genesis` (unlike #369's
@@ -377,11 +556,19 @@ mod tests {
     /// explicit.
     #[test]
     fn post_override_genesis_reflects_the_table() {
-        let cs = build_via_parser(GRAVITY_MAINNET_CHAIN_ID, Some(100), Some(50));
+        let cs = build_via_parser(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: Some(100), osaka: Some(200), alpha: Some(50), beta: Some(60) },
+        );
         assert_eq!(
             cs.genesis().config.prague_time,
             Some(table_prague_timestamp()),
             "preserved Genesis must reflect the table (Prague)",
+        );
+        assert_eq!(
+            cs.genesis().config.osaka_time,
+            Some(table_osaka_timestamp()),
+            "preserved Genesis must reflect the table (Osaka)",
         );
         assert_eq!(
             cs.genesis().config.extra_fields.get("alphaTime").and_then(|v| v.as_u64()),
@@ -389,12 +576,25 @@ mod tests {
             "preserved Genesis must reflect the table (alphaTime)",
         );
         assert_eq!(
+            cs.genesis().config.extra_fields.get("betaTime").and_then(|v| v.as_u64()),
+            Some(table_beta_timestamp()),
+            "preserved Genesis must reflect the table (betaTime)",
+        );
+        assert_eq!(
             cs.hardforks.fork(EthereumHardfork::Prague),
             ForkCondition::Timestamp(table_prague_timestamp()),
         );
         assert_eq!(
+            cs.hardforks.fork(EthereumHardfork::Osaka),
+            ForkCondition::Timestamp(table_osaka_timestamp()),
+        );
+        assert_eq!(
             cs.gravity_hardforks.fork(GravityHardfork::Alpha),
             ForkCondition::Timestamp(table_alpha_timestamp()),
+        );
+        assert_eq!(
+            cs.gravity_hardforks.fork(GravityHardfork::Beta),
+            ForkCondition::Timestamp(table_beta_timestamp()),
         );
     }
 
@@ -402,7 +602,10 @@ mod tests {
 
     #[test]
     fn parse_is_idempotent_on_mainnet() {
-        let s = genesis_json(GRAVITY_MAINNET_CHAIN_ID, Some(100), Some(50));
+        let s = genesis_json(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: Some(100), osaka: Some(200), alpha: Some(50), beta: Some(60) },
+        );
         let a = GravityChainSpecParser::parse(&s).expect("parse a");
         let b = GravityChainSpecParser::parse(&s).expect("parse b");
         assert_eq!(a.hardforks, b.hardforks);
@@ -440,27 +643,34 @@ mod tests {
         assert_eq!(table_alpha_timestamp(), 1_785_128_400);
     }
 
+    /// Consensus-affecting pin: 2026-08-17 13:00:00 Beijing (UTC+08:00),
+    /// equivalent to 2026-08-17 05:00:00 UTC. Beta and Osaka share this
+    /// wall-clock. Changing either value requires network-wide coordination.
+    #[test]
+    fn gravity_mainnet_beta_osaka_timestamp_pinned_to_coordinated_value() {
+        assert_eq!(table_beta_timestamp(), 1_786_942_800);
+        assert_eq!(table_osaka_timestamp(), 1_786_942_800);
+        assert_eq!(table_beta_timestamp(), table_osaka_timestamp());
+        assert_eq!(GRAVITY_MAINNET_BETA_OSAKA_TIME, 1_786_942_800);
+    }
+
     // ---------- Mismatch-warning event emission ----------
 
     /// Parse the JSON helper directly to a `Genesis` (without running the
     /// override) so tests can call `apply_overrides` themselves and assert
     /// on the returned events.
-    fn parse_genesis_only(
-        chain_id: u64,
-        prague_time: Option<u64>,
-        alpha_time: Option<u64>,
-    ) -> Genesis {
-        let s = genesis_json(chain_id, prague_time, alpha_time);
+    fn parse_genesis_only(chain_id: u64, forks: ForkInputs) -> Genesis {
+        let s = genesis_json(chain_id, forks);
         serde_json::from_str(&s).expect("valid genesis json")
     }
 
     #[test]
     fn apply_overrides_emits_event_when_genesis_prague_differs() {
-        let mut g =
-            parse_genesis_only(GRAVITY_MAINNET_CHAIN_ID, Some(100), Some(table_alpha_timestamp()));
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: Some(100), ..matching_mainnet_forks() },
+        );
         let events = apply_overrides(&mut g);
-        // Prague: genesis Some(100) vs forced Some(table_ts) → event.
-        // Alpha:  genesis Some(table_ts) vs forced Some(table_ts) → no event.
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].fork, "prague_time");
         assert_eq!(events[0].genesis, Some(100));
@@ -469,11 +679,11 @@ mod tests {
 
     #[test]
     fn apply_overrides_emits_event_when_genesis_omits_prague() {
-        let mut g =
-            parse_genesis_only(GRAVITY_MAINNET_CHAIN_ID, None, Some(table_alpha_timestamp()));
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: None, ..matching_mainnet_forks() },
+        );
         let events = apply_overrides(&mut g);
-        // Prague: genesis None vs forced Some(table_ts) → event.
-        // Alpha:  genesis Some(table_ts) vs forced Some(table_ts) → no event.
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].fork, "prague_time");
         assert_eq!(events[0].genesis, None);
@@ -481,12 +691,38 @@ mod tests {
     }
 
     #[test]
-    fn apply_overrides_emits_event_when_genesis_supplies_alpha() {
-        let mut g =
-            parse_genesis_only(GRAVITY_MAINNET_CHAIN_ID, Some(table_prague_timestamp()), Some(100));
+    fn apply_overrides_emits_event_when_genesis_osaka_differs() {
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { osaka: Some(100), ..matching_mainnet_forks() },
+        );
         let events = apply_overrides(&mut g);
-        // Prague: genesis Some(table_ts) vs forced Some(table_ts) → no event.
-        // Alpha:  genesis Some(100) vs forced Some(table_ts) → event.
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].fork, "osaka_time");
+        assert_eq!(events[0].genesis, Some(100));
+        assert_eq!(events[0].forced, Some(table_osaka_timestamp()));
+    }
+
+    #[test]
+    fn apply_overrides_emits_event_when_genesis_omits_osaka() {
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { osaka: None, ..matching_mainnet_forks() },
+        );
+        let events = apply_overrides(&mut g);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].fork, "osaka_time");
+        assert_eq!(events[0].genesis, None);
+        assert_eq!(events[0].forced, Some(table_osaka_timestamp()));
+    }
+
+    #[test]
+    fn apply_overrides_emits_event_when_genesis_supplies_alpha() {
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { alpha: Some(100), ..matching_mainnet_forks() },
+        );
+        let events = apply_overrides(&mut g);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].fork, "alphaTime");
         assert_eq!(events[0].genesis, Some(100));
@@ -495,36 +731,65 @@ mod tests {
 
     #[test]
     fn apply_overrides_emits_event_when_genesis_omits_alpha() {
-        let mut g =
-            parse_genesis_only(GRAVITY_MAINNET_CHAIN_ID, Some(table_prague_timestamp()), None);
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { alpha: None, ..matching_mainnet_forks() },
+        );
         let events = apply_overrides(&mut g);
-        // Prague already matches. A deployed genesis without alphaTime must
-        // visibly report the timestamp forced by this binary.
+        // Prague/Osaka/Beta already match. A deployed genesis without
+        // alphaTime must visibly report the timestamp forced by this binary.
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].fork, "alphaTime");
         assert_eq!(events[0].genesis, None);
         assert_eq!(events[0].forced, Some(table_alpha_timestamp()));
     }
 
-    /// Both forks disagree → both events fire, in declared table order
-    /// (prague_time first, then alphaTime).
     #[test]
-    fn apply_overrides_emits_both_events_when_both_disagree() {
-        let mut g = parse_genesis_only(GRAVITY_MAINNET_CHAIN_ID, Some(42), Some(99));
+    fn apply_overrides_emits_event_when_genesis_supplies_beta() {
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { beta: Some(100), ..matching_mainnet_forks() },
+        );
         let events = apply_overrides(&mut g);
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].fork, "betaTime");
+        assert_eq!(events[0].genesis, Some(100));
+        assert_eq!(events[0].forced, Some(table_beta_timestamp()));
+    }
+
+    #[test]
+    fn apply_overrides_emits_event_when_genesis_omits_beta() {
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { beta: None, ..matching_mainnet_forks() },
+        );
+        let events = apply_overrides(&mut g);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].fork, "betaTime");
+        assert_eq!(events[0].genesis, None);
+        assert_eq!(events[0].forced, Some(table_beta_timestamp()));
+    }
+
+    /// All four gated forks disagree → all four events fire, in apply order
+    /// (prague_time, osaka_time, alphaTime, betaTime).
+    #[test]
+    fn apply_overrides_emits_all_events_when_all_disagree() {
+        let mut g = parse_genesis_only(
+            GRAVITY_MAINNET_CHAIN_ID,
+            ForkInputs { prague: Some(42), osaka: Some(43), alpha: Some(99), beta: Some(100) },
+        );
+        let events = apply_overrides(&mut g);
+        assert_eq!(events.len(), 4);
         assert_eq!(events[0].fork, "prague_time");
-        assert_eq!(events[1].fork, "alphaTime");
+        assert_eq!(events[1].fork, "osaka_time");
+        assert_eq!(events[2].fork, "alphaTime");
+        assert_eq!(events[3].fork, "betaTime");
     }
 
     /// Genesis already matches the binary on every gated fork → silent.
     #[test]
     fn apply_overrides_is_silent_when_genesis_already_matches_table() {
-        let mut g = parse_genesis_only(
-            GRAVITY_MAINNET_CHAIN_ID,
-            Some(table_prague_timestamp()),
-            Some(table_alpha_timestamp()),
-        );
+        let mut g = parse_genesis_only(GRAVITY_MAINNET_CHAIN_ID, matching_mainnet_forks());
         let events = apply_overrides(&mut g);
         assert!(events.is_empty(), "no events when genesis agrees with the table");
     }
@@ -533,7 +798,10 @@ mod tests {
     /// genesis sets values that would mismatch the gravity-mainnet table.
     #[test]
     fn apply_overrides_is_silent_for_chain_id_not_in_table() {
-        let mut g = parse_genesis_only(7_771_625, Some(100), Some(50));
+        let mut g = parse_genesis_only(
+            7_771_625,
+            ForkInputs { prague: Some(100), osaka: Some(200), alpha: Some(50), beta: Some(60) },
+        );
         let events = apply_overrides(&mut g);
         assert!(events.is_empty(), "no events for chain id outside HARDCODED");
     }


### PR DESCRIPTION
## Summary

- Pin gravity mainnet (`chainId` 127001) `betaTime` and `osakaTime` in the binary-authoritative `HARDCODED` table to **2026-08-17 13:00:00 Beijing (UTC+08:00)** / `1_786_942_800`.
- Extend `GravityForkOverrides` + `apply_overrides` so Osaka (typed `osaka_time`) and Beta (`extra_fields["betaTime"]`) follow the same force-and-warn path as Prague/Alpha.
- Add override, pass-through, unified-view, and governance-pin unit tests (including `beta == osaka`).

## Context

Mainnet Beta (EIP-7702 lockdown release + block-gas last-gate) and Osaka activate at the same wall-clock. Operators still supply genesis, but the binary wins when values disagree (stderr WARN on mismatch).

## Test plan

- [x] `RUSTFLAGS="--cfg tokio_unstable" cargo test -p gravity_node --bin gravity_node chainspec` — 32 passed
- [ ] Confirm validator fleet upgrades to this binary before 2026-08-17 13:00 BJT
- [ ] Optional: align deployed `genesis.json` `betaTime`/`osakaTime` with the pin (not required for correctness; binary overrides)