### PR TITLE
chore(genesis): sync testnet genesis hardfork schedule with live chain

### DIFF
--- a/genesis/testnet/genesis.json
+++ b/genesis/testnet/genesis.json
@@ -30,7 +30,12 @@
     "terminalTotalDifficultyPassed": true,
     "extraFields": {},
     "depositContractAddress": null,
-    "gravityMinBaseFee": 50000000000
+    "gravityMinBaseFee": 50000000000,
+    "pragueTime": 1780909442,
+    "alphaTime": 1783328400,
+    "betaTime": 1785812400,
+    "osakaTime": 1785812400,
+    "gammaTime": 1787108400
   },
   "alloc": {
     "0x00000000000000000000000000000001625f0001": {


### PR DESCRIPTION
## Summary
- Refresh `genesis/testnet/genesis.json` with hardfork activation times that are already live on Longevity testnet (`pragueTime`, `alphaTime`, `betaTime`, `osakaTime`, `gammaTime`).
- Waypoint and alloc are unchanged (same chain identity as the 2026-06 reset).

## Verification
Compared against **on-disk** genesis from live nodes (via gcloud IAP):

| Node | Path | sha256 |
| --- | --- | --- |
| node1 (validator) | `/home/gravity/testnet/node1/config/genesis.json` | `0042496ccd8f17aacbdb6f3ff014f848b5adfaeb5afbf99621ce5069320fbfa1` |
| node4 (VFN) | `/home/gravity/testnet/node4/config/genesis.json` | same |
| node6 (PFN) | `/home/gravity/testnet/node6/config/genesis.json` | same |

This PR's file matches that digest byte-for-byte. Also cross-checked against `debug_chainConfig` on `https://testnet-rpc.gravity.xyz` and `mono-grav/docs/testnet/upgrades/*.json`.

## Why
The committed file was still the June reset snapshot. Rolling upgrades wrote these fields onto node-local genesis.json, but they were never written back to this public artifact. Docsite PFN guides curl this path.

Companion: https://github.com/Galxe/mono-grav/pull/103 · docsite timeline: https://github.com/Galxe/gravity-docsite/pull/55

## Test plan
- [x] Diff is only the five hardfork config keys
- [x] Matches live node1/node4/node6 genesis sha256
- [ ] Confirm raw URL serves updated file after merge