### PR TITLE
test(oracle): verify OracleV1 hardfork in live soak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 
 [[package]]
 name = "gravity-sdk"
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8668,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -14539,7 +14539,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 2.0.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14613,7 +14613,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14642,7 +14642,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14662,7 +14662,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -14675,7 +14675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -14769,7 +14769,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14818,7 +14818,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -14834,7 +14834,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -14848,7 +14848,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14861,7 +14861,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14886,7 +14886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -14910,7 +14910,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14967,7 +14967,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15006,7 +15006,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15030,7 +15030,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -15054,7 +15054,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15085,7 +15085,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -15113,7 +15113,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15136,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15161,7 +15161,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15216,7 +15216,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15246,7 +15246,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15262,7 +15262,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15278,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -15311,7 +15311,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -15339,7 +15339,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -15361,7 +15361,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15384,7 +15384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15400,7 +15400,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15416,7 +15416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -15429,7 +15429,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15459,7 +15459,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15473,7 +15473,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -15483,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -15509,7 +15509,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15534,7 +15534,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -15552,7 +15552,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -15565,7 +15565,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15584,7 +15584,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15622,7 +15622,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15636,7 +15636,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "serde",
  "serde_json",
@@ -15646,7 +15646,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15674,7 +15674,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "bytes",
  "futures",
@@ -15694,7 +15694,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -15711,7 +15711,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "bindgen",
  "cc",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "futures",
  "metrics",
@@ -15733,7 +15733,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -15742,7 +15742,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -15756,7 +15756,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15813,7 +15813,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15838,7 +15838,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15860,7 +15860,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15875,7 +15875,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -15889,7 +15889,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "anyhow",
  "bincode",
@@ -15906,7 +15906,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -15930,7 +15930,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15999,7 +15999,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16055,7 +16055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16102,7 +16102,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16126,7 +16126,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16150,7 +16150,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "bytes",
  "eyre",
@@ -16174,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -16186,7 +16186,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16210,7 +16210,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -16222,7 +16222,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16245,7 +16245,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
@@ -16255,7 +16255,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -16268,7 +16268,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16315,7 +16315,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -16339,7 +16339,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "once_cell",
@@ -16352,7 +16352,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.4.1"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16382,7 +16382,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16425,7 +16425,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16453,7 +16453,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16468,7 +16468,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16487,7 +16487,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16514,7 +16514,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16529,7 +16529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16606,7 +16606,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -16636,7 +16636,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-provider 2.0.5",
@@ -16679,7 +16679,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -16700,7 +16700,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16731,7 +16731,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16777,7 +16777,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -16827,7 +16827,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -16841,7 +16841,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16872,7 +16872,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16916,7 +16916,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16944,7 +16944,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16957,7 +16957,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -16991,7 +16991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17021,7 +17021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -17039,7 +17039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -17060,7 +17060,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -17070,7 +17070,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -17088,7 +17088,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "base64 0.22.1",
  "clap 4.5.57",
@@ -17106,7 +17106,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17152,7 +17152,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17177,7 +17177,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -17203,7 +17203,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17222,7 +17222,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-eip7928 0.4.5",
  "alloy-evm",
@@ -17251,7 +17251,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17272,7 +17272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=4372a103a42a862593fa8221814b3bcc8d47d0aa#4372a103a42a862593fa8221814b3bcc8d47d0aa"
+source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4981,7 +4981,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -8519,7 +8519,7 @@ dependencies = [
 [[package]]
 name = "gravity-precompiles"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "blst",
@@ -8531,7 +8531,7 @@ dependencies = [
 [[package]]
 name = "gravity-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 
 [[package]]
 name = "gravity-sdk"
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "gravity-storage"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -8668,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "greth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "async-trait",
  "gravity-primitives",
@@ -12274,7 +12274,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13671,7 +13671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -13684,7 +13684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -14539,7 +14539,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types 2.0.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14613,7 +14613,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14642,7 +14642,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14662,7 +14662,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.57",
@@ -14675,7 +14675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -14769,7 +14769,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14818,7 +14818,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -14834,7 +14834,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -14848,7 +14848,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14861,7 +14861,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -14886,7 +14886,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -14910,7 +14910,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14936,7 +14936,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-genesis",
@@ -14967,7 +14967,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -14981,7 +14981,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15006,7 +15006,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15030,7 +15030,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "dashmap 6.2.1",
@@ -15054,7 +15054,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15085,7 +15085,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -15113,7 +15113,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15136,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15161,7 +15161,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15216,7 +15216,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15246,7 +15246,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15262,7 +15262,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -15278,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15300,7 +15300,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -15311,7 +15311,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -15339,7 +15339,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -15361,7 +15361,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -15384,7 +15384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15400,7 +15400,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15416,7 +15416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -15429,7 +15429,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15459,7 +15459,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15473,7 +15473,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -15483,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eip7928 0.4.5",
@@ -15509,7 +15509,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15534,7 +15534,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -15552,7 +15552,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -15565,7 +15565,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15584,7 +15584,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15622,7 +15622,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -15636,7 +15636,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "serde",
  "serde_json",
@@ -15646,7 +15646,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15674,7 +15674,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "bytes",
  "futures",
@@ -15694,7 +15694,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -15711,7 +15711,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "bindgen",
  "cc",
@@ -15720,7 +15720,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "futures",
  "metrics",
@@ -15733,7 +15733,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -15742,7 +15742,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -15756,7 +15756,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15813,7 +15813,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -15838,7 +15838,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15860,7 +15860,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -15875,7 +15875,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -15889,7 +15889,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "anyhow",
  "bincode",
@@ -15906,7 +15906,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -15930,7 +15930,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -15999,7 +15999,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16055,7 +16055,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16102,7 +16102,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16126,7 +16126,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16150,7 +16150,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "bytes",
  "eyre",
@@ -16174,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -16186,7 +16186,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16210,7 +16210,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -16222,7 +16222,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16245,7 +16245,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-rpc-types-engine",
@@ -16255,7 +16255,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-event-bus"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "reth-chain-state",
@@ -16268,7 +16268,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-ext-v2"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16315,7 +16315,7 @@ dependencies = [
 [[package]]
 name = "reth-pipe-exec-layer-relayer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-primitives",
@@ -16339,7 +16339,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "once_cell",
@@ -16352,7 +16352,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.4.1"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16382,7 +16382,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16425,7 +16425,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -16453,7 +16453,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16468,7 +16468,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16487,7 +16487,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16514,7 +16514,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16529,7 +16529,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16606,7 +16606,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-genesis",
@@ -16636,7 +16636,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-network 2.0.5",
  "alloy-provider 2.0.5",
@@ -16679,7 +16679,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-evm",
@@ -16700,7 +16700,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16731,7 +16731,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-dyn-abi",
@@ -16777,7 +16777,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.0.5",
@@ -16827,7 +16827,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -16841,7 +16841,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16872,7 +16872,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -16916,7 +16916,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -16944,7 +16944,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16957,7 +16957,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "parking_lot 0.12.5",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "clap 4.5.57",
@@ -16991,7 +16991,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17021,7 +17021,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eips 2.0.5",
  "alloy-primitives",
@@ -17039,7 +17039,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "crossbeam-utils",
  "dashmap 6.2.1",
@@ -17060,7 +17060,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -17070,7 +17070,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "clap 4.5.57",
  "eyre",
@@ -17088,7 +17088,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "base64 0.22.1",
  "clap 4.5.57",
@@ -17106,7 +17106,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17152,7 +17152,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-eips 2.0.5",
@@ -17177,7 +17177,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-consensus 2.0.5",
  "alloy-primitives",
@@ -17203,7 +17203,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17222,7 +17222,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-eip7928 0.4.5",
  "alloy-evm",
@@ -17251,7 +17251,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17272,7 +17272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "2.3.0"
-source = "git+https://github.com/Galxe/gravity-reth?rev=43e57c22368385ee7ed551f6e4d96cf60f6f4f37#43e57c22368385ee7ed551f6e4d96cf60f6f4f37"
+source = "git+https://github.com/Galxe/gravity-reth?rev=d0f59d5b664ee68cf1816e77e91bf6457fca1ae9#d0f59d5b664ee68cf1816e77e91bf6457fca1ae9"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "43e57c22368385ee7ed551f6e4d96cf60f6f4f37" }
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "d0f59d5b664ee68cf1816e77e91bf6457fca1ae9" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ debug-assertions = true
 debug = true
 
 [patch.crates-io]
-reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "4372a103a42a862593fa8221814b3bcc8d47d0aa" }
+reth-primitives-traits = { git = "https://github.com/Galxe/gravity-reth", rev = "43e57c22368385ee7ed551f6e4d96cf60f6f4f37" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 merlin = { git = "https://github.com/aptos-labs/merlin" }
 tonic = { git = "https://github.com/aptos-labs/tonic.git", rev = "0da1ba8b1751d6e19eb55be24cccf9ae933c666e" }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -34,7 +34,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "4372a103a42a862593fa8221814b3bcc8d47d0aa" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "43e57c22368385ee7ed551f6e4d96cf60f6f4f37" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.6.0", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "=2.0.5", default-features = false }

--- a/bin/gravity_node/Cargo.toml
+++ b/bin/gravity_node/Cargo.toml
@@ -34,7 +34,7 @@ sha2.workspace = true
 bincode = "1.3"
 time = "0.3.36"
 anyhow = "1.0.87"
-greth = { git = "https://github.com/Galxe/gravity-reth", rev = "43e57c22368385ee7ed551f6e4d96cf60f6f4f37" }
+greth = { git = "https://github.com/Galxe/gravity-reth", rev = "d0f59d5b664ee68cf1816e77e91bf6457fca1ae9" }
 reqwest = "0.12.9"
 alloy-primitives = { version = "=1.6.0", default-features = false, features = ["map-foldhash"] }
 alloy-eips = { version = "=2.0.5", default-features = false }

--- a/gravity_e2e/cluster_test_cases/oracle_live_soak/README.md
+++ b/gravity_e2e/cluster_test_cases/oracle_live_soak/README.md
@@ -7,6 +7,13 @@ three continuous Binance Futures testnet closed index-price kline feeds:
 - `BTCUSDT` (`sourceType=3`, feed ID `1002`);
 - `ETHUSDT` (`sourceType=3`, feed ID `1003`).
 
+Before enabling those feeds, the suite exercises the OracleV1 testnet
+hardfork. Genesis is generated from the packed-V1 contracts, then the
+`NativeOracle` and `OracleTaskConfig` runtimes are replaced with the exact
+pre-fork bytes signed into `genesis/testnet/genesis.json`. At
+`config.oracleV1Block`, gravity-reth must atomically install both packed-V1
+runtimes without changing either account's balance, nonce, or storage root.
+
 Each callback uses packed Price Feed V1: a canonical 32-byte big-endian body
 containing `version`, `feedId`, `roundId`, `resolvedAtMs`, fixed-8 `price`, and
 zero `flags`. The resolver exposes the latest round as
@@ -51,6 +58,29 @@ NativeOracle callback count must equal its independent final delivery nonce.
 Observed price changes remain informational because timely identical index
 closes are valid Oracle updates.
 
+## OracleV1 Startup Gate
+
+Before deploying the resolver or submitting governance, the test captures each
+adjacent state while it is still inside the RPC proof window, waits until all
+four validators pass `oracleV1Block + 16`, and then confirms that both captured
+block hashes remain canonical:
+
+- block `oracleV1Block - 1` has the two frozen testnet pre-fork codehashes;
+- block `oracleV1Block` has the two frozen packed-V1 codehashes;
+- all four RPC replicas agree on both canonical block hashes and account
+  proofs;
+- `eth_getCode` and `eth_getProof.codeHash` agree for every observation;
+- balance, nonce, and full `storageHash` are unchanged across activation.
+
+The suite-local reth template enables a 64-block historical proof window for
+this evidence capture. Production defaults and shared E2E templates remain
+unchanged.
+
+Only after this gate passes does the suite deploy `PriceFeedResolver`, register
+the three Binance tasks, wait for JWK quorum, and begin the configured soak.
+This ordering proves that the live price-feed path is running on contracts
+installed by the hardfork rather than contracts already present at genesis.
+
 For runs of at least one hour, `node4` becomes eligible to restart halfway
 through by default. A focused run can configure multiple restart times. The
 runner defers each restart while the chain is within five minutes of an epoch
@@ -77,7 +107,7 @@ suite. Do not run it beside another local Gravity cluster that must stay alive.
 From the SDK repository root:
 
 ```bash
-make MODE=quick-release gravity_node gravity_cli
+CARGO_BUILD_JOBS=2 make -j2 MODE=quick-release gravity_node gravity_cli
 export PATH="$HOME/.foundry/bin:$PWD/target/quick-release:$PATH"
 ```
 
@@ -186,4 +216,5 @@ Runtime evidence remains local and ignored by Git:
   recovery times.
 
 The summary is the acceptance artifact. A process that is still running has not
-yet passed the soak.
+yet passed the soak. Its `oracleV1Hardfork` section records both canonical
+blocks and the pre/post account proofs used by the startup gate.

--- a/gravity_e2e/cluster_test_cases/oracle_live_soak/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_live_soak/genesis.toml
@@ -4,7 +4,7 @@
 
 [dependencies.genesis_contracts]
 repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
-ref = "2762c3c98f1eed5fb6fe4d9bd4b6fefbadf7ce14"
+ref = "5772b210b19761439147ce0d17590a42cb978af8"
 
 # Equal voting power means a JWK QC requires matching signatures from at least
 # three of the four validators.

--- a/gravity_e2e/cluster_test_cases/oracle_live_soak/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_live_soak/genesis.toml
@@ -57,6 +57,11 @@ execution_config = "0x00"
 initial_locked_until_micros = 1798848000000000
 governance_owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 
+[genesis.hardforks]
+# Leave enough startup headroom for the test to capture the signed testnet
+# OracleV1 pre-state before the code-only migration executes.
+oracleV1Block = 600
+
 [genesis.faucet]
 address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 balance = "0x2000000000000000000000000000000000000000000000000000000000000000"

--- a/gravity_e2e/cluster_test_cases/oracle_live_soak/hooks.py
+++ b/gravity_e2e/cluster_test_cases/oracle_live_soak/hooks.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import time
 from urllib.parse import urlparse
 
+from web3 import Web3
+
 try:
     import tomllib
 except ImportError:
@@ -29,6 +31,93 @@ _METADATA_FILE = "oracle_live_soak_metadata.json"
 _RELAYER_FILE = "relayer_config.live.json"
 _HEARTBEAT_FILE = "oracle_live_soak_heartbeat.jsonl"
 _SUMMARY_FILE = "oracle_live_soak_summary.json"
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SIGNED_TESTNET_GENESIS = PROJECT_ROOT / "genesis" / "testnet" / "genesis.json"
+ORACLE_V1_CONTRACTS = (
+    {
+        "name": "NativeOracle",
+        "address": "0x00000000000000000000000000000001625f4000",
+        "preForkCodeHash": "0x30dd3888ce26735c0d6c5a036b48a1de668dd5506efa7588ce450f976da28255",
+        "postForkCodeHash": "0x981087ccdaa0b7843960782e99b078ccdd3820b331f86ce337d9750c5565d984",
+    },
+    {
+        "name": "OracleTaskConfig",
+        "address": "0x00000000000000000000000000000001625f1009",
+        "preForkCodeHash": "0x74127baf705119810746598b2695ff5fa38f94bd778f0edae46799ffd3606bda",
+        "postForkCodeHash": "0xa21bf93e6123b0104b9ea851b8154fb342a5b576c22c71f15f851e266faa9f7f",
+    },
+)
+
+
+def _alloc_key(alloc: dict, address: str) -> str:
+    normalized = address.removeprefix("0x").lower()
+    for key in alloc:
+        if key.removeprefix("0x").lower() == normalized:
+            return key
+    raise RuntimeError(f"genesis alloc is missing system contract {address}")
+
+
+def _runtime_hash(code: str) -> str:
+    if not code.startswith("0x") or len(code) % 2 != 0:
+        raise RuntimeError("system-contract runtime is not canonical hex")
+    return Web3.to_hex(Web3.keccak(hexstr=code)).lower()
+
+
+def _install_oracle_v1_pre_fork_runtimes(test_dir: Path) -> dict:
+    genesis_path = test_dir / "artifacts" / "genesis.json"
+    if not genesis_path.exists():
+        raise RuntimeError(
+            "OracleV1 soak requires generated artifacts/genesis.json; use --force-init"
+        )
+    if not SIGNED_TESTNET_GENESIS.exists():
+        raise RuntimeError(
+            "signed SDK genesis/testnet/genesis.json fixture is missing"
+        )
+
+    generated = json.loads(genesis_path.read_text())
+    signed_testnet = json.loads(SIGNED_TESTNET_GENESIS.read_text())
+    activation_block = generated.get("config", {}).get("oracleV1Block")
+    if not isinstance(activation_block, int) or activation_block <= 0:
+        raise RuntimeError(
+            "generated genesis must configure a positive config.oracleV1Block"
+        )
+
+    generated_alloc = generated.get("alloc", {})
+    signed_alloc = signed_testnet.get("alloc", {})
+    evidence = []
+    for contract in ORACLE_V1_CONTRACTS:
+        generated_key = _alloc_key(generated_alloc, contract["address"])
+        signed_key = _alloc_key(signed_alloc, contract["address"])
+        signed_code = signed_alloc[signed_key].get("code", "")
+        signed_hash = _runtime_hash(signed_code)
+        if signed_hash != contract["preForkCodeHash"]:
+            raise RuntimeError(
+                f"signed testnet {contract['name']} runtime hash {signed_hash} "
+                f"does not match {contract['preForkCodeHash']}"
+            )
+
+        generated_code = generated_alloc[generated_key].get("code", "")
+        generated_hash = _runtime_hash(generated_code)
+        if generated_hash not in {
+            contract["preForkCodeHash"],
+            contract["postForkCodeHash"],
+        }:
+            raise RuntimeError(
+                f"generated {contract['name']} runtime hash {generated_hash} "
+                "matches neither frozen OracleV1 state"
+            )
+        generated_alloc[generated_key]["code"] = signed_code
+        evidence.append(dict(contract))
+
+    temporary_path = genesis_path.with_suffix(".json.tmp")
+    temporary_path.write_text(json.dumps(generated, indent=2) + "\n")
+    temporary_path.replace(genesis_path)
+    return {
+        "activationBlock": activation_block,
+        "contracts": evidence,
+        "fixture": "genesis/testnet/genesis.json",
+    }
 
 
 def _require_public_https_url(value: str, name: str) -> str:
@@ -78,6 +167,7 @@ def _price_uri(
 
 
 def pre_deploy(test_dir: Path, env: dict, pytest_args: list[str]):
+    oracle_v1_hardfork = _install_oracle_v1_pre_fork_runtimes(test_dir)
     binance_base_url = _require_public_https_url(
         env.get("BINANCE_PRICE_FEED_BASE_URL", DEFAULT_BINANCE_BASE_URL),
         "BINANCE_PRICE_FEED_BASE_URL",
@@ -119,7 +209,10 @@ def pre_deploy(test_dir: Path, env: dict, pytest_args: list[str]):
     metadata_path = artifacts / _METADATA_FILE
     metadata_path.write_text(
         json.dumps(
-            {"binanceFeeds": binance_feeds},
+            {
+                "binanceFeeds": binance_feeds,
+                "oracleV1Hardfork": oracle_v1_hardfork,
+            },
             indent=2,
             ensure_ascii=False,
         )
@@ -127,7 +220,8 @@ def pre_deploy(test_dir: Path, env: dict, pytest_args: list[str]):
     )
     env["RELAYER_CONFIG_TPL"] = str(relayer_path)
     LOG.info(
-        "Prepared live Oracle inputs: Binance pairs=%s anchor=%s",
+        "Prepared OracleV1 block=%s and live Binance pairs=%s anchor=%s",
+        oracle_v1_hardfork["activationBlock"],
         [feed["pair"] for feed in binance_feeds],
         bucket_start_ms,
     )

--- a/gravity_e2e/cluster_test_cases/oracle_live_soak/reth_config.json.tpl
+++ b/gravity_e2e/cluster_test_cases/oracle_live_soak/reth_config.json.tpl
@@ -1,0 +1,38 @@
+{
+    "reth_args": {
+        "chain": "${GENESIS_PATH}",
+        "http": "",
+        "relayer_config": "${CONFIG_DIR}/relayer_config.json",
+        "http.port": ${RPC_PORT},
+        "http.corsdomain": "${RPC_HTTP_CORSDOMAIN}",
+        "http.api": "${RPC_HTTP_API}",
+        "http.addr": "0.0.0.0",
+        "dev": "",
+        "port": ${P2P_PORT_RETH},
+        "authrpc.port": ${AUTHRPC_PORT},
+        "authrpc.addr": "0.0.0.0",
+        "metrics": "0.0.0.0:${METRICS_PORT}",
+        "log.file.filter": "info",
+        "log.stdout.filter": "error",
+        "datadir": "${STORAGE_DIR}/reth",
+        "datadir.static-files": "${STORAGE_DIR}/reth",
+        "gravity_node_config": "${CONFIG_DIR}/validator.yaml",
+        "log.file.directory": "${LOG_DIR}/execution_logs/",
+        "rpc.max-subscriptions-per-connection": 20000,
+        "rpc.max-connections": 20000,
+        "rpc.eth-proof-window": 64,
+        "txpool.max-new-pending-txs-notifications": 1000000,
+        "txpool.max-pending-txns": 1000000,
+        "txpool.pending-max-count": 200000,
+        "txpool.pending-max-size": 512,
+        "txpool.basefee-max-count": 200000,
+        "txpool.basefee-max-size": 512,
+        "txpool.queued-max-count": 100000,
+        "txpool.queued-max-size": 256,
+        "txpool.max-account-slots": ${TXPOOL_MAX_ACCOUNT_SLOTS},
+        "ipcdisable": ""
+    },
+    "env_vars": {
+        "BATCH_INSERT_TIME": 20
+    }
+}

--- a/gravity_e2e/cluster_test_cases/oracle_live_soak/test_oracle_live_soak.py
+++ b/gravity_e2e/cluster_test_cases/oracle_live_soak/test_oracle_live_soak.py
@@ -38,6 +38,24 @@ RECONFIGURATION_ADDRESS = Web3.to_checksum_address(
 EPOCH_CONFIG_ADDRESS = Web3.to_checksum_address(
     "0x00000000000000000000000000000001625F1005"
 )
+ORACLE_V1_CONTRACTS = (
+    {
+        "name": "NativeOracle",
+        "address": Web3.to_checksum_address(
+            "0x00000000000000000000000000000001625F4000"
+        ),
+        "preForkCodeHash": "0x30dd3888ce26735c0d6c5a036b48a1de668dd5506efa7588ce450f976da28255",
+        "postForkCodeHash": "0x981087ccdaa0b7843960782e99b078ccdd3820b331f86ce337d9750c5565d984",
+    },
+    {
+        "name": "OracleTaskConfig",
+        "address": Web3.to_checksum_address(
+            "0x00000000000000000000000000000001625F1009"
+        ),
+        "preForkCodeHash": "0x74127baf705119810746598b2695ff5fa38f94bd778f0edae46799ffd3606bda",
+        "postForkCodeHash": "0xa21bf93e6123b0104b9ea851b8154fb342a5b576c22c71f15f851e266faa9f7f",
+    },
+)
 SEL_CURRENT_EPOCH = Web3.keccak(text="currentEpoch()")[:4]
 SEL_REMAINING_TIME = Web3.keccak(text="getRemainingTimeSeconds()")[:4]
 CALLBACK_SUCCESS_TOPIC0 = Web3.keccak(
@@ -207,6 +225,23 @@ def test_soak_settings_rejects_two_restart_controls(monkeypatch):
         _soak_settings()
 
 
+def test_signed_testnet_genesis_pins_oracle_v1_pre_fork_runtimes():
+    path = SUITE_DIR.parents[2] / "genesis" / "testnet" / "genesis.json"
+    alloc = json.loads(path.read_text())["alloc"]
+    normalized_alloc = {
+        key.removeprefix("0x").lower(): account
+        for key, account in alloc.items()
+    }
+    for contract in ORACLE_V1_CONTRACTS:
+        key = contract["address"].removeprefix("0x").lower()
+        code = normalized_alloc[key]["code"]
+        assert len(code) > 2
+        assert (
+            Web3.to_hex(Web3.keccak(hexstr=code)).lower()
+            == contract["preForkCodeHash"]
+        )
+
+
 def _metadata() -> dict:
     path = SUITE_DIR / "artifacts" / "oracle_live_soak_metadata.json"
     return json.loads(path.read_text())
@@ -362,6 +397,127 @@ async def _wait_for_block(
         f"{node_id} RPC did not reach Gravity block {block_number}; "
         f"last height was {last_height}"
     )
+
+
+def _account_snapshot(w3: Web3, address: str, block_number: int) -> dict:
+    code = bytes(w3.eth.get_code(address, block_identifier=block_number))
+    proof = w3.eth.get_proof(address, [], block_identifier=block_number)
+    code_hash = Web3.to_hex(Web3.keccak(code)).lower()
+    proof_code_hash = Web3.to_hex(HexBytes(proof["codeHash"])).lower()
+    assert code_hash == proof_code_hash, (
+        f"eth_getCode/eth_getProof disagree for {address} at block "
+        f"{block_number}"
+    )
+    return {
+        "balance": int(proof["balance"]),
+        "nonce": int(proof["nonce"]),
+        "codeHash": code_hash,
+        "codeLength": len(code),
+        "storageHash": Web3.to_hex(HexBytes(proof["storageHash"])).lower(),
+    }
+
+
+async def _capture_oracle_v1_phase(
+    node_id: str, w3: Web3, block_number: int
+) -> tuple[str, dict]:
+    await _wait_for_block(node_id, w3, block_number, timeout=180)
+    block_hash = Web3.to_hex(w3.eth.get_block(block_number)["hash"])
+    accounts = {
+        contract["name"]: _account_snapshot(
+            w3, contract["address"], block_number
+        )
+        for contract in ORACLE_V1_CONTRACTS
+    }
+    return node_id, {
+        "block": block_number,
+        "blockHash": block_hash,
+        "accounts": accounts,
+    }
+
+
+async def _verify_oracle_v1_hardfork(
+    cluster: Cluster, activation_block: int
+) -> dict:
+    assert activation_block > 0
+    phase_blocks = {
+        "preFork": activation_block - 1,
+        "postFork": activation_block,
+    }
+    snapshots = {}
+    for phase, block_number in phase_blocks.items():
+        captured = dict(
+            await asyncio.gather(
+                *(
+                    _capture_oracle_v1_phase(
+                        node_id, node.w3, block_number
+                    )
+                    for node_id, node in cluster.nodes.items()
+                )
+            )
+        )
+        block_hashes = {
+            node_id: snapshot["blockHash"]
+            for node_id, snapshot in captured.items()
+        }
+        assert len(set(block_hashes.values())) == 1, (
+            f"validators disagree on OracleV1 {phase} block: {block_hashes}"
+        )
+        accounts = {
+            node_id: snapshot["accounts"]
+            for node_id, snapshot in captured.items()
+        }
+        canonical_accounts = next(iter(accounts.values()))
+        assert all(
+            node_accounts == canonical_accounts
+            for node_accounts in accounts.values()
+        ), f"validators disagree on OracleV1 {phase} account state"
+        snapshots[phase] = {
+            "block": block_number,
+            "blockHash": next(iter(block_hashes.values())),
+            "accounts": canonical_accounts,
+        }
+
+    await asyncio.gather(
+        *(
+            _wait_for_block(
+                node_id,
+                node.w3,
+                activation_block + SNAPSHOT_CONFIRMATION_BLOCKS,
+                timeout=180,
+            )
+            for node_id, node in cluster.nodes.items()
+        )
+    )
+    for phase, snapshot in snapshots.items():
+        canonical_hashes = {
+            node_id: Web3.to_hex(
+                node.w3.eth.get_block(snapshot["block"])["hash"]
+            )
+            for node_id, node in cluster.nodes.items()
+        }
+        assert set(canonical_hashes.values()) == {snapshot["blockHash"]}, (
+            f"OracleV1 {phase} block changed before confirmation: "
+            f"{canonical_hashes}"
+        )
+
+    for contract in ORACLE_V1_CONTRACTS:
+        name = contract["name"]
+        before = snapshots["preFork"]["accounts"][name]
+        after = snapshots["postFork"]["accounts"][name]
+        assert before["codeHash"] == contract["preForkCodeHash"]
+        assert after["codeHash"] == contract["postForkCodeHash"]
+        assert before["codeLength"] > 0 and after["codeLength"] > 0
+        for preserved_field in ("balance", "nonce", "storageHash"):
+            assert before[preserved_field] == after[preserved_field], (
+                f"OracleV1 changed {name}.{preserved_field}"
+            )
+
+    return {
+        "activationBlock": activation_block,
+        "preFork": snapshots["preFork"],
+        "postFork": snapshots["postFork"],
+        "validatorCount": len(cluster.nodes),
+    }
 
 
 def _call_at_block_hash(function, block_hash: str):
@@ -1057,8 +1213,17 @@ async def test_governance_activated_price_feeds_soak_for_configured_duration(
 ):
     settings = _soak_settings()
     metadata = _metadata()
-    assert set(metadata) == {"binanceFeeds"}
+    assert set(metadata) == {"binanceFeeds", "oracleV1Hardfork"}
     binance_feeds = metadata["binanceFeeds"]
+    oracle_v1_metadata = metadata["oracleV1Hardfork"]
+    assert oracle_v1_metadata["fixture"] == "genesis/testnet/genesis.json"
+    assert oracle_v1_metadata["contracts"] == [
+        {
+            **contract,
+            "address": contract["address"].lower(),
+        }
+        for contract in ORACLE_V1_CONTRACTS
+    ]
     assert [feed["pair"] for feed in binance_feeds] == [
         "NVDAUSDT",
         "BTCUSDT",
@@ -1074,9 +1239,12 @@ async def test_governance_activated_price_feeds_soak_for_configured_duration(
     assert set(relayer_config["uri_mappings"]) == expected_uris
     assert all(uri.startswith("gravity://3/") for uri in expected_uris)
     with (SUITE_DIR / "genesis.toml").open("rb") as genesis_file:
-        oracle_config = tomllib.load(genesis_file)["genesis"]["oracle_config"]
+        genesis_config = tomllib.load(genesis_file)["genesis"]
+    oracle_config = genesis_config["oracle_config"]
     assert oracle_config["source_types"] == [1, 3]
     assert len(oracle_config["callbacks"]) == 2
+    activation_block = int(oracle_v1_metadata["activationBlock"])
+    assert genesis_config["hardforks"]["oracleV1Block"] == activation_block
 
     assert len(cluster.nodes) == 4
     assert await cluster.set_full_live(timeout=180)
@@ -1087,6 +1255,22 @@ async def test_governance_activated_price_feeds_soak_for_configured_duration(
     node1 = cluster.get_node("node1")
     assert node1 is not None and node1.w3.is_connected()
     w3 = node1.w3
+    try:
+        hardfork_evidence = await _verify_oracle_v1_hardfork(
+            cluster, activation_block
+        )
+    except BaseException as error:
+        _write_summary(
+            {
+                "status": "failed",
+                "phase": "oracleV1Hardfork",
+                "errorType": type(error).__name__,
+                "error": str(error),
+                "activationBlock": activation_block,
+            }
+        )
+        raise
+
     required = [
         ("PriceFeedResolver.sol", "PriceFeedResolver"),
         ("NativeOracle.sol", "NativeOracle"),
@@ -1274,6 +1458,7 @@ async def test_governance_activated_price_feeds_soak_for_configured_duration(
                 "binancePairs": [
                     feed["pair"] for feed in binance_feeds
                 ],
+                "oracleV1Hardfork": hardfork_evidence,
                 "lastHeartbeat": last_heartbeat,
             }
         )
@@ -1299,6 +1484,7 @@ async def test_governance_activated_price_feeds_soak_for_configured_duration(
         {
             "activationEpoch": activation_epoch,
             "governanceBlock": receipt["blockNumber"],
+            "oracleV1Hardfork": hardfork_evidence,
             "priceCallbackEvents": price_delivery_counts,
             "soakEpochIntervalSeconds": (
                 SOAK_EPOCH_INTERVAL_MICROS // 1_000_000

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/.gitignore
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/README.md
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/README.md
@@ -1,0 +1,49 @@
+# OracleV1 Bridge Hardfork E2E
+
+This manual four-validator suite proves that the live `sourceType=0` bridge
+survives the OracleV1 code-only hardfork. It is intentionally separate from
+`oracle_v1_rolling_upgrade`: the rolling suite proves binary replacement, while
+this suite proves bridge state and execution across the activation block.
+
+The test starts every validator on the candidate binary but installs the exact
+signed testnet pre-fork runtimes for `NativeOracle` and `OracleTaskConfig` in
+genesis. A deterministic source RPC exposes canonical `MessageSent` logs in two
+stages:
+
+1. release nonce `N` before `oracleV1Block` and verify the legacy record, mint,
+   balance, and nonce on all validators;
+2. stop node4 with a pre-fork database;
+3. capture the exact code and account proofs at `H-1` and `H` on the remaining
+   validators;
+4. restart node4 after `H` and require it to replay the migration and converge;
+5. release nonce `N+1` after `H+1` and verify one mint, sequential source
+   progress, and identical state on all validators.
+
+The summary records whether `getRecord(N+1)` remains populated. Set
+`ORACLE_V1_REQUIRE_SOURCE0_RECORDS=1` to turn preservation of the legacy pull
+API into a hard release gate. This defaults to `0` until the compatibility
+decision tracked in `gravity_chain_core_contracts#112` is resolved.
+
+Run the suite with the candidate binary already built:
+
+```bash
+./gravity_e2e/run_test.sh \
+  oracle_v1_bridge_hardfork \
+  --force-init \
+  --log-cli-level=INFO
+```
+
+For a shorter local smoke, the activation block may be overridden while still
+leaving enough time for the first bridge delivery and node4 shutdown:
+
+```bash
+ORACLE_V1_BRIDGE_ACTIVATION_BLOCK=180 \
+  ./gravity_e2e/run_test.sh \
+    oracle_v1_bridge_hardfork \
+    --force-init \
+    --log-cli-level=INFO
+```
+
+The ignored `artifacts/oracle_v1_bridge_hardfork_summary.json` contains the
+pre/post contract proofs, bridge observations, replay timing, canonical
+checkpoints, and `getRecord` compatibility result.

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/cluster.toml
@@ -1,0 +1,72 @@
+# Four-validator OracleV1 bridge migration and replay test.
+
+[cluster]
+name = "gravity-devnet-oracle-v1-bridge-hardfork"
+base_dir = "/tmp/gravity-cluster-oracle-v1-bridge-hardfork"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27880
+vfn_port = 27890
+rpc_port = 27900
+api_port = 27910
+metrics_port = 27920
+inspection_port = 27930
+https_port = 27940
+authrpc_port = 27950
+reth_p2p_port = 27960
+
+[[nodes]]
+id = "node2"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27881
+vfn_port = 27891
+rpc_port = 27901
+api_port = 27911
+metrics_port = 27921
+inspection_port = 27931
+https_port = 27941
+authrpc_port = 27951
+reth_p2p_port = 27961
+
+[[nodes]]
+id = "node3"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27882
+vfn_port = 27892
+rpc_port = 27902
+api_port = 27912
+metrics_port = 27922
+inspection_port = 27932
+https_port = 27942
+authrpc_port = 27952
+reth_p2p_port = 27962
+
+[[nodes]]
+id = "node4"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27883
+vfn_port = 27893
+rpc_port = 27903
+api_port = 27913
+metrics_port = 27923
+inspection_port = 27933
+https_port = 27943
+authrpc_port = 27953
+reth_p2p_port = 27963
+
+[faucet_init]
+num_accounts = 0

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/genesis.toml
@@ -1,0 +1,110 @@
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "2762c3c98f1eed5fb6fe4d9bd4b6fefbadf7ce14"
+
+[[genesis_validators]]
+id = "node1"
+address = "0xf39Fd6e51aad88F6f4ce6aB8827279cffFb92266"
+host = "127.0.0.1"
+validator_port = 27880
+vfn_port = 27890
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node2"
+address = "0x7b254Bd44F6CE45e00a912b2460D47F3Be56fAD7"
+host = "127.0.0.1"
+validator_port = 27881
+vfn_port = 27891
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node3"
+address = "0x9B2C25E77a97d3e84DC0Cb7F83fb676ddC4F24b9"
+host = "127.0.0.1"
+validator_port = 27882
+vfn_port = 27892
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node4"
+address = "0x18c23753385ce7A60B15d171302E48b6AFf0BDC5"
+host = "127.0.0.1"
+validator_port = 27883
+vfn_port = 27893
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis]
+chain_id = 1337
+epoch_interval_micros = 1800000000
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+initial_locked_until_micros = 1798848000000000
+governance_owner = "0xf39Fd6e51aad88F6f4ce6aB8827279cffFb92266"
+
+[genesis.hardforks]
+oracleV1Block = 300
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6f4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "1000000000000000000"
+voting_duration_micros = 5000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
+
+[genesis.oracle_config.bridge_config]
+deploy = true
+trusted_bridge = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+trusted_source_id = 31337
+
+[[genesis.oracle_config.tasks]]
+source_type = 0
+source_id = 31337
+task_name = "anvil"
+config = "gravity://0/31337/events?contract=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512&eventSignature=0x5646e682c7d994bf11f5a2c8addb60d03c83cda3b65025a826346589df43406e&fromBlock=0"
+
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/genesis.toml
@@ -1,6 +1,6 @@
 [dependencies.genesis_contracts]
 repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
-ref = "2762c3c98f1eed5fb6fe4d9bd4b6fefbadf7ce14"
+ref = "5772b210b19761439147ce0d17590a42cb978af8"
 
 [[genesis_validators]]
 id = "node1"

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/hooks.py
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/hooks.py
@@ -1,0 +1,146 @@
+"""Install legacy Oracle runtimes and stage bridge events around OracleV1."""
+
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+
+from web3 import Web3
+
+
+LOG = logging.getLogger(__name__)
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SIGNED_TESTNET_GENESIS = PROJECT_ROOT / "genesis" / "testnet" / "genesis.json"
+METADATA_FILE = "oracle_v1_bridge_hardfork_metadata.json"
+SUMMARY_FILE = "oracle_v1_bridge_hardfork_summary.json"
+
+ORACLE_V1_CONTRACTS = (
+    {
+        "name": "NativeOracle",
+        "address": "0x00000000000000000000000000000001625f4000",
+        "preForkCodeHash": "0x30dd3888ce26735c0d6c5a036b48a1de668dd5506efa7588ce450f976da28255",
+        "postForkCodeHash": "0x981087ccdaa0b7843960782e99b078ccdd3820b331f86ce337d9750c5565d984",
+    },
+    {
+        "name": "OracleTaskConfig",
+        "address": "0x00000000000000000000000000000001625f1009",
+        "preForkCodeHash": "0x74127baf705119810746598b2695ff5fa38f94bd778f0edae46799ffd3606bda",
+        "postForkCodeHash": "0xa21bf93e6123b0104b9ea851b8154fb342a5b576c22c71f15f851e266faa9f7f",
+    },
+)
+
+_mock = None
+
+
+def _alloc_key(alloc: dict, address: str) -> str:
+    normalized = address.removeprefix("0x").lower()
+    for key in alloc:
+        if key.removeprefix("0x").lower() == normalized:
+            return key
+    raise RuntimeError(f"genesis alloc is missing system contract {address}")
+
+
+def _runtime_hash(code: str) -> str:
+    if not code.startswith("0x") or len(code) % 2:
+        raise RuntimeError("system-contract runtime is not canonical hex")
+    return Web3.to_hex(Web3.keccak(hexstr=code)).lower()
+
+
+def _install_legacy_runtimes(test_dir: Path) -> dict:
+    genesis_path = test_dir / "artifacts" / "genesis.json"
+    generated = json.loads(genesis_path.read_text())
+    signed = json.loads(SIGNED_TESTNET_GENESIS.read_text())
+
+    configured = generated.get("config", {}).get("oracleV1Block")
+    override = os.environ.get("ORACLE_V1_BRIDGE_ACTIVATION_BLOCK")
+    activation_block = int(override) if override else configured
+    if not isinstance(activation_block, int) or activation_block <= 0:
+        raise RuntimeError("config.oracleV1Block must be a positive integer")
+    generated.setdefault("config", {})["oracleV1Block"] = activation_block
+
+    generated_alloc = generated.get("alloc", {})
+    signed_alloc = signed.get("alloc", {})
+    evidence = []
+    for contract in ORACLE_V1_CONTRACTS:
+        generated_key = _alloc_key(generated_alloc, contract["address"])
+        signed_key = _alloc_key(signed_alloc, contract["address"])
+        signed_code = signed_alloc[signed_key].get("code", "")
+        signed_hash = _runtime_hash(signed_code)
+        if signed_hash != contract["preForkCodeHash"]:
+            raise RuntimeError(
+                f"signed {contract['name']} hash {signed_hash} does not match "
+                f"{contract['preForkCodeHash']}"
+            )
+        generated_hash = _runtime_hash(
+            generated_alloc[generated_key].get("code", "")
+        )
+        if generated_hash not in {
+            contract["preForkCodeHash"],
+            contract["postForkCodeHash"],
+        }:
+            raise RuntimeError(
+                f"generated {contract['name']} hash {generated_hash} is unknown"
+            )
+        generated_alloc[generated_key]["code"] = signed_code
+        evidence.append(dict(contract))
+
+    temporary = genesis_path.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(generated, indent=2) + "\n")
+    temporary.replace(genesis_path)
+    return {"activationBlock": activation_block, "contracts": evidence}
+
+
+def pre_deploy(test_dir: Path, env: dict, pytest_args: list[str]):
+    hardfork = _install_legacy_runtimes(test_dir)
+    artifacts = test_dir / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    (artifacts / SUMMARY_FILE).unlink(missing_ok=True)
+    (artifacts / METADATA_FILE).write_text(
+        json.dumps({"oracleV1Hardfork": hardfork}, indent=2) + "\n"
+    )
+
+
+def pre_start(test_dir: Path, env: dict, pytest_args: list[str]):
+    global _mock
+
+    e2e_root = str(Path(__file__).resolve().parent.parent.parent)
+    if e2e_root not in sys.path:
+        sys.path.insert(0, e2e_root)
+    from gravity_e2e.utils.mock_anvil import MockAnvil, DEFAULT_PORTAL_ADDRESS
+
+    amount = 1_000_000_000_000_000_000
+    recipient = "0x6954476eAe13Bd072D9f19406A6B9543514f765C"
+    sender = "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+    _mock = MockAnvil(port=28546)
+    _mock.start()
+    nonces = _mock.preload_events(
+        count=2,
+        amount=amount,
+        recipient=recipient,
+        sender_address=sender,
+        events_per_block=1,
+    )
+    _mock.set_finalized(0)
+
+    metadata_path = test_dir / "artifacts" / METADATA_FILE
+    metadata = json.loads(metadata_path.read_text())
+    metadata["bridge"] = {
+        "rpcUrl": _mock.rpc_url,
+        "amount": amount,
+        "recipient": recipient,
+        "sender": sender,
+        "portal": DEFAULT_PORTAL_ADDRESS,
+        "nonces": nonces,
+        "sourceBlocks": [1, 2],
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n")
+    LOG.info("Staged two bridge events; finalized source block remains 0")
+
+
+def post_stop(test_dir: Path, env: dict):
+    global _mock
+    if _mock is not None:
+        _mock.stop()
+        _mock = None
+    (test_dir / "artifacts" / METADATA_FILE).unlink(missing_ok=True)

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/relayer_config.json
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/relayer_config.json
@@ -1,0 +1,5 @@
+{
+  "uri_mappings": {
+    "gravity://0/31337/events?contract=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512&eventSignature=0x5646e682c7d994bf11f5a2c8addb60d03c83cda3b65025a826346589df43406e&fromBlock=0": "http://localhost:28546"
+  }
+}

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/reth_config.json.tpl
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/reth_config.json.tpl
@@ -1,0 +1,27 @@
+{
+  "reth_args": {
+    "chain": "${GENESIS_PATH}",
+    "http": "",
+    "relayer_config": "${CONFIG_DIR}/relayer_config.json",
+    "http.port": ${RPC_PORT},
+    "http.corsdomain": "${RPC_HTTP_CORSDOMAIN}",
+    "http.api": "${RPC_HTTP_API}",
+    "http.addr": "0.0.0.0",
+    "dev": "",
+    "port": ${P2P_PORT_RETH},
+    "authrpc.port": ${AUTHRPC_PORT},
+    "authrpc.addr": "0.0.0.0",
+    "metrics": "0.0.0.0:${METRICS_PORT}",
+    "log.file.filter": "info",
+    "log.stdout.filter": "error",
+    "datadir": "${STORAGE_DIR}/reth",
+    "datadir.static-files": "${STORAGE_DIR}/reth",
+    "gravity_node_config": "${CONFIG_DIR}/validator.yaml",
+    "log.file.directory": "${LOG_DIR}/execution_logs/",
+    "rpc.eth-proof-window": 128,
+    "ipcdisable": ""
+  },
+  "env_vars": {
+    "BATCH_INSERT_TIME": 20
+  }
+}

--- a/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/test_oracle_v1_bridge_hardfork.py
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_bridge_hardfork/test_oracle_v1_bridge_hardfork.py
@@ -1,0 +1,417 @@
+"""Prove sourceType=0 bridge continuity across the OracleV1 hardfork."""
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+import time
+
+from hexbytes import HexBytes
+import pytest
+import requests
+from web3 import Web3
+
+from gravity_e2e.cluster.manager import Cluster
+from gravity_e2e.utils.bridge_utils import (
+    BRIDGE_RECEIVER_ABI,
+    GBRIDGE_RECEIVER_ADDRESS,
+    NATIVE_MINTED_TOPIC0,
+    poll_all_native_minted,
+)
+
+
+LOG = logging.getLogger(__name__)
+SUITE_DIR = Path(__file__).resolve().parent
+METADATA_FILE = "oracle_v1_bridge_hardfork_metadata.json"
+SUMMARY_FILE = "oracle_v1_bridge_hardfork_summary.json"
+SOURCE_TYPE_BLOCKCHAIN = 0
+SOURCE_ID = 31337
+CONFIRMATION_BLOCKS = 16
+DEFAULT_TIMEOUT_SECONDS = 15 * 60
+
+ORACLE_V1_CONTRACTS = (
+    {
+        "name": "NativeOracle",
+        "address": Web3.to_checksum_address(
+            "0x00000000000000000000000000000001625f4000"
+        ),
+        "preForkCodeHash": "0x30dd3888ce26735c0d6c5a036b48a1de668dd5506efa7588ce450f976da28255",
+        "postForkCodeHash": "0x981087ccdaa0b7843960782e99b078ccdd3820b331f86ce337d9750c5565d984",
+    },
+    {
+        "name": "OracleTaskConfig",
+        "address": Web3.to_checksum_address(
+            "0x00000000000000000000000000000001625f1009"
+        ),
+        "preForkCodeHash": "0x74127baf705119810746598b2695ff5fa38f94bd778f0edae46799ffd3606bda",
+        "postForkCodeHash": "0xa21bf93e6123b0104b9ea851b8154fb342a5b576c22c71f15f851e266faa9f7f",
+    },
+)
+
+NATIVE_ORACLE_ABI = [
+    {
+        "type": "function",
+        "name": "getLatestNonce",
+        "inputs": [
+            {"name": "sourceType", "type": "uint32"},
+            {"name": "sourceId", "type": "uint256"},
+        ],
+        "outputs": [{"name": "nonce", "type": "uint128"}],
+        "stateMutability": "view",
+    },
+    {
+        "type": "function",
+        "name": "getRecord",
+        "inputs": [
+            {"name": "sourceType", "type": "uint32"},
+            {"name": "sourceId", "type": "uint256"},
+            {"name": "nonce", "type": "uint128"},
+        ],
+        "outputs": [
+            {
+                "name": "record",
+                "type": "tuple",
+                "components": [
+                    {"name": "recordedAt", "type": "uint64"},
+                    {"name": "blockNumber", "type": "uint256"},
+                    {"name": "data", "type": "bytes"},
+                ],
+            }
+        ],
+        "stateMutability": "view",
+    },
+    {
+        "type": "function",
+        "name": "getSourceProgress",
+        "inputs": [
+            {"name": "sourceType", "type": "uint32"},
+            {"name": "sourceId", "type": "uint256"},
+        ],
+        "outputs": [
+            {
+                "name": "progress",
+                "type": "tuple",
+                "components": [
+                    {"name": "latestNonce", "type": "uint128"},
+                    {"name": "latestPosition", "type": "uint128"},
+                ],
+            }
+        ],
+        "stateMutability": "view",
+    },
+]
+
+
+def _metadata() -> dict:
+    return json.loads((SUITE_DIR / "artifacts" / METADATA_FILE).read_text())
+
+
+def _write_summary(payload: dict) -> None:
+    (SUITE_DIR / "artifacts" / SUMMARY_FILE).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _set_finalized(rpc_url: str, block_number: int) -> None:
+    response = requests.post(
+        rpc_url,
+        json={
+            "jsonrpc": "2.0",
+            "method": "mock_setFinalized",
+            "params": [block_number],
+            "id": 1,
+        },
+        timeout=5,
+    )
+    response.raise_for_status()
+    result = response.json()
+    if "error" in result:
+        raise RuntimeError(f"mock_setFinalized failed: {result['error']}")
+    assert int(result["result"]) == block_number
+
+
+async def _wait_for_block(node_id: str, w3: Web3, target: int) -> None:
+    timeout = int(
+        os.environ.get(
+            "ORACLE_V1_BRIDGE_BLOCK_TIMEOUT_SECONDS",
+            str(DEFAULT_TIMEOUT_SECONDS),
+        )
+    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if w3.eth.block_number >= target:
+                return
+        except Exception:
+            pass
+        await asyncio.sleep(1)
+    raise TimeoutError(f"{node_id} did not reach block {target}")
+
+
+def _account_snapshot(w3: Web3, address: str, block_number: int) -> dict:
+    code = bytes(w3.eth.get_code(address, block_identifier=block_number))
+    proof = w3.eth.get_proof(address, [], block_identifier=block_number)
+    code_hash = Web3.to_hex(Web3.keccak(code)).lower()
+    assert Web3.to_hex(HexBytes(proof["codeHash"])).lower() == code_hash
+    return {
+        "balance": int(proof["balance"]),
+        "nonce": int(proof["nonce"]),
+        "codeHash": code_hash,
+        "codeLength": len(code),
+        "storageHash": Web3.to_hex(HexBytes(proof["storageHash"])).lower(),
+    }
+
+
+async def _capture_phase(nodes: dict, block_number: int) -> dict:
+    await asyncio.gather(
+        *(
+            _wait_for_block(node_id, node.w3, block_number)
+            for node_id, node in nodes.items()
+        )
+    )
+    replicas = {
+        node_id: {
+            "blockHash": Web3.to_hex(
+                node.w3.eth.get_block(block_number)["hash"]
+            ),
+            "accounts": {
+                contract["name"]: _account_snapshot(
+                    node.w3, contract["address"], block_number
+                )
+                for contract in ORACLE_V1_CONTRACTS
+            },
+        }
+        for node_id, node in nodes.items()
+    }
+    assert len({entry["blockHash"] for entry in replicas.values()}) == 1
+    assert len(
+        {
+            json.dumps(entry["accounts"], sort_keys=True)
+            for entry in replicas.values()
+        }
+    ) == 1
+    canonical = next(iter(replicas.values()))
+    return {
+        "block": block_number,
+        "blockHash": canonical["blockHash"],
+        "accounts": canonical["accounts"],
+    }
+
+
+def _oracle(w3: Web3):
+    return w3.eth.contract(
+        address=ORACLE_V1_CONTRACTS[0]["address"],
+        abi=NATIVE_ORACLE_ABI,
+    )
+
+
+def _bridge_state(w3: Web3, nonce: int, include_progress: bool) -> dict:
+    oracle = _oracle(w3)
+    record = oracle.functions.getRecord(
+        SOURCE_TYPE_BLOCKCHAIN, SOURCE_ID, nonce
+    ).call()
+    state = {
+        "latestNonce": int(
+            oracle.functions.getLatestNonce(
+                SOURCE_TYPE_BLOCKCHAIN, SOURCE_ID
+            ).call()
+        ),
+        "record": {
+            "recordedAt": int(record[0]),
+            "sourcePosition": int(record[1]),
+            "payloadLength": len(record[2]),
+        },
+    }
+    if include_progress:
+        progress = oracle.functions.getSourceProgress(
+            SOURCE_TYPE_BLOCKCHAIN, SOURCE_ID
+        ).call()
+        state["progress"] = {
+            "latestNonce": int(progress[0]),
+            "latestPosition": int(progress[1]),
+        }
+    return state
+
+
+def _mint_counts(w3: Web3) -> dict[int, int]:
+    receiver = w3.eth.contract(
+        address=Web3.to_checksum_address(GBRIDGE_RECEIVER_ADDRESS),
+        abi=BRIDGE_RECEIVER_ABI,
+    )
+    logs = w3.eth.get_logs(
+        {
+            "address": receiver.address,
+            "fromBlock": 0,
+            "toBlock": "latest",
+            "topics": [NATIVE_MINTED_TOPIC0],
+        }
+    )
+    counts: dict[int, int] = {}
+    for log in logs:
+        event = receiver.events.NativeMinted().process_log(log)
+        nonce = int(event.args.nonce)
+        counts[nonce] = counts.get(nonce, 0) + 1
+    return counts
+
+
+@pytest.mark.cross_chain
+@pytest.mark.bridge
+@pytest.mark.asyncio
+async def test_oracle_v1_bridge_hardfork(cluster: Cluster):
+    metadata = _metadata()
+    bridge = metadata["bridge"]
+    activation_block = int(
+        metadata["oracleV1Hardfork"]["activationBlock"]
+    )
+    evidence = {}
+
+    try:
+        assert len(cluster.nodes) == 4
+        assert await cluster.set_full_live(timeout=180)
+        assert await cluster.check_block_increasing(timeout=60)
+
+        node1 = cluster.get_node("node1")
+        node4 = cluster.get_node("node4")
+        assert node1 is not None and node4 is not None
+        recipient = Web3.to_checksum_address(bridge["recipient"])
+        initial_balance = node1.w3.eth.get_balance(recipient)
+
+        assert activation_block - node1.w3.eth.block_number > 64, (
+            "insufficient headroom for pre-fork bridge delivery"
+        )
+        _set_finalized(bridge["rpcUrl"], bridge["sourceBlocks"][0])
+        first = await poll_all_native_minted(
+            gravity_w3=node1.w3,
+            max_nonce=1,
+            timeout=300,
+            poll_interval=2,
+        )
+        assert first["missing_nonces"] == set()
+        assert _mint_counts(node1.w3).get(1) == 1
+        assert node1.w3.eth.get_balance(recipient) - initial_balance == bridge["amount"]
+
+        pre_states = {
+            node_id: _bridge_state(node.w3, 1, include_progress=False)
+            for node_id, node in cluster.nodes.items()
+        }
+        assert len({json.dumps(value, sort_keys=True) for value in pre_states.values()}) == 1
+        pre_state = next(iter(pre_states.values()))
+        assert pre_state["latestNonce"] == 1
+        assert pre_state["record"]["recordedAt"] > 0
+        assert pre_state["record"]["sourcePosition"] == bridge["sourceBlocks"][0]
+        assert pre_state["record"]["payloadLength"] > 0
+        evidence["preForkBridge"] = pre_state
+
+        assert activation_block - node1.w3.eth.block_number > 32
+        node4_height = node4.w3.eth.block_number
+        assert node4_height < activation_block
+        assert await node4.stop(), "failed to stop node4 before hardfork"
+
+        live_nodes = {
+            node_id: node
+            for node_id, node in cluster.nodes.items()
+            if node_id != "node4"
+        }
+        pre_fork = await _capture_phase(live_nodes, activation_block - 1)
+        post_fork = await _capture_phase(live_nodes, activation_block)
+        await asyncio.gather(
+            *(
+                _wait_for_block(
+                    node_id,
+                    node.w3,
+                    activation_block + CONFIRMATION_BLOCKS,
+                )
+                for node_id, node in live_nodes.items()
+            )
+        )
+
+        for contract in ORACLE_V1_CONTRACTS:
+            before = pre_fork["accounts"][contract["name"]]
+            after = post_fork["accounts"][contract["name"]]
+            assert before["codeHash"] == contract["preForkCodeHash"]
+            assert after["codeHash"] == contract["postForkCodeHash"]
+            for field in ("balance", "nonce", "storageHash"):
+                assert before[field] == after[field]
+        evidence["hardfork"] = {"preFork": pre_fork, "postFork": post_fork}
+
+        peer_tip = max(node.w3.eth.block_number for node in live_nodes.values())
+        replay_started = time.monotonic()
+        assert await node4.start(rpc_timeout=120), "failed to restart node4"
+        await _wait_for_block("node4", node4.w3, peer_tip)
+        replay_seconds = round(time.monotonic() - replay_started, 3)
+        replay_pre = await _capture_phase(cluster.nodes, activation_block - 1)
+        replay_post = await _capture_phase(cluster.nodes, activation_block)
+        assert replay_pre == pre_fork
+        assert replay_post == post_fork
+
+        replay_states = {
+            node_id: _bridge_state(node.w3, 1, include_progress=True)
+            for node_id, node in cluster.nodes.items()
+        }
+        assert len({json.dumps(value, sort_keys=True) for value in replay_states.values()}) == 1
+        replay_state = next(iter(replay_states.values()))
+        assert replay_state["progress"] == {
+            "latestNonce": 1,
+            "latestPosition": bridge["sourceBlocks"][0],
+        }
+        evidence["node4Replay"] = {
+            "stoppedAtBlock": node4_height,
+            "peerTip": peer_tip,
+            "recoverySeconds": replay_seconds,
+            "bridgeState": replay_state,
+        }
+
+        _set_finalized(bridge["rpcUrl"], bridge["sourceBlocks"][1])
+        second = await poll_all_native_minted(
+            gravity_w3=node1.w3,
+            max_nonce=2,
+            timeout=300,
+            poll_interval=2,
+        )
+        assert second["missing_nonces"] == set()
+        assert _mint_counts(node1.w3) == {1: 1, 2: 1}
+        assert node1.w3.eth.get_balance(recipient) - initial_balance == 2 * bridge["amount"]
+
+        post_states = {
+            node_id: _bridge_state(node.w3, 2, include_progress=True)
+            for node_id, node in cluster.nodes.items()
+        }
+        assert len({json.dumps(value, sort_keys=True) for value in post_states.values()}) == 1
+        post_state = next(iter(post_states.values()))
+        assert post_state["latestNonce"] == 2
+        assert post_state["progress"] == {
+            "latestNonce": 2,
+            "latestPosition": bridge["sourceBlocks"][1],
+        }
+        records_preserved = post_state["record"]["recordedAt"] > 0
+        if os.environ.get("ORACLE_V1_REQUIRE_SOURCE0_RECORDS", "0") == "1":
+            assert records_preserved, (
+                "sourceType=0 getRecord compatibility was required but nonce 2 "
+                "was not stored"
+            )
+        evidence["postForkBridge"] = {
+            **post_state,
+            "mintCounts": _mint_counts(node1.w3),
+            "source0RecordPreserved": records_preserved,
+        }
+
+        assert await cluster.check_block_increasing(timeout=60)
+        _write_summary(
+            {
+                "status": "passed",
+                "activationBlock": activation_block,
+                "evidence": evidence,
+            }
+        )
+    except BaseException as error:
+        _write_summary(
+            {
+                "status": "failed",
+                "activationBlock": activation_block,
+                "evidence": evidence,
+                "errorType": type(error).__name__,
+                "error": str(error),
+            }
+        )
+        raise

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/README.md
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/README.md
@@ -41,7 +41,7 @@ RUSTFLAGS='--cfg tokio_unstable' \
 
 The old baseline for this PR is SDK `90c78afdb5`, which pins gravity-reth
 `4372a103a42a862593fa8221814b3bcc8d47d0aa`. The candidate pins gravity-reth
-`43e57c22368385ee7ed551f6e4d96cf60f6f4f37`.
+`d0f59d5b664ee68cf1816e77e91bf6457fca1ae9`.
 
 ## Run
 

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/README.md
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/README.md
@@ -1,0 +1,77 @@
+# OracleV1 Rolling Binary Upgrade E2E
+
+This manual suite proves the safe deployment order for the OracleV1 system
+contract hardfork:
+
+1. Start four equal-power validators on a pre-OracleV1 `gravity_node`.
+2. Replace `node1` through `node4` one at a time while the chain remains below
+   `oracleV1Block`.
+3. After every replacement, require RPC recovery, block catch-up, continued
+   block production, a common canonical checkpoint, and exact running-binary
+   hashes for the mixed old/new cluster.
+4. Require all four validators to run the new binary before activation.
+5. At `oracleV1Block`, verify the exact NativeOracle and OracleTaskConfig
+   pre/post codehashes on all replicas while balance, nonce, and storage root
+   remain unchanged.
+6. Restart one upgraded validator after activation and require it to replay and
+   rejoin the same canonical chain.
+
+The suite uses a 30-minute epoch and requires at least ten minutes of epoch
+headroom before every stop/start. It also asserts the rollout, activation, and
+post-fork restart all stay in one epoch. Epoch-transition restart recovery is a
+separate safety property and must not obscure the OracleV1 rolling result.
+
+An old binary must never remain in the validator set at activation: it does not
+execute the OracleV1 migration and would diverge from upgraded validators.
+
+## Prepare Binaries
+
+Build the baseline from the SDK commit immediately before the OracleV1 reth pin
+and build the candidate from this branch. Keep the resulting files at stable,
+different paths. Limit Rust parallelism on memory-constrained hosts:
+
+```bash
+export CARGO_BUILD_JOBS=2
+export CARGO_INCREMENTAL=0
+export MALLOC_ARENA_MAX=2
+
+RUSTFLAGS='--cfg tokio_unstable' \
+  cargo build -j2 --profile quick-release -p gravity_node
+```
+
+The old baseline for this PR is SDK `90c78afdb5`, which pins gravity-reth
+`4372a103a42a862593fa8221814b3bcc8d47d0aa`. The candidate pins gravity-reth
+`43e57c22368385ee7ed551f6e4d96cf60f6f4f37`.
+
+## Run
+
+```bash
+export GRAVITY_OLD_BINARY=/stable/path/old/gravity_node
+export GRAVITY_NEW_BINARY=/stable/path/new/gravity_node
+
+./gravity_e2e/run_test.sh \
+  oracle_v1_rolling_upgrade \
+  --force-init \
+  --log-cli-level=INFO
+```
+
+The default activation block is 1600. A shorter manual smoke may override it,
+provided there is enough headroom to finish all four replacements:
+
+```bash
+ORACLE_V1_ROLLING_ACTIVATION_BLOCK=800 \
+ORACLE_V1_ROLLING_MIN_BLOCKS_PER_NODE=128 \
+  ./gravity_e2e/run_test.sh \
+    oracle_v1_rolling_upgrade \
+    --force-init \
+    --log-cli-level=INFO
+```
+
+`ORACLE_V1_ROLLING_BLOCK_TIMEOUT_SECONDS` defaults to 900 seconds and bounds
+each catch-up or activation wait. Increase it for slower CI workers rather than
+lowering the activation block until the four replacements lose safe headroom.
+
+The ignored `artifacts/oracle_v1_rolling_upgrade_summary.json` records every
+binary replacement, canonical checkpoint, activation snapshot, storage guard,
+and post-fork restart. The suite deploys an empty relayer mapping and makes no
+external data-provider request.

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/cluster.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/cluster.toml
@@ -1,0 +1,73 @@
+# Four-validator OracleV1 binary rolling-upgrade test.
+# Keep fixed listeners below Linux's default ephemeral source-port range.
+
+[cluster]
+name = "gravity-devnet-oracle-v1-rolling-upgrade"
+base_dir = "/tmp/gravity-cluster-oracle-v1-rolling-upgrade"
+
+[genesis_source]
+genesis_path = "./artifacts/genesis.json"
+waypoint_path = "./artifacts/waypoint.txt"
+
+[[nodes]]
+id = "node1"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27680
+vfn_port = 27690
+rpc_port = 27700
+api_port = 27710
+metrics_port = 27720
+inspection_port = 27730
+https_port = 27740
+authrpc_port = 27750
+reth_p2p_port = 27760
+
+[[nodes]]
+id = "node2"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27681
+vfn_port = 27691
+rpc_port = 27701
+api_port = 27711
+metrics_port = 27721
+inspection_port = 27731
+https_port = 27741
+authrpc_port = 27751
+reth_p2p_port = 27761
+
+[[nodes]]
+id = "node3"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27682
+vfn_port = 27692
+rpc_port = 27702
+api_port = 27712
+metrics_port = 27722
+inspection_port = 27732
+https_port = 27742
+authrpc_port = 27752
+reth_p2p_port = 27762
+
+[[nodes]]
+id = "node4"
+role = "genesis"
+source = { project_path = "../" }
+host = "127.0.0.1"
+validator_port = 27683
+vfn_port = 27693
+rpc_port = 27703
+api_port = 27713
+metrics_port = 27723
+inspection_port = 27733
+https_port = 27743
+authrpc_port = 27753
+reth_p2p_port = 27763
+
+[faucet_init]
+num_accounts = 0

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/genesis.toml
@@ -1,6 +1,6 @@
 [dependencies.genesis_contracts]
 repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
-ref = "2762c3c98f1eed5fb6fe4d9bd4b6fefbadf7ce14"
+ref = "5772b210b19761439147ce0d17590a42cb978af8"
 
 # Equal voting power keeps the chain live while one validator is replaced.
 [[genesis_validators]]

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/genesis.toml
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/genesis.toml
@@ -1,0 +1,104 @@
+[dependencies.genesis_contracts]
+repo = "https://github.com/Galxe/gravity_chain_core_contracts.git"
+ref = "2762c3c98f1eed5fb6fe4d9bd4b6fefbadf7ce14"
+
+# Equal voting power keeps the chain live while one validator is replaced.
+[[genesis_validators]]
+id = "node1"
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+host = "127.0.0.1"
+validator_port = 27680
+vfn_port = 27690
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node2"
+address = "0x7b254Bd44F6CE45e00a912b2460D47F3Be56fAD7"
+host = "127.0.0.1"
+validator_port = 27681
+vfn_port = 27691
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node3"
+address = "0x9B2C25E77a97d3e84DC0Cb7F83fb676ddC4F24b9"
+host = "127.0.0.1"
+validator_port = 27682
+vfn_port = 27692
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[[genesis_validators]]
+id = "node4"
+address = "0x18c23753385ce7A60B15d171302E48b6AFf0BDC5"
+host = "127.0.0.1"
+validator_port = 27683
+vfn_port = 27693
+stake_amount = "2000000000000000000"
+voting_power = "2000000000000000000"
+consensus_pop = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis]
+chain_id = 1337
+# Keep the binary rollout and OracleV1 activation in one epoch. Restarting a
+# validator across an epoch transition exercises a separate reconfiguration
+# recovery path and can hide the hardfork result behind that failure mode.
+epoch_interval_micros = 1800000000
+major_version = 1
+consensus_config = "0x0301010a00000000000000280000000000000001010000000a000000000000000100010200000000000000000020000000000000"
+execution_config = "0x00"
+initial_locked_until_micros = 1798848000000000
+governance_owner = "0xf39Fd6e51aad88F6f4ce6aB8827279cffFb92266"
+
+[genesis.hardforks]
+# The hook may override this in generated genesis for a shorter manual smoke.
+oracleV1Block = 1600
+
+[genesis.faucet]
+address = "0xf39Fd6e51aad88F6f4ce6aB8827279cffFb92266"
+balance = "0x2000000000000000000000000000000000000000000000000000000000000000"
+
+[genesis.validator_config]
+minimum_bond = "1000000000000000000"
+maximum_bond = "1000000000000000000000000"
+unbonding_delay_micros = 604800000000
+allow_validator_set_change = true
+voting_power_increase_limit_pct = 20
+max_validator_set_size = "100"
+auto_evict_enabled = false
+auto_evict_threshold_pct = 0
+
+[genesis.staking_config]
+minimum_stake = "1000000000000000000"
+lockup_duration_micros = 86400000000
+unbonding_delay_micros = 86400000000
+
+[genesis.governance_config]
+min_voting_threshold = "1000000000000000000"
+required_proposer_stake = "1000000000000000000"
+voting_duration_micros = 5000000
+
+[genesis.randomness_config]
+variant = 1
+secrecy_threshold = 9223372036854775808
+reconstruction_threshold = 12297829382473033728
+fast_path_secrecy_threshold = 12297829382473033728
+
+[genesis.oracle_config]
+source_types = [1]
+callbacks = ["0x00000000000000000000000000000001625F4001"]
+
+[genesis.jwk_config]
+issuers = ["0x68747470733a2f2f6163636f756e74732e676f6f676c652e636f6d"]
+
+[[genesis.jwk_config.jwks]]
+kid = "f5f4c0ae6e6090a65ab0a694d6ba6f19d5d0b4e6"
+kty = "RSA"
+alg = "RS256"
+e = "AQAB"
+n = "2K7epoJWl_aBoYGpXmDBBiEnwQ0QdVRU1gsbGXNrEbrZEQdY5KjH5P5gZMq3d3KvT1j5KsD2tF_9jFMDLqV4VWDNJRLgSNJxhJuO_oLO2BXUSL9a7fLHxnZCUfJvT2K-O8AXjT3_ZM8UuL8d4jBn_fZLzdEI4MHrZLVSaHDvvKqL_mExQo6cFD-qyLZ-T6aHv2x8R7L_3X7E1nGMjKVVZMveQ_HMeXvnGxKf5yfEP0hIQlC_kFm4L_1kV1S0UPmMptZL2qI4VnXqmqI6TZJyE-3VXHgNn1Z1O_9QZlPC0fF0spLHf2S3nNqI0v3k2E7q3DkqxVf5xvn7q_X-gPqzVE9Jw"

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/hooks.py
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/hooks.py
@@ -1,0 +1,170 @@
+"""Prepare old/new binaries and the OracleV1 pre-fork genesis state."""
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import shutil
+
+from web3 import Web3
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+
+LOG = logging.getLogger(__name__)
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SIGNED_TESTNET_GENESIS = PROJECT_ROOT / "genesis" / "testnet" / "genesis.json"
+METADATA_FILE = "oracle_v1_rolling_upgrade_metadata.json"
+SUMMARY_FILE = "oracle_v1_rolling_upgrade_summary.json"
+
+ORACLE_V1_CONTRACTS = (
+    {
+        "name": "NativeOracle",
+        "address": "0x00000000000000000000000000000001625f4000",
+        "preForkCodeHash": "0x30dd3888ce26735c0d6c5a036b48a1de668dd5506efa7588ce450f976da28255",
+        "postForkCodeHash": "0x981087ccdaa0b7843960782e99b078ccdd3820b331f86ce337d9750c5565d984",
+    },
+    {
+        "name": "OracleTaskConfig",
+        "address": "0x00000000000000000000000000000001625f1009",
+        "preForkCodeHash": "0x74127baf705119810746598b2695ff5fa38f94bd778f0edae46799ffd3606bda",
+        "postForkCodeHash": "0xa21bf93e6123b0104b9ea851b8154fb342a5b576c22c71f15f851e266faa9f7f",
+    },
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _required_binary(env: dict, name: str) -> Path:
+    value = env.get(name)
+    if not value:
+        raise RuntimeError(f"{name} must point to an executable gravity_node")
+    path = Path(value).expanduser().resolve()
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise RuntimeError(f"{name} is not an executable file")
+    return path
+
+
+def _alloc_key(alloc: dict, address: str) -> str:
+    normalized = address.removeprefix("0x").lower()
+    for key in alloc:
+        if key.removeprefix("0x").lower() == normalized:
+            return key
+    raise RuntimeError(f"genesis alloc is missing system contract {address}")
+
+
+def _runtime_hash(code: str) -> str:
+    if not code.startswith("0x") or len(code) % 2:
+        raise RuntimeError("system-contract runtime is not canonical hex")
+    return Web3.to_hex(Web3.keccak(hexstr=code)).lower()
+
+
+def _replace_binary(source: Path, destination: Path) -> None:
+    temporary = destination.with_name(f".{destination.name}.rolling.tmp")
+    temporary.unlink(missing_ok=True)
+    shutil.copy2(source, temporary)
+    temporary.chmod(0o755)
+    os.replace(temporary, destination)
+
+
+def _prepare_genesis(test_dir: Path, activation_override: str | None) -> dict:
+    genesis_path = test_dir / "artifacts" / "genesis.json"
+    generated = json.loads(genesis_path.read_text())
+    signed = json.loads(SIGNED_TESTNET_GENESIS.read_text())
+
+    if activation_override is not None:
+        activation_block = int(activation_override)
+        generated.setdefault("config", {})["oracleV1Block"] = activation_block
+    else:
+        activation_block = generated.get("config", {}).get("oracleV1Block")
+    if not isinstance(activation_block, int) or activation_block <= 0:
+        raise RuntimeError("config.oracleV1Block must be a positive integer")
+
+    generated_alloc = generated.get("alloc", {})
+    signed_alloc = signed.get("alloc", {})
+    contracts = []
+    for contract in ORACLE_V1_CONTRACTS:
+        generated_key = _alloc_key(generated_alloc, contract["address"])
+        signed_key = _alloc_key(signed_alloc, contract["address"])
+        pre_fork_code = signed_alloc[signed_key].get("code", "")
+        if _runtime_hash(pre_fork_code) != contract["preForkCodeHash"]:
+            raise RuntimeError(
+                f"signed testnet {contract['name']} pre-fork hash changed"
+            )
+        generated_hash = _runtime_hash(
+            generated_alloc[generated_key].get("code", "")
+        )
+        if generated_hash not in {
+            contract["preForkCodeHash"],
+            contract["postForkCodeHash"],
+        }:
+            raise RuntimeError(
+                f"generated {contract['name']} is not a frozen OracleV1 state"
+            )
+        generated_alloc[generated_key]["code"] = pre_fork_code
+        contracts.append(dict(contract))
+
+    temporary = genesis_path.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(generated, indent=2) + "\n")
+    os.replace(temporary, genesis_path)
+    return {"activationBlock": activation_block, "contracts": contracts}
+
+
+def pre_deploy(test_dir: Path, env: dict, pytest_args: list[str]):
+    old_binary = _required_binary(env, "GRAVITY_OLD_BINARY")
+    new_binary = _required_binary(env, "GRAVITY_NEW_BINARY")
+    old_hash = _sha256(old_binary)
+    new_hash = _sha256(new_binary)
+    if old_hash == new_hash:
+        raise RuntimeError("old and new gravity_node binaries must differ")
+
+    hardfork = _prepare_genesis(
+        test_dir, env.get("ORACLE_V1_ROLLING_ACTIVATION_BLOCK")
+    )
+    artifacts = test_dir / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+    (artifacts / SUMMARY_FILE).unlink(missing_ok=True)
+    (artifacts / METADATA_FILE).write_text(
+        json.dumps(
+            {
+                "oldBinarySha256": old_hash,
+                "newBinarySha256": new_hash,
+                "oracleV1Hardfork": hardfork,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    env["GRAVITY_OLD_BINARY"] = str(old_binary)
+    env["GRAVITY_NEW_BINARY"] = str(new_binary)
+    LOG.info(
+        "Prepared OracleV1 rolling upgrade old=%s new=%s activation=%d",
+        old_hash[:12],
+        new_hash[:12],
+        hardfork["activationBlock"],
+    )
+
+
+def pre_start(test_dir: Path, env: dict, pytest_args: list[str]):
+    old_binary = _required_binary(env, "GRAVITY_OLD_BINARY")
+    with (test_dir / "cluster.toml").open("rb") as source:
+        config = tomllib.load(source)
+    base_dir = Path(config["cluster"]["base_dir"])
+    for node in config["nodes"]:
+        destination = base_dir / node["id"] / "bin" / "gravity_node"
+        _replace_binary(old_binary, destination)
+        LOG.info("Installed old binary for %s", node["id"])
+
+
+def post_stop(test_dir: Path, env: dict):
+    (test_dir / "artifacts" / METADATA_FILE).unlink(missing_ok=True)

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/relayer_config.json
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/relayer_config.json
@@ -1,0 +1,3 @@
+{
+  "uri_mappings": {}
+}

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/reth_config.json.tpl
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/reth_config.json.tpl
@@ -1,0 +1,27 @@
+{
+    "reth_args": {
+        "chain": "${GENESIS_PATH}",
+        "http": "",
+        "relayer_config": "${CONFIG_DIR}/relayer_config.json",
+        "http.port": ${RPC_PORT},
+        "http.corsdomain": "${RPC_HTTP_CORSDOMAIN}",
+        "http.api": "${RPC_HTTP_API}",
+        "http.addr": "0.0.0.0",
+        "dev": "",
+        "port": ${P2P_PORT_RETH},
+        "authrpc.port": ${AUTHRPC_PORT},
+        "authrpc.addr": "0.0.0.0",
+        "metrics": "0.0.0.0:${METRICS_PORT}",
+        "log.file.filter": "info",
+        "log.stdout.filter": "error",
+        "datadir": "${STORAGE_DIR}/reth",
+        "datadir.static-files": "${STORAGE_DIR}/reth",
+        "gravity_node_config": "${CONFIG_DIR}/validator.yaml",
+        "log.file.directory": "${LOG_DIR}/execution_logs/",
+        "rpc.eth-proof-window": 64,
+        "ipcdisable": ""
+    },
+    "env_vars": {
+        "BATCH_INSERT_TIME": 20
+    }
+}

--- a/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/test_oracle_v1_rolling_upgrade.py
+++ b/gravity_e2e/cluster_test_cases/oracle_v1_rolling_upgrade/test_oracle_v1_rolling_upgrade.py
@@ -1,0 +1,389 @@
+"""Roll four validators from pre-OracleV1 reth to the activation binary."""
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import shutil
+import time
+
+from hexbytes import HexBytes
+import pytest
+from web3 import Web3
+
+from gravity_e2e.cluster.manager import Cluster
+
+
+LOG = logging.getLogger(__name__)
+SUITE_DIR = Path(__file__).resolve().parent
+METADATA_FILE = "oracle_v1_rolling_upgrade_metadata.json"
+SUMMARY_FILE = "oracle_v1_rolling_upgrade_summary.json"
+CONFIRMATION_BLOCKS = 16
+DEFAULT_MIN_BLOCKS_PER_REMAINING_NODE = 256
+DEFAULT_BLOCK_WAIT_TIMEOUT_SECONDS = 15 * 60
+RECONFIGURATION_ADDRESS = Web3.to_checksum_address(
+    "0x00000000000000000000000000000001625F2003"
+)
+SEL_CURRENT_EPOCH = Web3.keccak(text="currentEpoch()")[:4]
+SEL_REMAINING_TIME = Web3.keccak(text="getRemainingTimeSeconds()")[:4]
+MIN_ROLLING_EPOCH_HEADROOM_SECONDS = 10 * 60
+
+ORACLE_V1_CONTRACTS = (
+    {
+        "name": "NativeOracle",
+        "address": Web3.to_checksum_address(
+            "0x00000000000000000000000000000001625f4000"
+        ),
+        "preForkCodeHash": "0x30dd3888ce26735c0d6c5a036b48a1de668dd5506efa7588ce450f976da28255",
+        "postForkCodeHash": "0x981087ccdaa0b7843960782e99b078ccdd3820b331f86ce337d9750c5565d984",
+    },
+    {
+        "name": "OracleTaskConfig",
+        "address": Web3.to_checksum_address(
+            "0x00000000000000000000000000000001625f1009"
+        ),
+        "preForkCodeHash": "0x74127baf705119810746598b2695ff5fa38f94bd778f0edae46799ffd3606bda",
+        "postForkCodeHash": "0xa21bf93e6123b0104b9ea851b8154fb342a5b576c22c71f15f851e266faa9f7f",
+    },
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _metadata() -> dict:
+    return json.loads((SUITE_DIR / "artifacts" / METADATA_FILE).read_text())
+
+
+def _write_summary(payload: dict) -> None:
+    path = SUITE_DIR / "artifacts" / SUMMARY_FILE
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _node_binary(cluster: Cluster, node_id: str) -> Path:
+    return cluster.base_dir / node_id / "bin" / "gravity_node"
+
+
+def _running_binary_hash(cluster: Cluster, node_id: str) -> str:
+    node = cluster.get_node(node_id)
+    assert node is not None and node.pid_file.exists()
+    pid = int(node.pid_file.read_text().strip())
+    return _sha256(Path(f"/proc/{pid}/exe"))
+
+
+def _assert_binary_matrix(
+    cluster: Cluster, upgraded: set[str], old_hash: str, new_hash: str
+) -> None:
+    for node_id in sorted(cluster.nodes):
+        expected = new_hash if node_id in upgraded else old_hash
+        assert _sha256(_node_binary(cluster, node_id)) == expected
+        assert _running_binary_hash(cluster, node_id) == expected
+
+
+def _replace_binary(source: Path, destination: Path) -> None:
+    temporary = destination.with_name(f".{destination.name}.rolling.tmp")
+    temporary.unlink(missing_ok=True)
+    shutil.copy2(source, temporary)
+    temporary.chmod(0o755)
+    os.replace(temporary, destination)
+
+
+async def _wait_for_block(
+    node_id: str, w3: Web3, target: int, timeout: int | None = None
+) -> None:
+    if timeout is None:
+        timeout = int(
+            os.environ.get(
+                "ORACLE_V1_ROLLING_BLOCK_TIMEOUT_SECONDS",
+                str(DEFAULT_BLOCK_WAIT_TIMEOUT_SECONDS),
+            )
+        )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if w3.eth.block_number >= target:
+                return
+        except Exception:
+            pass
+        await asyncio.sleep(1)
+    last_height = None
+    try:
+        last_height = w3.eth.block_number
+    except Exception:
+        pass
+    raise TimeoutError(
+        f"{node_id} did not reach block {target} within {timeout}s; "
+        f"last height was {last_height}"
+    )
+
+
+async def _canonical_checkpoint(cluster: Cluster) -> dict:
+    heights = {
+        node_id: node.w3.eth.block_number
+        for node_id, node in cluster.nodes.items()
+    }
+    target = max(1, min(heights.values()) - 2)
+    hashes = {
+        node_id: Web3.to_hex(node.w3.eth.get_block(target)["hash"])
+        for node_id, node in cluster.nodes.items()
+    }
+    assert len(set(hashes.values())) == 1, hashes
+    return {"block": target, "blockHash": next(iter(hashes.values()))}
+
+
+def _uint_call(w3: Web3, selector: bytes) -> int:
+    return int.from_bytes(
+        w3.eth.call({"to": RECONFIGURATION_ADDRESS, "data": selector}),
+        "big",
+    )
+
+
+def _epoch_snapshot(w3: Web3) -> dict:
+    return {
+        "epoch": _uint_call(w3, SEL_CURRENT_EPOCH),
+        "remainingSeconds": _uint_call(w3, SEL_REMAINING_TIME),
+    }
+
+
+async def _upgrade_node(
+    cluster: Cluster,
+    node_id: str,
+    new_binary: Path,
+    rollout_epoch: int,
+) -> dict:
+    node = cluster.get_node(node_id)
+    assert node is not None
+    peer_tip = max(
+        peer.w3.eth.block_number
+        for peer_id, peer in cluster.nodes.items()
+        if peer_id != node_id
+    )
+    epoch_before = _epoch_snapshot(node.w3)
+    assert epoch_before["epoch"] == rollout_epoch
+    assert (
+        epoch_before["remainingSeconds"]
+        > MIN_ROLLING_EPOCH_HEADROOM_SECONDS
+    ), f"unsafe epoch window before replacing {node_id}: {epoch_before}"
+    started = time.monotonic()
+    assert await node.stop(), f"failed to stop {node_id}"
+    _replace_binary(new_binary, _node_binary(cluster, node_id))
+    assert await node.start(rpc_timeout=120), f"failed to start {node_id}"
+    await _wait_for_block(node_id, node.w3, peer_tip)
+    assert await cluster.check_block_increasing(timeout=60)
+    checkpoint = await _canonical_checkpoint(cluster)
+    epoch_after = _epoch_snapshot(node.w3)
+    assert epoch_after["epoch"] == rollout_epoch, (
+        f"epoch changed while replacing {node_id}: "
+        f"before={epoch_before} after={epoch_after}"
+    )
+    return {
+        "node": node_id,
+        "peerTipBeforeStop": peer_tip,
+        "caughtUpHeight": node.w3.eth.block_number,
+        "durationSeconds": round(time.monotonic() - started, 3),
+        "canonicalCheckpoint": checkpoint,
+        "epochBefore": epoch_before,
+        "epochAfter": epoch_after,
+    }
+
+
+def _account_snapshot(w3: Web3, address: str, block_number: int) -> dict:
+    code = bytes(w3.eth.get_code(address, block_identifier=block_number))
+    proof = w3.eth.get_proof(address, [], block_identifier=block_number)
+    code_hash = Web3.to_hex(Web3.keccak(code)).lower()
+    assert Web3.to_hex(HexBytes(proof["codeHash"])).lower() == code_hash
+    return {
+        "balance": int(proof["balance"]),
+        "nonce": int(proof["nonce"]),
+        "codeHash": code_hash,
+        "codeLength": len(code),
+        "storageHash": Web3.to_hex(HexBytes(proof["storageHash"])).lower(),
+    }
+
+
+async def _capture_phase(
+    cluster: Cluster, block_number: int
+) -> dict:
+    await asyncio.gather(
+        *(
+            _wait_for_block(node_id, node.w3, block_number)
+            for node_id, node in cluster.nodes.items()
+        )
+    )
+    replicas = {}
+    for node_id, node in cluster.nodes.items():
+        replicas[node_id] = {
+            "blockHash": Web3.to_hex(
+                node.w3.eth.get_block(block_number)["hash"]
+            ),
+            "accounts": {
+                contract["name"]: _account_snapshot(
+                    node.w3, contract["address"], block_number
+                )
+                for contract in ORACLE_V1_CONTRACTS
+            },
+        }
+    assert len({value["blockHash"] for value in replicas.values()}) == 1
+    assert len(
+        {
+            json.dumps(value["accounts"], sort_keys=True)
+            for value in replicas.values()
+        }
+    ) == 1
+    canonical = next(iter(replicas.values()))
+    return {
+        "block": block_number,
+        "blockHash": canonical["blockHash"],
+        "accounts": canonical["accounts"],
+    }
+
+
+async def _verify_hardfork(cluster: Cluster, activation_block: int) -> dict:
+    pre_fork = await _capture_phase(cluster, activation_block - 1)
+    post_fork = await _capture_phase(cluster, activation_block)
+    await asyncio.gather(
+        *(
+            _wait_for_block(
+                node_id,
+                node.w3,
+                activation_block + CONFIRMATION_BLOCKS,
+            )
+            for node_id, node in cluster.nodes.items()
+        )
+    )
+    for snapshot in (pre_fork, post_fork):
+        hashes = {
+            Web3.to_hex(node.w3.eth.get_block(snapshot["block"])["hash"])
+            for node in cluster.nodes.values()
+        }
+        assert hashes == {snapshot["blockHash"]}
+
+    for contract in ORACLE_V1_CONTRACTS:
+        before = pre_fork["accounts"][contract["name"]]
+        after = post_fork["accounts"][contract["name"]]
+        assert before["codeHash"] == contract["preForkCodeHash"]
+        assert after["codeHash"] == contract["postForkCodeHash"]
+        assert before["codeLength"] > 0 and after["codeLength"] > 0
+        for field in ("balance", "nonce", "storageHash"):
+            assert before[field] == after[field]
+    return {"preFork": pre_fork, "postFork": post_fork}
+
+
+@pytest.mark.asyncio
+async def test_oracle_v1_rolling_binary_upgrade(cluster: Cluster):
+    metadata = _metadata()
+    old_hash = metadata["oldBinarySha256"]
+    new_hash = metadata["newBinarySha256"]
+    activation_block = int(
+        metadata["oracleV1Hardfork"]["activationBlock"]
+    )
+    new_binary = Path(os.environ["GRAVITY_NEW_BINARY"]).resolve()
+    min_blocks = int(
+        os.environ.get(
+            "ORACLE_V1_ROLLING_MIN_BLOCKS_PER_NODE",
+            str(DEFAULT_MIN_BLOCKS_PER_REMAINING_NODE),
+        )
+    )
+    evidence = []
+    upgraded: set[str] = set()
+
+    try:
+        assert len(cluster.nodes) == 4
+        assert await cluster.set_full_live(timeout=180)
+        assert await cluster.check_block_increasing(timeout=60)
+        _assert_binary_matrix(cluster, upgraded, old_hash, new_hash)
+        node1 = cluster.get_node("node1")
+        assert node1 is not None
+        rollout_epoch = _epoch_snapshot(node1.w3)["epoch"]
+
+        for node_id in sorted(cluster.nodes):
+            current_tip = max(
+                node.w3.eth.block_number for node in cluster.nodes.values()
+            )
+            remaining = len(cluster.nodes) - len(upgraded)
+            required_headroom = min_blocks * remaining + CONFIRMATION_BLOCKS
+            assert activation_block - current_tip > required_headroom, (
+                f"insufficient pre-activation headroom before {node_id}: "
+                f"tip={current_tip} activation={activation_block} "
+                f"required={required_headroom}"
+            )
+            evidence.append(
+                await _upgrade_node(
+                    cluster, node_id, new_binary, rollout_epoch
+                )
+            )
+            upgraded.add(node_id)
+            _assert_binary_matrix(cluster, upgraded, old_hash, new_hash)
+
+        assert upgraded == set(cluster.nodes)
+        final_upgrade_tip = max(
+            node.w3.eth.block_number for node in cluster.nodes.values()
+        )
+        assert final_upgrade_tip < activation_block
+        hardfork = await _verify_hardfork(cluster, activation_block)
+        assert _epoch_snapshot(cluster.get_node("node1").w3)["epoch"] == (
+            rollout_epoch
+        ), "epoch changed before OracleV1 activation completed"
+
+        restart_node = cluster.get_node("node4")
+        assert restart_node is not None
+        restart_target = max(
+            node.w3.eth.block_number for node in cluster.nodes.values()
+        )
+        restart_started = time.monotonic()
+        restart_epoch_before = _epoch_snapshot(restart_node.w3)
+        assert restart_epoch_before["epoch"] == rollout_epoch
+        assert (
+            restart_epoch_before["remainingSeconds"]
+            > MIN_ROLLING_EPOCH_HEADROOM_SECONDS
+        )
+        assert await restart_node.restart(rpc_timeout=120)
+        await _wait_for_block("node4", restart_node.w3, restart_target)
+        assert await cluster.check_block_increasing(timeout=60)
+        _assert_binary_matrix(cluster, upgraded, old_hash, new_hash)
+        restart_evidence = {
+            "node": "node4",
+            "targetBlock": restart_target,
+            "recoverySeconds": round(
+                time.monotonic() - restart_started, 3
+            ),
+            "canonicalCheckpoint": await _canonical_checkpoint(cluster),
+            "epochBefore": restart_epoch_before,
+            "epochAfter": _epoch_snapshot(restart_node.w3),
+        }
+        assert restart_evidence["epochAfter"]["epoch"] == rollout_epoch
+
+        summary = {
+            "status": "passed",
+            "activationBlock": activation_block,
+            "rolloutEpoch": rollout_epoch,
+            "allValidatorsUpgradedAtBlock": final_upgrade_tip,
+            "oldBinarySha256": old_hash,
+            "newBinarySha256": new_hash,
+            "upgrades": evidence,
+            "hardfork": hardfork,
+            "postForkRestart": restart_evidence,
+        }
+        _write_summary(summary)
+        LOG.info("OracleV1 rolling upgrade summary: %s", summary)
+    except BaseException as error:
+        _write_summary(
+            {
+                "status": "failed",
+                "activationBlock": activation_block,
+                "oldBinarySha256": old_hash,
+                "newBinarySha256": new_hash,
+                "upgrades": evidence,
+                "upgradedNodes": sorted(upgraded),
+                "errorType": type(error).__name__,
+                "error": str(error),
+            }
+        )
+        raise

--- a/gravity_e2e/runner.py
+++ b/gravity_e2e/runner.py
@@ -443,7 +443,12 @@ def main():
     )
     # Long-running suites excluded from CI by default.
     # Run them explicitly: runner.py long_test
-    DEFAULT_EXCLUDES = ["long_test", "rolling_upgrade", "oracle_live_soak"]
+    DEFAULT_EXCLUDES = [
+        "long_test",
+        "rolling_upgrade",
+        "oracle_live_soak",
+        "oracle_v1_rolling_upgrade",
+    ]
 
     parser.add_argument(
         "--exclude",


### PR DESCRIPTION
## Summary

- pin `greth` and `reth-primitives-traits` to merged Galxe/gravity-reth commit `d0f59d5b664ee68cf1816e77e91bf6457fca1ae9`
- pin OracleV1 E2E genesis generation to merged Galxe/gravity_chain_core_contracts commit `5772b210b19761439147ce0d17590a42cb978af8`
- generate the four-validator Binance live-soak chain with the exact signed testnet Oracle pre-fork runtimes
- verify the atomic NativeOracle + OracleTaskConfig replacement at `oracleV1Block`, including exact codehashes and preserved balance/nonce/storage roots
- start governance activation and live Binance feeds only after the hardfork gate passes
- add a manual old-to-new four-validator rolling-upgrade gate with running-binary SHA checks, per-node catch-up/canonical-chain evidence, epoch headroom, exact activation snapshots, and a post-fork restart
- add a bridge compatibility gate with real pre/post-fork bridge events and an offline validator replaying across activation
- keep the rolling suite offline with an empty relayer mapping and exclude it from default CI discovery

## Cross-repo dependency

- contracts runtime artifacts and guards: Galxe/gravity_chain_core_contracts#117, merged as `5772b210b19761439147ce0d17590a42cb978af8`
- reth hardfork implementation: Galxe/gravity-reth#424, merged as `d0f59d5b664ee68cf1816e77e91bf6457fca1ae9`
- split plan and acceptance criteria: Galxe/gravity-audit#1038

## Build

Bounded parallelism was used for both current and baseline binaries:

```bash
export CARGO_BUILD_JOBS=2
export CARGO_INCREMENTAL=0
export MALLOC_ARENA_MAX=2

RUSTFLAGS='--cfg tokio_unstable' \
  cargo build -j2 --locked --profile quick-release -p gravity_node -p gravity_cli
```

The rolling baseline is SDK `90c78afdb5`, which pins gravity-reth `4372a103a42a862593fa8221814b3bcc8d47d0aa`. The candidate pins the merged reth commit `d0f59d5b664ee68cf1816e77e91bf6457fca1ae9`.

## Run

Two-hour live compatibility/restart gate:

```bash
ORACLE_SOAK_DURATION_SECONDS=7200 \
ORACLE_SOAK_POLL_SECONDS=15 \
ORACLE_SOAK_STALL_TIMEOUT_SECONDS=900 \
ORACLE_SOAK_MIN_ADVANCES=96 \
ORACLE_SOAK_RESTART_AFTER_SECONDS=3600 \
  ./gravity_e2e/run_test.sh oracle_live_soak --force-init --log-cli-level=INFO
```

Rolling hardfork gate:

```bash
export GRAVITY_OLD_BINARY=/stable/path/old/gravity_node
export GRAVITY_NEW_BINARY=/stable/path/new/gravity_node

ORACLE_V1_ROLLING_ACTIVATION_BLOCK=800 \
ORACLE_V1_ROLLING_MIN_BLOCKS_PER_NODE=128 \
  ./gravity_e2e/run_test.sh \
    oracle_v1_rolling_upgrade \
    --force-init \
    --log-cli-level=INFO
```

Bridge hardfork gate:

```bash
ORACLE_V1_BRIDGE_ACTIVATION_BLOCK=180 \
  ./gravity_e2e/run_test.sh \
    oracle_v1_bridge_hardfork \
    --force-init \
    --log-cli-level=INFO
```

## Verified

### Final merged pins

- `cargo metadata --locked --no-deps --format-version 1`
- `RUSTFLAGS='--cfg tokio_unstable' cargo check -j2 --locked -p gravity_node`
- `RUSTFLAGS='--cfg tokio_unstable' cargo build -j2 --locked --profile quick-release -p gravity_node -p gravity_cli`
- all OracleV1 Python suites compile and 14 tests collect
- frozen contracts manifest, reth hardfork constants, and SDK E2E constants have matching NativeOracle and OracleTaskConfig pre/post codehashes

### Live soak

- PASS for 7202.507 seconds with 473 samples and final Gravity block 32434
- node4 midpoint restart recovered in 13.175 seconds with zero epoch-guard deferrals
- NVDA/BTC/ETH each advanced 123 rounds, from nonce 2 to nonce 125
- callback event counts exactly matched final source nonces: 125 each
- blocks 599/600 matched the frozen pre/post codehashes on all four validators
- NativeOracle and OracleTaskConfig preserved balance, nonce, and storage root
- all four RPC replicas and relayer checkpoints converged

### Rolling upgrade

- PASS with old binary SHA `b0985dd34fa4...` and candidate SHA `70b8c16d3fa2...`
- node1 through node4 were replaced one at a time; every mixed composition kept producing one canonical chain
- all four validators ran the candidate by block 63, before activation at block 800
- the full rollout, activation, and post-fork restart remained in epoch 2 with explicit epoch headroom
- blocks 799/800 matched the exact NativeOracle and OracleTaskConfig pre/post codehashes on all replicas
- both contracts preserved balance, nonce, and storage root
- post-fork node4 restart recovered in 14.054 seconds and all validators continued producing blocks

### Bridge hardfork

- PASS from a fresh genesis generated at the merged contracts commit
- finalized one bridge event before activation and one after activation
- node4 stayed offline across activation, restarted, caught up to the other validators, and continued producing blocks
- observed exactly two unique `NativeMinted` events for nonces 1 and 2, with no duplicate mint during replay
- all four validators converged and advanced together after node4 recovery
