### PR TITLE
ci(e2e): split Docker E2E into per-suite matrix jobs

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -146,14 +146,17 @@ jobs:
       - name: Run E2E suite ${{ matrix.suite }} (skip build)
         run: |
           set -euo pipefail
-          # Artifact may land as flat files or nested; normalize paths.
-          if [ ! -x target/quick-release/gravity_node ]; then
-            found="$(find target/quick-release -type f -name gravity_node | head -1)"
-            cli="$(find target/quick-release -type f -name gravity_cli | head -1)"
-            test -n "${found}" && test -n "${cli}"
-            mkdir -p target/quick-release
-            cp -f "${found}" target/quick-release/gravity_node
-            cp -f "${cli}" target/quick-release/gravity_cli
+          # Artifact may land flat under target/quick-release/ or nested.
+          # download-artifact does not preserve +x; only relocate when needed.
+          node_src="$(find target/quick-release -type f -name gravity_node | head -1)"
+          cli_src="$(find target/quick-release -type f -name gravity_cli | head -1)"
+          test -n "${node_src}" && test -n "${cli_src}"
+          mkdir -p target/quick-release
+          if [ "${node_src}" != "target/quick-release/gravity_node" ]; then
+            cp -f "${node_src}" target/quick-release/gravity_node
+          fi
+          if [ "${cli_src}" != "target/quick-release/gravity_cli" ]; then
+            cp -f "${cli_src}" target/quick-release/gravity_cli
           fi
           chmod +x target/quick-release/gravity_node target/quick-release/gravity_cli
           chmod +x gravity_e2e/run_docker.sh

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       suite:
-        description: 'Test suite to run (empty = all)'
+        description: >
+          Single suite to run (empty = all PR suites). Examples: distinct_roles,
+          single_node, fuzzy_cluster, rolling_upgrade, long_test.
         required: false
         default: ''
 
@@ -31,22 +33,118 @@ jobs:
       workflow_file: e2e-docker.yml
       ignore_patterns: 'book/*|scripts/*|template_config/*|*.md|bin/sentinel/*|genesis/*'
 
-  e2e-test:
-    name: E2E Test
-    runs-on: [self-hosted, linux]
+  # ==========================================================================
+  # Build the suite matrix as JSON.
+  #
+  # Job-level `if` cannot use the `matrix` context, so selection lives here:
+  #   - PR review / dispatch with empty suite → PR default suite set
+  #     (same as the old serial job: all suites minus fuzzy_cluster,
+  #     rolling_upgrade, long_test)
+  #   - dispatch with suite=NAME → single-cell matrix
+  # ==========================================================================
+  prepare-matrix:
+    name: Prepare E2E matrix
+    runs-on: ubuntu-latest
     needs: gate
     if: needs.gate.outputs.should_run == 'true'
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - name: Select suites
+        id: set
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          # workflow_dispatch only; empty on pull_request_review
+          SUITE: ${{ github.event.inputs.suite || '' }}
+        run: |
+          set -euo pipefail
+
+          # PR / default-dispatch suite set (matches prior
+          # `--exclude fuzzy_cluster --exclude rolling_upgrade` plus the
+          # run_docker.sh / runner default exclude of long_test).
+          PR_SUITES='[
+            "bridge",
+            "bridge_cross_epoch",
+            "bridge_multi_round",
+            "distinct_roles",
+            "distinct_roles_3nodes",
+            "four_validator",
+            "gov_consensus_config_test",
+            "gov_validator_whitelist_test",
+            "pfn_chain",
+            "prague",
+            "randomness_config_transition",
+            "single_node",
+            "vfn",
+            "vfn_shadow"
+          ]'
+
+          # Also accepted for workflow_dispatch single-suite runs.
+          EXTRA_SUITES='["fuzzy_cluster","rolling_upgrade","long_test"]'
+
+          ALL=$(jq -cn --argjson a "${PR_SUITES}" --argjson b "${EXTRA_SUITES}" '$a + $b')
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${SUITE}" ]; then
+            if ! echo "${ALL}" | jq -e --arg s "${SUITE}" 'index($s) != null' >/dev/null; then
+              echo "::error::Unknown suite '${SUITE}'. Valid: $(echo "${ALL}" | jq -r 'join(", ")')"
+              exit 1
+            fi
+            MATRIX=$(jq -cn --arg s "${SUITE}" '{include:[{suite:$s}]}')
+          else
+            MATRIX=$(jq -cn --argjson s "${PR_SUITES}" '{include:[$s[]|{suite:.}]}')
+          fi
+
+          echo "matrix=${MATRIX}" >> "${GITHUB_OUTPUT}"
+          echo "Selected matrix: ${MATRIX}"
+
+  # ==========================================================================
+  # Per-suite jobs – "Re-run failed jobs" retries only red suite(s).
+  #
+  # Each cell still invokes gravity_e2e/run_docker.sh (full docker build +
+  # suite). max-parallel caps simultaneous cargo builds on self-hosted.
+  # ==========================================================================
+  e2e-test:
+    name: E2E / ${{ matrix.suite }}
+    runs-on: [self-hosted, linux]
+    needs: [gate, prepare-matrix]
+    if: needs.gate.outputs.should_run == 'true'
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Run E2E Tests
+    - name: Run E2E suite ${{ matrix.suite }}
       run: |
+        set -euo pipefail
         chmod +x gravity_e2e/run_docker.sh
-        if [ "${{ github.event_name }}" = "pull_request_review" ]; then
-          ./gravity_e2e/run_docker.sh --exclude fuzzy_cluster --exclude rolling_upgrade
-        else
-          ./gravity_e2e/run_docker.sh ${{ github.event.inputs.suite }}
-        fi
+        # Named suite: runner does not apply default excludes, so
+        # long_test / rolling_upgrade / fuzzy_cluster stay reachable via
+        # workflow_dispatch.
+        ./gravity_e2e/run_docker.sh "${{ matrix.suite }}"
+
+  # Single check name for merge queues / humans. Fails if any matrix cell
+  # failed, or if prepare-matrix rejected an unknown suite name.
+  e2e-result:
+    name: E2E Result
+    runs-on: ubuntu-latest
+    needs: [gate, prepare-matrix, e2e-test]
+    if: always() && needs.gate.outputs.should_run == 'true'
+    steps:
+      - name: Check matrix conclusion
+        env:
+          PREPARE: ${{ needs.prepare-matrix.result }}
+          TEST: ${{ needs.e2e-test.result }}
+        run: |
+          set -euo pipefail
+          echo "prepare-matrix: ${PREPARE}"
+          echo "e2e-test:       ${TEST}"
+          if [ "${PREPARE}" = "success" ] && [ "${TEST}" = "success" ]; then
+            exit 0
+          fi
+          echo "::error::E2E did not succeed (prepare=${PREPARE}, test=${TEST}). Re-run failed jobs to retry only the red suite(s)."
+          exit 1

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -34,13 +34,7 @@ jobs:
       ignore_patterns: 'book/*|scripts/*|template_config/*|*.md|bin/sentinel/*|genesis/*'
 
   # ==========================================================================
-  # Build the suite matrix as JSON.
-  #
-  # Job-level `if` cannot use the `matrix` context, so selection lives here:
-  #   - PR review / dispatch with empty suite → PR default suite set
-  #     (same as the old serial job: all suites minus fuzzy_cluster,
-  #     rolling_upgrade, long_test)
-  #   - dispatch with suite=NAME → single-cell matrix
+  # Build the suite matrix as JSON (job-level if cannot use matrix context).
   # ==========================================================================
   prepare-matrix:
     name: Prepare E2E matrix
@@ -54,14 +48,12 @@ jobs:
         id: set
         env:
           EVENT_NAME: ${{ github.event_name }}
-          # workflow_dispatch only; empty on pull_request_review
           SUITE: ${{ github.event.inputs.suite || '' }}
         run: |
           set -euo pipefail
 
-          # PR / default-dispatch suite set (matches prior
-          # `--exclude fuzzy_cluster --exclude rolling_upgrade` plus the
-          # run_docker.sh / runner default exclude of long_test).
+          # PR / default-dispatch suite set (matches prior excludes:
+          # fuzzy_cluster, rolling_upgrade, long_test).
           PR_SUITES='[
             "bridge",
             "bridge_cross_epoch",
@@ -79,9 +71,7 @@ jobs:
             "vfn_shadow"
           ]'
 
-          # Also accepted for workflow_dispatch single-suite runs.
           EXTRA_SUITES='["fuzzy_cluster","rolling_upgrade","long_test"]'
-
           ALL=$(jq -cn --argjson a "${PR_SUITES}" --argjson b "${EXTRA_SUITES}" '$a + $b')
 
           if [ "${EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${SUITE}" ]; then
@@ -98,53 +88,98 @@ jobs:
           echo "Selected matrix: ${MATRIX}"
 
   # ==========================================================================
-  # Per-suite jobs – "Re-run failed jobs" retries only red suite(s).
-  #
-  # Each cell still invokes gravity_e2e/run_docker.sh (full docker build +
-  # suite). max-parallel caps simultaneous cargo builds on self-hosted.
+  # Build once: cargo build gravity_node + gravity_cli, upload artifact.
+  # Matrix suite jobs and "Re-run failed jobs" reuse this artifact — no
+  # second compile.
+  # ==========================================================================
+  e2e-build:
+    name: E2E Build
+    runs-on: [self-hosted, linux]
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build gravity_node + gravity_cli (once)
+        run: |
+          set -euo pipefail
+          chmod +x gravity_e2e/run_docker.sh
+          ./gravity_e2e/run_docker.sh --build-only
+          ls -la target/quick-release/gravity_node target/quick-release/gravity_cli
+
+      - name: Upload prebuilt binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-binaries
+          # Directory upload: artifact root = contents of quick-release/
+          path: target/quick-release/
+          if-no-files-found: error
+          retention-days: 3
+          compression-level: 0
+
+  # ==========================================================================
+  # Per-suite jobs — download the one build, never cargo-build again.
   # ==========================================================================
   e2e-test:
     name: E2E / ${{ matrix.suite }}
     runs-on: [self-hosted, linux]
-    needs: [gate, prepare-matrix]
+    needs: [gate, prepare-matrix, e2e-build]
     if: needs.gate.outputs.should_run == 'true'
-    timeout-minutes: 120
+    timeout-minutes: 90
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Run E2E suite ${{ matrix.suite }}
-      run: |
-        set -euo pipefail
-        chmod +x gravity_e2e/run_docker.sh
-        # Named suite: runner does not apply default excludes, so
-        # long_test / rolling_upgrade / fuzzy_cluster stay reachable via
-        # workflow_dispatch.
-        ./gravity_e2e/run_docker.sh "${{ matrix.suite }}"
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-binaries
+          path: target/quick-release
 
-  # Single check name for merge queues / humans. Fails if any matrix cell
-  # failed, or if prepare-matrix rejected an unknown suite name.
+      - name: Run E2E suite ${{ matrix.suite }} (skip build)
+        run: |
+          set -euo pipefail
+          # Artifact may land as flat files or nested; normalize paths.
+          if [ ! -x target/quick-release/gravity_node ]; then
+            found="$(find target/quick-release -type f -name gravity_node | head -1)"
+            cli="$(find target/quick-release -type f -name gravity_cli | head -1)"
+            test -n "${found}" && test -n "${cli}"
+            mkdir -p target/quick-release
+            cp -f "${found}" target/quick-release/gravity_node
+            cp -f "${cli}" target/quick-release/gravity_cli
+          fi
+          chmod +x target/quick-release/gravity_node target/quick-release/gravity_cli
+          chmod +x gravity_e2e/run_docker.sh
+          ls -la target/quick-release/gravity_node target/quick-release/gravity_cli
+          # Named suite + --skip-build: reuse e2e-build artifact (no cargo).
+          ./gravity_e2e/run_docker.sh --skip-build "${{ matrix.suite }}"
+
+  # Aggregate matrix + build for a single green/red check.
   e2e-result:
     name: E2E Result
     runs-on: ubuntu-latest
-    needs: [gate, prepare-matrix, e2e-test]
+    needs: [gate, prepare-matrix, e2e-build, e2e-test]
     if: always() && needs.gate.outputs.should_run == 'true'
     steps:
-      - name: Check matrix conclusion
+      - name: Check conclusion
         env:
           PREPARE: ${{ needs.prepare-matrix.result }}
+          BUILD: ${{ needs.e2e-build.result }}
           TEST: ${{ needs.e2e-test.result }}
         run: |
           set -euo pipefail
           echo "prepare-matrix: ${PREPARE}"
+          echo "e2e-build:      ${BUILD}"
           echo "e2e-test:       ${TEST}"
-          if [ "${PREPARE}" = "success" ] && [ "${TEST}" = "success" ]; then
+          if [ "${PREPARE}" = "success" ] && [ "${BUILD}" = "success" ] && [ "${TEST}" = "success" ]; then
             exit 0
           fi
-          echo "::error::E2E did not succeed (prepare=${PREPARE}, test=${TEST}). Re-run failed jobs to retry only the red suite(s)."
+          echo "::error::E2E did not succeed (prepare=${PREPARE}, build=${BUILD}, test=${TEST}). Re-run failed jobs retries only the red suite(s); the build artifact is reused."
           exit 1

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -164,9 +164,10 @@ jobs:
           # Named suite + --skip-build: reuse e2e-build artifact (no cargo).
           ./gravity_e2e/run_docker.sh --skip-build "${{ matrix.suite }}"
 
-  # Aggregate matrix + build for a single green/red check.
+  # Aggregate matrix + build into the required status check name
+  # (branch protection on main expects exactly "E2E Test").
   e2e-result:
-    name: E2E Result
+    name: E2E Test
     runs-on: ubuntu-latest
     needs: [gate, prepare-matrix, e2e-build, e2e-test]
     if: always() && needs.gate.outputs.should_run == 'true'

--- a/gravity_e2e/run_docker.sh
+++ b/gravity_e2e/run_docker.sh
@@ -207,9 +207,10 @@ fi
 echo ''
 echo '===== Phase 3: Running E2E Tests ====='
 echo '[Step 7] Running runner.py...'
-# ${PYTHONPATH:-} — container starts with PYTHONPATH unset; set -u would
-# otherwise abort on a bare $PYTHONPATH expansion.
-export PYTHONPATH=\"/app:/app/gravity_e2e\${PYTHONPATH:+:\$PYTHONPATH}\"
+# Fresh container: hardcode PYTHONPATH. Do not expand host/container
+# PYTHONPATH inside this double-quoted bash -c (outer set -u would
+# treat comment refs as real expansions too).
+export PYTHONPATH=/app:/app/gravity_e2e
 cd /app/gravity_e2e
 python3 runner.py --force-init --exclude long_test ${RUNNER_ARGS}
 

--- a/gravity_e2e/run_docker.sh
+++ b/gravity_e2e/run_docker.sh
@@ -207,7 +207,9 @@ fi
 echo ''
 echo '===== Phase 3: Running E2E Tests ====='
 echo '[Step 7] Running runner.py...'
-export PYTHONPATH=/app:/app/gravity_e2e:\$PYTHONPATH
+# ${PYTHONPATH:-} — container starts with PYTHONPATH unset; set -u would
+# otherwise abort on a bare $PYTHONPATH expansion.
+export PYTHONPATH=\"/app:/app/gravity_e2e\${PYTHONPATH:+:\$PYTHONPATH}\"
 cd /app/gravity_e2e
 python3 runner.py --force-init --exclude long_test ${RUNNER_ARGS}
 

--- a/gravity_e2e/run_docker.sh
+++ b/gravity_e2e/run_docker.sh
@@ -1,49 +1,179 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # ============================================================
 # Gravity E2E Docker Runner (CI/CD)
 #
 # Usage:
-#   ./gravity_e2e/run_docker.sh [suite1] [suite2] ... [--exclude suite] [pytest_args]
+#   ./gravity_e2e/run_docker.sh [options] [suite1] [suite2] ... [--exclude suite] [pytest_args]
+#
+# Options:
+#   --build-only   Build gravity_node + gravity_cli into host
+#                  target/quick-release/ and exit (no tests).
+#   --skip-build   Do not cargo-build; require prebuilt binaries at
+#                  host target/quick-release/{gravity_node,gravity_cli}.
 #
 # Examples:
-#   ./gravity_e2e/run_docker.sh                    # Run all test suites
-#   ./gravity_e2e/run_docker.sh single_node        # Run only single_node suite
+#   ./gravity_e2e/run_docker.sh                    # Build + all suites
+#   ./gravity_e2e/run_docker.sh --build-only       # Build once for CI
+#   ./gravity_e2e/run_docker.sh --skip-build single_node
 #   ./gravity_e2e/run_docker.sh single_node -k test_transfer
-#   ./gravity_e2e/run_docker.sh --exclude fuzzy_cluster  # Run all except fuzzy_cluster
 #
 # Description:
-#   Runs the complete E2E pipeline inside Docker (no host mount):
-#   1. Copy source code into container
-#   2. Build gravity_node + gravity_cli
-#   3. Run cluster init/deploy/start + pytest via runner.py
+#   Source is piped into Docker via tar (no full host mount — avoids
+#   permission issues). Prebuilt binaries use a bind mount of
+#   target/quick-release only.
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 DOCKER_IMAGE="rust:1.88.0-bookworm"
-ARGS="$@"
+BUILD_ONLY=0
+SKIP_BUILD=0
+ARGS=()
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --build-only)
+            BUILD_ONLY=1
+            shift
+            ;;
+        --skip-build)
+            SKIP_BUILD=1
+            shift
+            ;;
+        --)
+            shift
+            ARGS+=("$@")
+            break
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ "${BUILD_ONLY}" -eq 1 ] && [ "${SKIP_BUILD}" -eq 1 ]; then
+    echo "error: --build-only and --skip-build are mutually exclusive" >&2
+    exit 2
+fi
+
+if [ "${BUILD_ONLY}" -eq 1 ] && [ "${#ARGS[@]}" -gt 0 ]; then
+    echo "error: --build-only does not accept suite / pytest args: ${ARGS[*]}" >&2
+    exit 2
+fi
 
 echo "===== Gravity E2E Docker Runner ====="
 echo "Repo Root: $REPO_ROOT"
 echo "Image: $DOCKER_IMAGE"
-echo "Args: ${ARGS:-<all suites>}"
+echo "Build only: ${BUILD_ONLY}"
+echo "Skip build: ${SKIP_BUILD}"
+echo "Args: ${ARGS[*]:-<all suites>}"
 echo "======================================"
 
-# Pipe repo into container via tar (no volume mount, no permission issues)
-tar -C "$REPO_ROOT" \
-    --exclude='target' \
-    --exclude='.git' \
-    --exclude='external/gravity_bench' \
-    --exclude='external/gravity_chain_core_contracts' \
-    -cf - . \
-| docker run --rm -i \
+PREBUILT_DIR="${REPO_ROOT}/target/quick-release"
+mkdir -p "${PREBUILT_DIR}"
+
+if [ "${SKIP_BUILD}" -eq 1 ]; then
+    for bin in gravity_node gravity_cli; do
+        if [ ! -x "${PREBUILT_DIR}/${bin}" ]; then
+            echo "error: --skip-build requires executable ${PREBUILT_DIR}/${bin}" >&2
+            exit 1
+        fi
+    done
+fi
+
+source_tar() {
+    tar -C "$REPO_ROOT" \
+        --exclude='target' \
+        --exclude='.git' \
+        --exclude='external/gravity_bench' \
+        --exclude='external/gravity_chain_core_contracts' \
+        -cf - .
+}
+
+# ---------------------------------------------------------------------------
+# --build-only: compile once, write binaries to host target/quick-release
+# ---------------------------------------------------------------------------
+if [ "${BUILD_ONLY}" -eq 1 ]; then
+    echo "===== Build-only → host target/quick-release ====="
+    source_tar | docker run --rm -i \
+        -e RUST_BACKTRACE=1 \
+        -v "${PREBUILT_DIR}:/out" \
+        "$DOCKER_IMAGE" \
+        bash -c '
+set -euo pipefail
+mkdir -p /app && cd /app && tar xf -
+
+echo "[Setup] Installing build dependencies..."
+apt-get update >/dev/null 2>&1
+apt-get install -y --no-install-recommends \
+    clang llvm build-essential pkg-config libssl-dev libudev-dev \
+    git curl ca-certificates >/dev/null 2>&1
+
+export RUSTFLAGS="--cfg tokio_unstable -C debug-assertions=yes"
+
+echo "[Build] gravity_node (quick-release)..."
+cargo build --bin gravity_node --profile quick-release 2>&1 | tail -20
+
+echo "[Build] gravity_cli (quick-release)..."
+cargo build --bin gravity_cli --profile quick-release 2>&1 | tail -20
+
+install -m 755 target/quick-release/gravity_node /out/gravity_node
+install -m 755 target/quick-release/gravity_cli /out/gravity_cli
+ls -la /out/gravity_node /out/gravity_cli
+echo "===== Build-only completed ====="
+'
+    test -x "${PREBUILT_DIR}/gravity_node"
+    test -x "${PREBUILT_DIR}/gravity_cli"
+    echo "Host artifacts:"
+    ls -la "${PREBUILT_DIR}/gravity_node" "${PREBUILT_DIR}/gravity_cli"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Test path: optional --skip-build
+# ---------------------------------------------------------------------------
+# Safely quote runner args for nested bash -c
+RUNNER_ARGS=""
+if [ "${#ARGS[@]}" -gt 0 ]; then
+    printf -v RUNNER_ARGS '%q ' "${ARGS[@]}"
+fi
+
+DOCKER_VOL_ARGS=()
+PHASE2_SCRIPT=""
+if [ "${SKIP_BUILD}" -eq 1 ]; then
+    DOCKER_VOL_ARGS+=(-v "${PREBUILT_DIR}:/prebuilt:ro")
+    PHASE2_SCRIPT='
+echo ""
+echo "===== Phase 2: Using prebuilt binaries (no cargo build) ====="
+mkdir -p /app/target/quick-release
+cp -a /prebuilt/gravity_node /prebuilt/gravity_cli /app/target/quick-release/
+chmod +x /app/target/quick-release/gravity_node /app/target/quick-release/gravity_cli
+ls -la /app/target/quick-release/gravity_node /app/target/quick-release/gravity_cli
+'
+else
+    PHASE2_SCRIPT='
+echo ""
+echo "===== Phase 2: Building Binaries ====="
+export RUSTFLAGS="--cfg tokio_unstable -C debug-assertions=yes"
+
+echo "[Step 4] Building gravity_node (quick-release)..."
+cargo build --bin gravity_node --profile quick-release 2>&1 | tail -5
+
+echo "[Step 5] Building gravity_cli (quick-release)..."
+cargo build --bin gravity_cli --profile quick-release 2>&1 | tail -5
+'
+fi
+
+source_tar | docker run --rm -i \
     -e RUST_BACKTRACE=1 \
+    "${DOCKER_VOL_ARGS[@]+"${DOCKER_VOL_ARGS[@]}"}" \
     "$DOCKER_IMAGE" \
     bash -c "
-set -e
+set -euo pipefail
 mkdir -p /app && cd /app && tar xf -
 
 echo '===== Phase 1: Environment Setup ====='
@@ -66,28 +196,20 @@ echo '  Foundry installed: '\$(forge --version | head -1)
 echo '[Step 3] Installing Python dependencies...'
 pip install -r /app/gravity_e2e/requirements.txt --quiet --break-system-packages
 
+${PHASE2_SCRIPT}
+
 echo ''
-echo '===== Phase 2: Building Binaries ====='
-
-echo '[Step 4] Building gravity_node (quick-release)...'
-export RUSTFLAGS='--cfg tokio_unstable -C debug-assertions=yes'
-cargo build --bin gravity_node --profile quick-release 2>&1 | tail -5
-
-echo '[Step 5] Building gravity_cli (quick-release)...'
-cargo build --bin gravity_cli --profile quick-release 2>&1 | tail -5
-
-echo '[Step 6] Building E2E Solidity test contracts...'
+echo '===== Phase 2b: E2E Solidity test contracts ====='
 if [ -f /app/gravity_e2e/tests/contracts/randomness/foundry.toml ]; then
     (cd /app/gravity_e2e/tests/contracts/randomness && forge build)
 fi
 
 echo ''
 echo '===== Phase 3: Running E2E Tests ====='
-
 echo '[Step 7] Running runner.py...'
 export PYTHONPATH=/app:/app/gravity_e2e:\$PYTHONPATH
 cd /app/gravity_e2e
-python3 runner.py --force-init --exclude long_test $ARGS
+python3 runner.py --force-init --exclude long_test ${RUNNER_ARGS}
 
 echo ''
 echo '===== E2E Tests Completed Successfully ====='


### PR DESCRIPTION
## Summary

- Split the single serial `E2E Test` job into **one GitHub Actions job per suite** (`E2E / distinct_roles`, `E2E / single_node`, …).
- **Re-run failed jobs** now retries only the red suite(s), instead of replaying the full ~1h run.
- Keep the previous **PR suite set** (all suites minus `fuzzy_cluster` / `rolling_upgrade` / `long_test`).
- `workflow_dispatch` with `suite=NAME` runs a **single** matrix cell (including opt-in suites: `fuzzy_cluster`, `rolling_upgrade`, `long_test`).
- Add `E2E Result` aggregate job for a single green/red summary.

## Why a prepare job?

Job-level `if` cannot use the `matrix` context (actionlint / GH docs). Suite selection is done in `prepare-matrix`, which emits JSON for `strategy.matrix`.

## Cost note

Each matrix cell still runs `gravity_e2e/run_docker.sh` end-to-end (**full Docker cargo build per suite**). `max-parallel: 3` caps fan-out on self-hosted runners. A follow-up can share one build artifact across cells if wall-clock/CPU becomes painful.

## Test plan

- [x] `actionlint -shellcheck=` clean on `e2e-docker.yml`
- [ ] Merge, then approve a PR (or `workflow_dispatch`) and confirm the run lists multiple `E2E / <suite>` jobs
- [ ] Intentionally fail or wait for a flake, click **Re-run failed jobs**, confirm only the failed suite restarts
- [ ] `workflow_dispatch` with `suite=distinct_roles` runs only that job
- [ ] `workflow_dispatch` with unknown suite name fails in `prepare-matrix` with a clear error