### PR TITLE
chore(genesis): sync testnetOwnerFixTime into testnet genesis

### DIFF
--- a/genesis/testnet/genesis.json
+++ b/genesis/testnet/genesis.json
@@ -35,7 +35,8 @@
     "alphaTime": 1783328400,
     "betaTime": 1785812400,
     "osakaTime": 1785812400,
-    "gammaTime": 1787108400
+    "gammaTime": 1787108400,
+    "testnetOwnerFixTime": 1788490800
   },
   "alloc": {
     "0x00000000000000000000000000000001625f0001": {


### PR DESCRIPTION
## Summary
- Refresh `genesis/testnet/genesis.json` with `testnetOwnerFixTime=1788490800` (2026-09-04 03:00 UTC / 11:00 UTC+8) from live Longevity testnet nodes.
- Waypoint and alloc unchanged.

## Verification
Compared against **on-disk** genesis from live nodes (gcloud IAP):

| Node | sha256 |
| --- | --- |
| node1 (validator) | `5e89ed4ed1e3ec06bcefb7f2f38405d4106baf46b57605b07ac195541f0e2d87` |
| node6 (PFN) | same |

This PR's file matches that digest byte-for-byte. Also cross-checked against `debug_chainConfig` on `https://testnet-rpc.gravity.xyz` and `mono-grav/docs/testnet/upgrades/upgrade_v1.10.1-testnet.json`.

## Why
Rolling upgrade to `v1.10.1-testnet` wrote `testnetOwnerFixTime` onto node-local genesis.json; the public artifact still lagged at the Gamma sync (#826). Docsite PFN guides curl this path.

## Companions
- mono-grav archive + cluster genesis: https://github.com/Galxe/mono-grav/pull/104
- docsite timeline: https://github.com/Galxe/gravity-docsite/pull/56

## Test plan
- [x] Diff is only the `testnetOwnerFixTime` config key
- [x] Matches live node1/node6 genesis sha256
- [ ] Confirm raw URL serves updated file after merge
