### PR TITLE
chore: squash-merge commit body from ## Description only

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
 ## Description
-<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
+<!--
+Squash-merge commit body = this section only (until the next ## heading).
+Keep it short: what changed and why. Reviewer-only notes go in the sections below.
+When merging via UI, paste this section into the squash commit message (or use
+`scripts/pr-squash-merge.sh <pr>`).
+-->
 
 Issue Number: closes #xxx
 

--- a/scripts/pr-description.sh
+++ b/scripts/pr-description.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Extract the ## Description section from a GitHub PR body.
+#
+# Usage:
+#   scripts/pr-description.sh <pr-number-or-url> [--repo OWNER/REPO]
+#
+# Prints the Description section (until the next ## heading), with HTML
+# comments stripped. Intended as the squash-merge commit message body.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <pr-number-or-url> [--repo OWNER/REPO]" >&2
+  exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+pr="$1"
+shift
+repo_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || usage
+      repo_args=(--repo "$2")
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+# Accept bare numbers or full PR URLs.
+if [[ "$pr" =~ ^https?://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  repo_args=(--repo "${BASH_REMATCH[1]}")
+  pr="${BASH_REMATCH[2]}"
+fi
+
+body="$(gh pr view "$pr" "${repo_args[@]}" --json body -q .body)"
+
+python3 - "$body" <<'PY'
+import re, sys
+
+body = sys.argv[1]
+# Strip HTML comments.
+body = re.sub(r"<!--.*?-->", "", body, flags=re.S)
+
+# Find ## Description (allow optional trailing whitespace / BOM noise).
+m = re.search(r"(?im)^##\s+Description\s*\n", body)
+if not m:
+    sys.stderr.write("error: no '## Description' section found in PR body\n")
+    sys.exit(1)
+
+rest = body[m.end():]
+# Next markdown H2 ends the section.
+nxt = re.search(r"(?m)^##\s+\S", rest)
+section = rest[: nxt.start()] if nxt else rest
+section = section.strip() + "\n"
+if not section.strip():
+    sys.stderr.write("error: '## Description' section is empty\n")
+    sys.exit(1)
+sys.stdout.write(section)
+PY

--- a/scripts/pr-squash-merge.sh
+++ b/scripts/pr-squash-merge.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Squash-merge a PR using PR title as subject and ## Description as body.
+#
+# Usage:
+#   scripts/pr-squash-merge.sh <pr-number-or-url> [--repo OWNER/REPO] [extra gh pr merge args...]
+#
+# Examples:
+#   scripts/pr-squash-merge.sh 824
+#   scripts/pr-squash-merge.sh 824 --repo Galxe/gravity-sdk --admin
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <pr-number-or-url> [--repo OWNER/REPO] [extra gh pr merge args...]" >&2
+  exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+pr="$1"
+shift
+
+repo_args=()
+extra=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || usage
+      repo_args=(--repo "$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      extra+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$pr" =~ ^https?://github.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  repo_args=(--repo "${BASH_REMATCH[1]}")
+  pr="${BASH_REMATCH[2]}"
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+desc="$("$root/scripts/pr-description.sh" "$pr" "${repo_args[@]}")"
+title="$(gh pr view "$pr" "${repo_args[@]}" --json title -q .title)"
+
+echo "Squash-merging #$pr"
+echo "---- subject ----"
+echo "$title"
+echo "---- body (## Description) ----"
+printf '%s' "$desc"
+echo "-----------------"
+
+gh pr merge "$pr" "${repo_args[@]}" --squash --subject "$title" --body "$desc" "${extra[@]}"


### PR DESCRIPTION
## Description

GitHub squash defaults can only use the whole PR body, not a subsection. Make `## Description` the squash-commit body by convention, and add helpers to extract/merge with that section only.

- document the convention in `PULL_REQUEST_TEMPLATE.md`
- `scripts/pr-description.sh` — print `## Description` until the next `##`
- `scripts/pr-squash-merge.sh` — `gh pr merge --squash` with PR title + Description
- repo setting: squash title=`PR_TITLE`, message=`BLANK` (avoid dumping checklists into main)

Usage: `scripts/pr-squash-merge.sh <pr>` (or paste Description in the UI).

Issue Number: n/a

## How Has This Been Tested?

- `scripts/pr-description.sh 824 --repo Galxe/gravity-sdk` returns only the Description section

## Type of Change
- [x] Documentation update
- [ ] Other (specify)

## Checklist
- [x] I have performed a self-review of my own code