### PR TITLE
fix(ci): make gate PR dedup work for open PRs

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -51,16 +51,20 @@ jobs:
           # Candidates are workflow runs on the same branch, but "same branch"
           # alone is not a safe duplicate key: a reused branch name (e.g. a
           # prior PR's branch that was force-pushed for a new PR) would match
-          # stale runs from a different PR. So for each candidate run we ask
-          # `commits/{head_sha}/pulls` whether the current PR number is
-          # associated with that SHA — only then is it a real duplicate of
-          # this PR.
+          # stale runs from a different PR. Verify each candidate head_sha is
+          # actually in this PR's commit list.
+          #
+          # Use pulls/{n}/commits — not commits/{sha}/pulls. The latter returns
+          # [] for commits that only exist on open PRs, which disables PR-wide
+          # dedup after the first successful run (every re-approve re-runs CI).
+          PR_COMMIT_SHAS=$(gh api \
+            "repos/${REPO}/pulls/${PR_NUMBER}/commits?per_page=100" \
+            --paginate --jq '.[].sha' 2>/dev/null || true)
+
           belongs_to_pr() {
             local sha="$1"
-            local count
-            count=$(gh api "repos/${REPO}/commits/${sha}/pulls" \
-              --jq "[.[]? | select(.number == ${PR_NUMBER})] | length" 2>/dev/null || echo 0)
-            [ "${count:-0}" -gt 0 ]
+            [ -n "$sha" ] || return 1
+            printf '%s\n' "$PR_COMMIT_SHAS" | grep -Fxq -- "$sha"
           }
 
           # In-progress runs whose head_sha belongs to this PR


### PR DESCRIPTION
## Summary
- Gate PR-wide dedup (`belongs_to_pr`) used `GET /commits/{sha}/pulls`, which returns `[]` for commits that only exist on **open** PRs.
- That made every re-approve after the first successful run treat the PR as "never passed" and re-run E2E/UT (seen on #819 after merge-from-main + re-approve).
- Switch the membership check to `GET /pulls/{n}/commits` (paginated), which correctly lists open-PR commits and still rejects SHAs from a reused branch name / foreign PR.

## Test plan
- [x] Locally replay gate logic against #819: previous success run `32322914975` (`1e6e4a8`) is recognized → would `should_run=false`.
- [x] Foreign SHA from merged #822 is rejected.
- [ ] After merge: on a PR that already has a successful E2E/UT run, re-approve (optionally after a docs-only or merge-from-main commit) and confirm Gate logs `CI already passed for PR #N. Skipping.` with downstream jobs skipped.